### PR TITLE
Add desktop notification permission handling and Android Lint reporting in CI

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -44,3 +44,13 @@ jobs:
         with:
           name: app-release-apk
           path: app/build/outputs/apk/release/app-release.apk
+
+      - name: Run Android Lint
+        run: gradle :app:lintDebug
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-lint-report
+          path: app/build/reports/lint-results-debug.html

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -47,6 +47,16 @@ jobs:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
 
+      - name: Run Android Lint
+        run: gradle :app:lintDebug
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-lint-report
+          path: app/build/reports/lint-results-debug.html
+
       - name: Comment APK download URL
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_SET_ORIGIN" />
     <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_QUERY_CANDIDATE_CREDENTIALS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -32,6 +32,7 @@ import net.matsudamper.browser.data.PersistedTabState
 import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.data.resolvedHomepageUrl
 import net.matsudamper.browser.data.resolvedSearchTemplate
+import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import kotlinx.coroutines.delay
 
@@ -51,6 +52,7 @@ private sealed interface AppDestination : NavKey {
 internal fun BrowserApp(
     runtime: GeckoRuntime,
     onInstallExtensionRequest: (String) -> Unit,
+    onDesktopNotificationPermissionRequest: () -> GeckoResult<Int>,
 ) {
     val context = LocalContext.current
     val settingsRepository = remember { SettingsRepository(context) }
@@ -129,6 +131,7 @@ internal fun BrowserApp(
                                 searchTemplate = searchTemplate,
                                 tabCount = tabs.size,
                                 onInstallExtensionRequest = onInstallExtensionRequest,
+                                onDesktopNotificationPermissionRequest = onDesktopNotificationPermissionRequest,
                                 onOpenSettings = {
                                     backStack.add(AppDestination.Settings)
                                 },


### PR DESCRIPTION
### Motivation
- Enable support for web/desktop notification permission requests from GeckoView-based web content by bridging Android runtime permission flow to Gecko's permission API.
- Ensure lint checks are executed in CI and upload lint reports for easier diagnostics.

### Description
- Add `POST_NOTIFICATIONS` permission to `app/src/main/AndroidManifest.xml`.
- Implement notification permission request handling in `MainActivity`: add a `RequestPermission` launcher, map the result to `GeckoSession.PermissionDelegate.ContentPermission` via `GeckoResult`, track pending requests, and fail pending results on `onDestroy`.
- Propagate a callback from `BrowserApp` into `GeckoBrowserTab` and install a `GeckoSession.PermissionDelegate` that delegates desktop notification permission requests to the activity callback and cleans up delegates on dispose.
- Add a minimal `app/lint.xml` and update GitHub Actions workflows (`.github/workflows/pr-build.yml` and `main-build.yml`) to run `gradle :app:lintDebug` and upload `app/build/reports/lint-results-debug.html` as an artifact.

### Testing
- No automated test runs were executed as part of this change; CI workflows were updated to run `gradle :app:lintDebug` and upload the lint report when the pipelines run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d54c57208325b062f57a266b2529)