### PR TITLE
Add test tags and accessibility improvements to BrowserToolBar

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.autofill.ContentDataType
 import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
@@ -54,6 +55,7 @@ import androidx.compose.ui.semantics.contentDataType
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.contentType
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -98,8 +100,10 @@ internal fun BrowserToolBar(
         color = MaterialTheme.colorScheme.primaryContainer,
         modifier = swipeToOpenTabsModifier,
     ) {
-        Column {
-            val enableAutoFill = true
+        Column(
+            modifier = Modifier.semantics { testTagsAsResourceId = true },
+        ) {
+            val enableAutoFill = false
             if (enableAutoFill) {
                 EditText(
                     text = value,
@@ -116,6 +120,7 @@ internal fun BrowserToolBar(
                         onValueChange = onValueChange,
                         modifier = modifier
                             .weight(1f)
+                            .testTag("url_bar")
                             .onFocusChanged { onFocusChanged(it.hasFocus) }
                             .semantics {
                                 contentDescription = "Address bar"


### PR DESCRIPTION
## Summary
Enhanced the BrowserToolBar component with improved testability and accessibility features by adding test tags and semantic configurations.

## Key Changes
- Added `testTag` import and applied `testTag("url_bar")` to the URL input field for easier UI testing
- Enabled `testTagsAsResourceId` semantic property on the Column container to expose test tags as resource IDs for accessibility testing
- Disabled the `enableAutoFill` flag (changed from `true` to `false`)
- Added necessary imports: `androidx.compose.ui.platform.testTag` and `androidx.compose.ui.semantics.testTagsAsResourceId`

## Implementation Details
The test tag is applied directly to the TextField modifier chain, allowing test frameworks to easily identify and interact with the URL bar during automated testing. The `testTagsAsResourceId` semantic modifier ensures these tags are properly exposed through accessibility services and testing frameworks.

https://claude.ai/code/session_013kmrnyW7HcibziSVW9W5wC