### PR TITLE
Navigation3を導入してメニューから設定画面へ遷移可能にする

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,8 @@ dependencies {
     implementation libs.androidx.compose.material3
     implementation libs.androidx.compose.ui
     implementation libs.androidx.compose.ui.tooling.preview
+    implementation libs.androidx.navigation3.runtime
+    implementation libs.androidx.navigation3.ui
     implementation libs.mozilla.geckoview
 
     debugImplementation libs.androidx.compose.ui.tooling

--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -1,0 +1,61 @@
+package net.matsudamper.browser
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import org.mozilla.geckoview.GeckoRuntime
+
+private sealed interface AppDestination : NavKey {
+    data object Browser : AppDestination
+    data object Settings : AppDestination
+}
+
+@Composable
+internal fun BrowserApp(
+    runtime: GeckoRuntime,
+) {
+    val backStack = rememberNavBackStack(AppDestination.Browser)
+
+    BackHandler(enabled = backStack.size > 1) {
+        backStack.removeLastOrNull()
+    }
+
+    NavDisplay(
+        backStack = backStack,
+        onBack = { backStack.removeLastOrNull() },
+        entryProvider = { key: NavKey ->
+            when (key) {
+                AppDestination.Browser -> NavEntry<NavKey>(key) {
+                    GeckoBrowserTab(
+                        runtime = runtime,
+                        onOpenSettings = {
+                            backStack.add(AppDestination.Settings)
+                        }
+                    )
+                }
+
+                AppDestination.Settings -> NavEntry<NavKey>(key) {
+                    SettingsScreen()
+                }
+
+                else -> error("Unknown destination: $key")
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsScreen() {
+    TopAppBar(
+        title = {
+            Text("設定")
+        }
+    )
+}

--- a/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
@@ -38,6 +38,7 @@ internal fun BrowserToolBar(
     onSubmit: (String) -> Unit,
     modifier: Modifier = Modifier,
     onFocusChanged: (Boolean) -> Unit,
+    onOpenSettings: () -> Unit,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.primaryContainer
@@ -82,7 +83,8 @@ internal fun BrowserToolBar(
                             Text(text = "設定")
                         },
                         onClick = {
-
+                            visibleMenu = false
+                            onOpenSettings()
                         },
                     )
                 }
@@ -111,5 +113,6 @@ private fun Preview() {
         onValueChange = {},
         onSubmit = {},
         onFocusChanged = {},
+        onOpenSettings = {},
     )
 }

--- a/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -31,6 +31,7 @@ private const val DEFAULT_URL = "https://webauthn.io"
 fun GeckoBrowserTab(
     runtime: GeckoRuntime,
     modifier: Modifier = Modifier,
+    onOpenSettings: () -> Unit,
 ) {
     var urlInput by rememberSaveable { mutableStateOf(DEFAULT_URL) }
     var loadedUrl by rememberSaveable { mutableStateOf(DEFAULT_URL) }
@@ -99,6 +100,7 @@ fun GeckoBrowserTab(
                 keyboardController?.hide()
             },
             onFocusChanged = { hasFocus -> isUrlInputFocused = hasFocus },
+            onOpenSettings = onOpenSettings,
         )
 
         AndroidView(

--- a/app/src/main/java/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
         runtime = GeckoRuntime.getDefault(this)
         runtime.setActivityDelegate(activityDelegate)
         setContent {
-            GeckoBrowserTab(runtime = runtime)
+            BrowserApp(runtime = runtime)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ geckoview = "148.0.20260216153405"
 junit4 = "4.13.2"
 androidxJunit = "1.3.0"
 espressoCore = "3.7.0"
+navigation3 = "1.0.0-alpha06"
 
 [libraries]
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
@@ -21,6 +22,8 @@ junit4 = { module = "junit:junit", version.ref = "junit4" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### Motivation
- メニューの「設定」から遷移できる画面遷移を導入するために `Navigation3` を追加しました。 
- 設定画面は要件どおり ToolBar のみを表示するシンプルな構成にします。

### Description
- `gradle/libs.versions.toml` と `app/build.gradle` に `androidx.navigation3` の依存関係を追加しました（`navigation3-runtime` / `navigation3-ui`）。
- 画面遷移を管理する `AppNavigation.kt` を追加し、`BrowserApp` で `rememberNavBackStack` と `NavDisplay` を使って `Browser` ⇄ `Settings` を管理するようにしました。 
- `MainActivity` の `setContent` を `GeckoBrowserTab` から `BrowserApp` に差し替えました。 
- `BrowserToolBar` に `onOpenSettings` コールバックを追加し、メニューの「設定」押下で呼び出すように変更し、`GeckoBrowserTab` は `onOpenSettings` を受け取って Toolbar に渡すようにしました。
- `SettingsScreen` は `TopAppBar` のみを表示する最小構成の実装です。 

### Testing
- `./gradlew :app:compileDebugKotlin` を実行してビルドが成功することを確認しました（コンパイル成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3943280c883259921b711e0b8c354)