### PR TITLE
拡張機能一覧タップで拡張機能の設定ページを開けるようにする

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -223,6 +223,10 @@ internal fun BrowserApp(
                         ExtensionsScreen(
                             runtime = runtime,
                             onBack = { backStack.removeLastOrNull() },
+                            onOpenExtensionSettings = { optionsPageUrl ->
+                                browserSessionController.selectedTab?.session?.loadUri(optionsPageUrl)
+                                backStack.removeLastOrNull()
+                            },
                         )
                     }
 

--- a/app/src/main/java/net/matsudamper/browser/ExtensionsScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/ExtensionsScreen.kt
@@ -4,11 +4,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -40,6 +43,7 @@ import org.mozilla.geckoview.WebExtension
 internal fun ExtensionsScreen(
     runtime: GeckoRuntime,
     onBack: () -> Unit,
+    onOpenExtensionSettings: (String) -> Unit,
 ) {
     var extensions by remember { mutableStateOf<List<WebExtension>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
@@ -125,6 +129,14 @@ internal fun ExtensionsScreen(
                         extension = extension,
                         isUninstalling = uninstallingId == extension.id,
                         uninstallEnabled = uninstallingId == null,
+                        onOpenSettings = {
+                            extension.metaData.optionsPageUrl
+                                ?.takeIf { it.isNotBlank() }
+                                ?.let(onOpenExtensionSettings)
+                                ?: run {
+                                    errorMessage = "この拡張機能には設定画面がありません。"
+                                }
+                        },
                         onUninstall = {
                             uninstallingId = extension.id
                             runtime.webExtensionController.uninstall(extension).accept(
@@ -166,6 +178,7 @@ private fun ExtensionRow(
     extension: WebExtension,
     isUninstalling: Boolean,
     uninstallEnabled: Boolean,
+    onOpenSettings: () -> Unit,
     onUninstall: () -> Unit,
 ) {
     val displayName = extension.metaData.name?.takeIf { it.isNotBlank() } ?: extension.id
@@ -174,6 +187,10 @@ private fun ExtensionRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .selectable(
+                selected = false,
+                onClick = onOpenSettings,
+            )
             .padding(horizontal = 16.dp, vertical = 12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -202,6 +219,7 @@ private fun ExtensionRow(
                 overflow = TextOverflow.Ellipsis,
             )
         }
+        Spacer(modifier = Modifier.width(8.dp))
         TextButton(
             onClick = onUninstall,
             enabled = uninstallEnabled,


### PR DESCRIPTION
### Motivation
- 拡張機能一覧から該当拡張機能の設定（options）ページへ直接遷移できるようにするため。\

### Description
- `ExtensionsScreen` に `onOpenExtensionSettings: (String) -> Unit` コールバックを追加し、各行タップで `optionsPageUrl` があればコールバックを呼ぶようにしました。\
- 各拡張機能行をタップ可能にするために `selectable` を使って行をクリックできるようにし、ボタンレイアウトは `Spacer` を追加して調整しました。\
- `AppNavigation` 側で `onOpenExtensionSettings` を受け取り、現在選択中のタブで `loadUri(optionsPageUrl)` を呼んで設定ページを開き、その後拡張機能画面から戻る処理を追加しました。\
- `optionsPageUrl` が存在しない場合はダイアログでエラーメッセージを表示するようにしました。\

### Testing
- 実機ビルド相当のコンパイルを確認するために `./gradlew :app:compileDebugKotlin --console=plain` を実行し、最終的に `BUILD SUCCESSFUL` を確認しました。\
- ビルド中に Kotlin daemon の一時的なキャッシュ例外が発生しましたが、Gradle のフォールバックでコンパイルは成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3dc2289608325bcbab869fd2fb755)