### PR TITLE
Enable Firefox extension installation prompts in GeckoView runtime

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/MainActivity.kt
@@ -32,8 +32,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.viewinterop.AndroidView
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoView
+import org.mozilla.geckoview.WebExtension
+import org.mozilla.geckoview.WebExtensionController
 
 class MainActivity : ComponentActivity() {
     private lateinit var runtime: GeckoRuntime
@@ -41,6 +44,24 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         runtime = GeckoRuntime.getDefault(this)
+        runtime.webExtensionController.setPromptDelegate(
+            object : WebExtensionController.PromptDelegate {
+                override fun onInstallPromptRequest(
+                    extension: WebExtension,
+                    permissions: Array<String>,
+                    origins: Array<String>,
+                    dataCollectionPermissions: Array<String>
+                ): GeckoResult<WebExtension.PermissionPromptResponse> {
+                    return GeckoResult.fromValue(
+                        WebExtension.PermissionPromptResponse(
+                            true,
+                            false,
+                            true,
+                        )
+                    )
+                }
+            }
+        )
         setContent {
             BrowserApp(runtime = runtime)
         }


### PR DESCRIPTION
### Motivation
- Allow WebExtensions installed via GeckoView to proceed without blocking by responding to install permission prompts programmatically.

### Description
- Set a `WebExtensionController.PromptDelegate` on the `GeckoRuntime` in `MainActivity` to handle install prompts. 
- Implemented `onInstallPromptRequest` to return a `WebExtension.PermissionPromptResponse` (accepting the prompt) via `GeckoResult.fromValue`.
- Added necessary imports: `GeckoResult`, `WebExtension`, and `WebExtensionController` and modified `app/src/main/java/net/matsudamper/browser/MainActivity.kt`.

### Testing
- Ran `./gradlew :app:assembleDebug` which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ef0c514c8325bff283011436c40f)