### PR TITLE
Move Android dependencies to Gradle version catalog (TOML)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.plugin.compose'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -50,19 +50,19 @@ kotlin {
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2026.01.00')
-    implementation 'androidx.activity:activity-compose:1.11.0'
-    implementation 'androidx.compose.material3:material3'
-    implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'org.mozilla.geckoview:geckoview:136.0.20250227124745'
+    implementation platform(libs.androidx.compose.bom)
+    implementation libs.androidx.activity.compose
+    implementation libs.androidx.compose.material3
+    implementation libs.androidx.compose.ui
+    implementation libs.androidx.compose.ui.tooling.preview
+    implementation libs.mozilla.geckoview
 
-    debugImplementation 'androidx.compose.ui:ui-tooling'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    debugImplementation libs.androidx.compose.ui.tooling
+    debugImplementation libs.androidx.compose.ui.test.manifest
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation platform('androidx.compose:compose-bom:2026.01.00')
-    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    testImplementation libs.junit4
+    androidTestImplementation platform(libs.androidx.compose.bom)
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.androidx.compose.ui.test.junit4
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.application' version '9.0.0' apply false
-    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
-    id 'org.jetbrains.kotlin.plugin.compose' version '2.2.0' apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,28 @@
+[versions]
+agp = "9.0.0"
+kotlin = "2.2.0"
+composeBom = "2026.01.00"
+activityCompose = "1.11.0"
+geckoview = "136.0.20250227124745"
+junit4 = "4.13.2"
+androidxJunit = "1.3.0"
+espressoCore = "3.7.0"
+
+[libraries]
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+mozilla-geckoview = { module = "org.mozilla.geckoview:geckoview", version.ref = "geckoview" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
### Motivation
- Centralize dependency and plugin versions into a Gradle version catalog to simplify upgrades and share versions across modules.
- Replace hard-coded dependency coordinates in module build files with `libs` aliases for clearer maintenance.

### Description
- Added `gradle/libs.versions.toml` with `[versions]`, `[libraries]`, and `[plugins]` entries for AGP, Kotlin, Compose BOM, GeckoView, and test libraries.
- Updated root `build.gradle` to use plugin aliases via `alias(libs.plugins.*)` instead of inline `id(...) version ...` declarations.
- Updated `app/build.gradle` to use `libs.*` dependency references and to apply plugins using `alias(libs.plugins.android.application)` and `alias(libs.plugins.kotlin.compose)`.
- Removed an explicit application of the `kotlin.android` plugin in the app module to avoid a duplicate `kotlin` extension conflict encountered during validation.

### Testing
- Ran `./gradlew :app:help` which initially failed due to `gradlew` permission and a plugin extension conflict, and then succeeded after `chmod +x gradlew` and removing the duplicate plugin application, with the final run reporting `BUILD SUCCESSFUL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1edb1a07083258da773689b084621)