### PR TITLE
PRのAPKコメントをIDベース更新に変更して重複防止

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -48,11 +48,40 @@ jobs:
           path: app/build/outputs/apk/debug/app-debug.apk
 
       - name: Comment APK download URL
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: ${{ steps.upload_apk.outputs.artifact-url }}
         with:
-          header: apk-download
-          message: |
+          script: |
+            const marker = '<!-- apk-download-comment-id -->';
+            const message = `${marker}
             ✅ Debug APK artifact is ready.
 
-            - Download URL: ${{ steps.upload_apk.outputs.artifact-url }}
-            - Artifact Name: `app-debug-apk`
+            - Download URL: ${process.env.ARTIFACT_URL}
+            - Artifact Name: \`app-debug-apk\``;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: message,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: message,
+              });
+            }


### PR DESCRIPTION
### Motivation
- PRワークフローでビルドしたAPKのダウンロード案内コメントがワークフロー再実行で重複して投稿される問題を解消するため。 
- コメントを固定IDで識別して同一PR上で常に1件だけ更新するようにする目的。 

### Description
- `.github/workflows/pr-build.yml`でコメント投稿アクションを `marocchino/sticky-pull-request-comment@v2` から `actions/github-script@v7` に置き換えた。 
- コメント本文に固定マーカー `<!-- apk-download-comment-id -->` を埋め込み、`github.rest.issues.listComments` で既存コメントを取得してマーカーを含むBotコメントを検索する処理を追加した。 
- 既存コメントが見つかれば `issues.updateComment` で更新し、見つからなければ `issues.createComment` で新規作成する分岐を実装した。 

### Testing
- `git diff -- .github/workflows/pr-build.yml` を実行して差分を確認し成功した。 
- `git status --short` を実行してワークツリーの状態を確認し成功した。 
- `nl -ba .github/workflows/pr-build.yml | sed -n '40,120p'` を実行して該当箇所を表示し内容を確認し成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d35dde48832599b007a1026b5e9c)