### PR TITLE
Update GeckoView version to fix dependency resolution

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'org.mozilla.geckoview:geckoview:136.0.20250219214118'
+    implementation 'org.mozilla.geckoview:geckoview:136.0.20250227124745'
 
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'


### PR DESCRIPTION
### Motivation
- Resolve a build failure where Gradle could not find `org.mozilla.geckoview:geckoview:136.0.20250219214118` during `:app:processDebugNavigationResources`.

### Description
- Bumped GeckoView in `app/build.gradle` from `136.0.20250219214118` to `136.0.20250227124745` which is published on Mozilla Maven.

### Testing
- Confirmed the new artifact URL returns HTTP 200 with `curl -I https://maven.mozilla.org/maven2/org/mozilla/geckoview/geckoview/136.0.20250227124745/geckoview-136.0.20250227124745.pom`.
- Ran `./gradlew :app:processDebugNavigationResources --stacktrace` but Gradle Wrapper execution failed because `gradle/wrapper/gradle-wrapper.jar` is missing in this environment, so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e3d918148325950fc3e82c4a0b2e)