### PR TITLE
Tabs画面：新規追加をFAB化し戻るボタンを削除

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -196,9 +196,6 @@ internal fun BrowserApp(
                                             tabPersistenceSignal++
                                             tabsVisible = false
                                         },
-                                        onBack = {
-                                            tabsVisible = false
-                                        },
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .background(MaterialTheme.colorScheme.surface),

--- a/app/src/main/java/net/matsudamper/browser/TabsScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/TabsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,13 +21,16 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,142 +67,151 @@ internal fun TabsScreen(
     onSelectTab: (Long) -> Unit,
     onCloseTab: (Long) -> Unit,
     onOpenNewTab: () -> Unit,
-    onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Box(
         modifier = modifier
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.safeDrawing),
     ) {
-        Surface(
-            color = MaterialTheme.colorScheme.primaryContainer,
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(TabsLayoutDefaults.topBarHeight)
-                    .padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                TextButton(onClick = onBack) {
-                    Text("戻る")
-                }
-                Text(
-                    text = "Tabs",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
-                TextButton(onClick = onOpenNewTab) {
-                    Text("新規")
-                }
-            }
-        }
-
-        if (tabs.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text("タブがありません")
-            }
-            return
-        }
-
-        BoxWithConstraints(
+        Column(
             modifier = Modifier.fillMaxSize(),
         ) {
-            val columns = TabsLayoutDefaults.calculateColumns(maxWidth)
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(columns),
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(TabsLayoutDefaults.gridPadding),
-                verticalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
-                horizontalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
+            Surface(
+                color = MaterialTheme.colorScheme.primaryContainer,
             ) {
-                items(
-                    items = tabs,
-                    key = { tab -> tab.id },
-                ) { tab ->
-                    val selected = tab.id == selectedTabId
-                    Card(
-                        onClick = { onSelectTab(tab.id) },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(TabsLayoutDefaults.cardAspectRatio),
-                        border = BorderStroke(
-                            width = if (selected) 2.dp else 1.dp,
-                            color = if (selected) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.outlineVariant
-                            },
-                        ),
-                        colors = CardDefaults.cardColors(
-                            containerColor = if (selected) {
-                                MaterialTheme.colorScheme.primaryContainer
-                            } else {
-                                MaterialTheme.colorScheme.surfaceVariant
-                            }
-                        ),
-                        elevation = CardDefaults.cardElevation(
-                            defaultElevation = if (selected) 8.dp else 1.dp
-                        ),
-                    ) {
-                        Column(
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(TabsLayoutDefaults.topBarHeight)
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Tabs",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            if (tabs.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("タブがありません")
+                }
+                return
+            }
+
+            BoxWithConstraints(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                val columns = TabsLayoutDefaults.calculateColumns(maxWidth)
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(columns),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(TabsLayoutDefaults.gridPadding),
+                    verticalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
+                    horizontalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
+                ) {
+                    items(
+                        items = tabs,
+                        key = { tab -> tab.id },
+                    ) { tab ->
+                        val selected = tab.id == selectedTabId
+                        Card(
+                            onClick = { onSelectTab(tab.id) },
                             modifier = Modifier
-                                .fillMaxSize(),
+                                .fillMaxWidth()
+                                .aspectRatio(TabsLayoutDefaults.cardAspectRatio),
+                            border = BorderStroke(
+                                width = if (selected) 2.dp else 1.dp,
+                                color = if (selected) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.outlineVariant
+                                },
+                            ),
+                            colors = CardDefaults.cardColors(
+                                containerColor = if (selected) {
+                                    MaterialTheme.colorScheme.primaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.surfaceVariant
+                                }
+                            ),
+                            elevation = CardDefaults.cardElevation(
+                                defaultElevation = if (selected) 8.dp else 1.dp
+                            ),
                         ) {
-                            Row(
+                            Column(
                                 modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(start = 12.dp, top = 8.dp, end = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
+                                    .fillMaxSize(),
                             ) {
-                                Text(
-                                    text = tab.title.ifBlank { "Untitled" },
-                                    style = MaterialTheme.typography.titleSmall,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f),
-                                )
-                                IconButton(
-                                    onClick = { onCloseTab(tab.id) },
-                                    modifier = Modifier.offset { IntOffset(4, -4) },
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(start = 12.dp, top = 8.dp, end = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
                                 ) {
                                     Text(
-                                        text = "×",
-                                        style = MaterialTheme.typography.titleMedium,
+                                        text = tab.title.ifBlank { "Untitled" },
+                                        style = MaterialTheme.typography.titleSmall,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f),
                                     )
+                                    IconButton(
+                                        onClick = { onCloseTab(tab.id) },
+                                        modifier = Modifier.offset { IntOffset(4, -4) },
+                                    ) {
+                                        Text(
+                                            text = "×",
+                                            style = MaterialTheme.typography.titleMedium,
+                                        )
+                                    }
                                 }
-                            }
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .weight(1f)
-                                    .padding(horizontal = 12.dp, vertical = 8.dp)
-                                    .clip(RoundedCornerShape(8.dp)),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                val preview = tab.previewBitmap
-                                if (preview != null) {
-                                    Image(
-                                        bitmap = preview.asImageBitmap(),
-                                        contentDescription = "Tab preview",
-                                        contentScale = ContentScale.Crop,
-                                        modifier = Modifier.fillMaxSize(),
-                                    )
-                                } else {
-                                    Text(
-                                        text = "No Preview",
-                                        style = MaterialTheme.typography.bodySmall,
-                                    )
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .weight(1f)
+                                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                                        .clip(RoundedCornerShape(8.dp)),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    val preview = tab.previewBitmap
+                                    if (preview != null) {
+                                        Image(
+                                            bitmap = preview.asImageBitmap(),
+                                            contentDescription = "Tab preview",
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier.fillMaxSize(),
+                                        )
+                                    } else {
+                                        Text(
+                                            text = "No Preview",
+                                            style = MaterialTheme.typography.bodySmall,
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
+        }
+
+        FloatingActionButton(
+            onClick = onOpenNewTab,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "新規タブ",
+            )
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Tabs画面の操作を簡潔にするため、ヘッダーの「戻る」ボタンを廃止して新規タブ作成を右下のFABに移す変更を行いました。 

### Description
- `TabsScreen.kt` のヘッダーから `TextButton`（「戻る」「新規」）を削除してタイトルのみ表示に変更しました。 
- 画面レイアウトを `Box` + `Column` 構成に変更し、右下に `FloatingActionButton`（`Icons.Default.Add`）を重ねて配置して `onOpenNewTab` を呼ぶようにしました。 
- 必要なインポートを追加して（`FloatingActionButton`, `Icon`, `Icons` 等）カードレイアウトのままタブ一覧表示を維持しました。 
- `TabsScreen` の `onBack` コールバックを削除し、呼び出し元の `AppNavigation.kt` 側の呼び出しも合わせて更新しました。 

### Testing
- 実装後に `./gradlew --no-daemon :app:compileDebugKotlin --console=plain` を実行し、編集時に出た一時的なコンパイルエラーを修正したうえで最終的にコンパイルは成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3db4bd9c883258b3ed12ce8c1811a)