### PR TITLE
Add translation state management and status bar UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,9 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.mozilla.geckoview)
+    implementation(libs.mlkit.translate)
+    implementation(libs.mlkit.language.id)
+    implementation(libs.kotlinx.coroutines.play.services)
     implementation(project(":data"))
 
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -192,6 +192,7 @@ internal fun BrowserApp(
                                 initialUrl = selectedTab.currentUrl,
                                 homepageUrl = homepageUrl,
                                 searchTemplate = searchTemplate,
+                                translationProvider = currentSettings.translationProvider,
                                 tabCount = tabs.size,
                                 onInstallExtensionRequest = onInstallExtensionRequest,
                                 onDesktopNotificationPermissionRequest = onDesktopNotificationPermissionRequest,

--- a/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
@@ -79,6 +79,7 @@ internal fun BrowserToolBar(
     onFindInPage: () -> Unit,
     isPcMode: Boolean,
     onPcModeToggle: () -> Unit,
+    onTranslatePage: () -> Unit,
     toolbarColor: Color?,
 ) {
     val latestOnOpenTabs by rememberUpdatedState(onOpenTabs)
@@ -114,11 +115,36 @@ internal fun BrowserToolBar(
                             val currentOnValueChange by rememberUpdatedState(latestOnValueChange)
                             val currentOnSubmit by rememberUpdatedState(latestOnSubmit)
                             val currentOnFocusChanged by rememberUpdatedState(latestOnFocusChanged)
-                            UrlTextField(
-                                currentValue = currentValue,
-                                currentOnValueChange = currentOnValueChange,
-                                currentOnSubmit = currentOnSubmit,
-                                currentOnFocusChanged = currentOnFocusChanged,
+                            BasicTextField(
+                                value = currentValue,
+                                onValueChange = { currentOnValueChange(it) },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag("url_bar")
+                                    .onFocusChanged { currentOnFocusChanged(it.hasFocus) }
+                                    .semantics {
+                                        contentDescription = "Address bar"
+                                        contentType = ContentType("url")
+                                        contentDataType = ContentDataType.Text
+                                    }
+                                    .padding(4.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surface)
+                                    .padding(8.dp)
+                                    .horizontalScroll(rememberScrollState()),
+                                singleLine = true,
+                                textStyle = TextStyle(color = MaterialTheme.colorScheme.onSurface),
+                                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                                keyboardOptions = KeyboardOptions.Default.copy(
+                                    imeAction = ImeAction.Go,
+                                    keyboardType = KeyboardType.Uri,
+                                    autoCorrectEnabled = false,
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onGo = { currentOnSubmit(currentValue) },
+                                    onDone = { currentOnSubmit(currentValue) },
+                                    onSearch = { currentOnSubmit(currentValue) },
+                                ),
                             )
                         }
                     }
@@ -238,6 +264,15 @@ internal fun BrowserToolBar(
                     }
                     DropdownMenuItem(
                         text = {
+                            Text(text = "翻訳")
+                        },
+                        onClick = {
+                            visibleMenu = false
+                            onTranslatePage()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = {
                             Text(text = "共有")
                         },
                         onClick = {
@@ -269,47 +304,6 @@ internal fun BrowserToolBar(
     }
 }
 
-@Composable
-private fun UrlTextField(
-    currentValue: String,
-    currentOnValueChange: (String) -> Unit,
-    currentOnSubmit: (String) -> Unit,
-    currentOnFocusChanged: (Boolean) -> Unit,
-) {
-    BasicTextField(
-        value = currentValue,
-        onValueChange = { currentOnValueChange(it) },
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("url_bar")
-            .onFocusChanged { currentOnFocusChanged(it.hasFocus) }
-            .semantics {
-                contentDescription = "Address bar"
-                contentType = ContentType("url")
-                contentDataType = ContentDataType.Text
-            }
-            .padding(4.dp)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(8.dp)
-            .horizontalScroll(rememberScrollState()),
-        singleLine = true,
-        textStyle = TextStyle(color = MaterialTheme.colorScheme.onSurface),
-        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-        keyboardOptions = KeyboardOptions.Default.copy(
-            imeAction = ImeAction.Go,
-            keyboardType = KeyboardType.Uri,
-            autoCorrectEnabled = false,
-        ),
-        keyboardActions = KeyboardActions(
-            onGo = { currentOnSubmit(currentValue) },
-            onDone = { currentOnSubmit(currentValue) },
-            onSearch = { currentOnSubmit(currentValue) },
-        ),
-    )
-
-}
-
 @Preview(name = "Light")
 @Preview(name = "Dark", uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
 @Composable
@@ -334,6 +328,7 @@ private fun Preview() {
             onHome = {},
             onForward = {},
             canGoForward = false,
+            onTranslatePage = {},
         )
     }
 }

--- a/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -59,6 +60,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import net.matsudamper.browser.data.TranslationProvider
 import kotlinx.coroutines.launch
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoResult
@@ -69,6 +71,8 @@ import java.net.URL
 import java.util.concurrent.Executors
 import androidx.core.graphics.toColorInt
 
+private enum class TranslationState { Idle, Loading, Translated, Error }
+
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun GeckoBrowserTab(
@@ -77,6 +81,7 @@ fun GeckoBrowserTab(
     initialUrl: String,
     homepageUrl: String,
     searchTemplate: String,
+    translationProvider: TranslationProvider,
     modifier: Modifier = Modifier,
     tabCount: Int,
     onInstallExtensionRequest: (String) -> Unit,
@@ -103,12 +108,16 @@ fun GeckoBrowserTab(
     val isImeVisible = WindowInsets.isImeVisible
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    val scope = coroutineScope
     val geckoDownloadManager = remember(context) {
         GeckoDownloadManager(
             context = context,
             runtime = GeckoRuntime.getDefault(context),
         )
     }
+
+    var translationState by remember(tabId) { mutableStateOf(TranslationState.Idle) }
+    var originalPageUrlForRevert by remember(tabId) { mutableStateOf<String?>(null) }
 
     var showFindInPage by remember { mutableStateOf(false) }
     var findQuery by remember { mutableStateOf("") }
@@ -198,6 +207,15 @@ fun GeckoBrowserTab(
                     urlInput = newUrl
                 }
                 toolbarColor = null
+                // ユーザーが別ページへ手動遷移した場合、翻訳状態をリセット
+                val revertUrl = originalPageUrlForRevert
+                if (translationState != TranslationState.Idle &&
+                    !newUrl.startsWith("data:") &&
+                    newUrl != revertUrl
+                ) {
+                    translationState = TranslationState.Idle
+                    originalPageUrlForRevert = null
+                }
             }
         }
         val contentDelegate = object : GeckoSession.ContentDelegate {
@@ -381,6 +399,37 @@ fun GeckoBrowserTab(
                 onForward = { session.goForward() },
                 canGoForward = canGoForward,
                 onRefresh = { session.reload() },
+                onTranslatePage = {
+                    if (translationState != TranslationState.Loading) {
+                        scope.launch {
+                            originalPageUrlForRevert = currentPageUrl
+                            translationState = TranslationState.Loading
+                            val result = runCatching {
+                                PageTranslator(session, currentPageUrl).translatePageToJapanese(translationProvider)
+                            }
+                            translationState = if (result.isSuccess) {
+                                TranslationState.Translated
+                            } else {
+                                TranslationState.Error
+                            }
+                        }
+                    }
+                },
+            )
+            TranslationStatusBar(
+                state = translationState,
+                onRevert = {
+                    val savedUrl = originalPageUrlForRevert
+                    translationState = TranslationState.Idle
+                    originalPageUrlForRevert = null
+                    if (savedUrl != null) {
+                        session.loadUri(savedUrl)
+                    }
+                },
+                onDismissError = {
+                    translationState = TranslationState.Idle
+                    originalPageUrlForRevert = null
+                },
             )
         }
 
@@ -496,6 +545,71 @@ private fun parseManifestColor(colorValue: String): Color? {
         Color(colorValue.toColorInt())
     } catch (_: IllegalArgumentException) {
         null
+    }
+}
+
+@Composable
+private fun TranslationStatusBar(
+    state: TranslationState,
+    onRevert: () -> Unit,
+    onDismissError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state == TranslationState.Idle) return
+
+    val backgroundColor = when (state) {
+        TranslationState.Loading,
+        TranslationState.Translated -> MaterialTheme.colorScheme.secondaryContainer
+        TranslationState.Error -> MaterialTheme.colorScheme.errorContainer
+        TranslationState.Idle -> return
+    }
+
+    Surface(
+        color = backgroundColor,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column {
+            if (state == TranslationState.Loading) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 8.dp),
+            ) {
+                Text(
+                    text = when (state) {
+                        TranslationState.Loading -> "翻訳中..."
+                        TranslationState.Translated -> "翻訳済み"
+                        TranslationState.Error -> "翻訳に失敗しました"
+                        TranslationState.Idle -> ""
+                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(vertical = 8.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = when (state) {
+                        TranslationState.Error -> MaterialTheme.colorScheme.onErrorContainer
+                        else -> MaterialTheme.colorScheme.onSecondaryContainer
+                    },
+                )
+                when (state) {
+                    TranslationState.Translated -> {
+                        TextButton(onClick = onRevert) {
+                            Text(text = "元に戻す")
+                        }
+                    }
+                    TranslationState.Error -> {
+                        IconButton(onClick = onDismissError) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "閉じる",
+                            )
+                        }
+                    }
+                    else -> {}
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/net/matsudamper/browser/PageTranslator.kt
+++ b/app/src/main/java/net/matsudamper/browser/PageTranslator.kt
@@ -1,0 +1,155 @@
+package net.matsudamper.browser
+
+import android.text.Html
+import android.util.Base64
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.TranslatorOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import net.matsudamper.browser.data.TranslationProvider
+import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.TranslationsController
+import java.net.URL
+import java.util.Locale
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal class PageTranslator(
+    private val session: GeckoSession,
+    private val currentPageUrl: String,
+) {
+    suspend fun translatePageToJapanese(provider: TranslationProvider) {
+        when (provider) {
+            TranslationProvider.TRANSLATION_PROVIDER_GECKO,
+            TranslationProvider.UNRECOGNIZED,
+            -> {
+                translateByGecko()
+            }
+
+            TranslationProvider.TRANSLATION_PROVIDER_LOCAL_AI -> {
+                translateByLocalAi()
+            }
+        }
+    }
+
+    private suspend fun translateByGecko() {
+        val state = suspendCancellableCoroutine { cont ->
+            val delegate = object : TranslationsController.SessionTranslation.Delegate {
+                override fun onTranslationStateChange(
+                    session: GeckoSession,
+                    translationState: TranslationsController.SessionTranslation.TranslationState?
+                ) {
+                    if (cont.isActive) {
+                        cont.resume(translationState)
+                    }
+                    session.translationsSessionDelegate = null
+                }
+            }
+            session.translationsSessionDelegate = delegate
+            cont.invokeOnCancellation {
+                session.translationsSessionDelegate = null
+            }
+        }
+        val source = state?.detectedLanguages?.docLangTag ?: return
+        val sourceTag = source.substringBefore('-').lowercase(Locale.ROOT)
+        if (sourceTag == "ja") {
+            return
+        }
+        val options = TranslationsController.SessionTranslation.TranslationOptions.Builder()
+            .downloadModel(true)
+            .build()
+        val sessionTranslation = session.sessionTranslation ?: return
+        sessionTranslation
+            .translate(sourceTag, "ja", options)
+            .awaitGecko()
+    }
+
+    private suspend fun translateByLocalAi() {
+        val plainText = withContext(Dispatchers.IO) {
+            val raw = URL(currentPageUrl).readText()
+            Html.fromHtml(raw, Html.FROM_HTML_MODE_COMPACT).toString()
+        }.take(4500)
+        if (plainText.isBlank()) {
+            return
+        }
+        val sourceLang = detectLanguage(plainText)
+        val sourceTranslateLang = toTranslateLanguageTag(sourceLang) ?: return
+        if (sourceTranslateLang == TranslateLanguage.JAPANESE) {
+            return
+        }
+        val translated = translateWithLocalAi(
+            text = plainText,
+            sourceLanguage = sourceTranslateLang,
+            targetLanguage = TranslateLanguage.JAPANESE,
+        )
+        val html = """
+            <html><body style=\"font-family:sans-serif;padding:16px;line-height:1.6;\">
+            <h2>翻訳（ローカルAI）</h2>
+            <p>${escapeHtml(translated)}</p>
+            </body></html>
+        """.trimIndent()
+        val encoded = Base64.encodeToString(html.toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+        session.loadUri("data:text/html;base64,$encoded")
+    }
+
+    private fun escapeHtml(input: String): String {
+        return input
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+    }
+
+    private suspend fun detectLanguage(text: String): String = withContext(Dispatchers.IO) {
+        val languageIdentifier = LanguageIdentification.getClient()
+        languageIdentifier.use { languageIdentifier ->
+            languageIdentifier.identifyLanguage(text.take(1000)).await().orEmpty()
+        }
+    }
+
+    private fun toTranslateLanguageTag(languageTag: String): String? {
+        if (languageTag.isBlank() || languageTag == "und") {
+            return null
+        }
+        val normalized = languageTag.lowercase(Locale.ROOT)
+        return TranslateLanguage.fromLanguageTag(normalized)
+            ?: TranslateLanguage.fromLanguageTag(normalized.substringBefore('-'))
+    }
+
+    private suspend fun translateWithLocalAi(
+        text: String,
+        sourceLanguage: String,
+        targetLanguage: String,
+    ): String = withContext(Dispatchers.IO) {
+        val options = TranslatorOptions.Builder()
+            .setSourceLanguage(sourceLanguage)
+            .setTargetLanguage(targetLanguage)
+            .build()
+        val translator = Translation.getClient(options)
+        translator.use { translator ->
+            val conditions = DownloadConditions.Builder().build()
+            translator.downloadModelIfNeeded(conditions).await()
+            translator.translate(text).await()
+        }
+    }
+}
+
+private suspend fun <T> GeckoResult<T>.awaitGecko(): T? = suspendCancellableCoroutine { cont ->
+    accept(
+        { value ->
+            if (cont.isActive) {
+                cont.resume(value)
+            }
+        },
+        { throwable ->
+            if (cont.isActive) {
+                cont.resumeWithException(throwable ?: RuntimeException("Unknown Gecko error"))
+            }
+        },
+    )
+}

--- a/app/src/main/java/net/matsudamper/browser/SettingsScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/SettingsScreen.kt
@@ -35,6 +35,7 @@ import net.matsudamper.browser.data.BrowserSettings
 import net.matsudamper.browser.data.HomepageType
 import net.matsudamper.browser.data.SearchProvider
 import net.matsudamper.browser.data.ThemeMode
+import net.matsudamper.browser.data.TranslationProvider
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -128,8 +129,6 @@ internal fun SettingsScreen(
                     }
                 }
             }
-
-
 
             Spacer(Modifier.height(24.dp))
 
@@ -239,6 +238,38 @@ internal fun SettingsScreen(
                     )
                 }
             }
+
+            Spacer(Modifier.height(24.dp))
+
+            SettingSection(
+                title = "翻訳プロバイダー",
+            ) {
+                Column(Modifier.selectableGroup()) {
+                    TranslationProviderOption(
+                        label = "Gecko",
+                        selected = settings.translationProvider == TranslationProvider.TRANSLATION_PROVIDER_GECKO,
+                        onClick = {
+                            onSettingsChange(
+                                settings.toBuilder()
+                                    .setTranslationProvider(TranslationProvider.TRANSLATION_PROVIDER_GECKO)
+                                    .build(),
+                            )
+                        },
+                    )
+                    TranslationProviderOption(
+                        label = "ローカルAI (Android)",
+                        selected = settings.translationProvider == TranslationProvider.TRANSLATION_PROVIDER_LOCAL_AI,
+                        onClick = {
+                            onSettingsChange(
+                                settings.toBuilder()
+                                    .setTranslationProvider(TranslationProvider.TRANSLATION_PROVIDER_LOCAL_AI)
+                                    .build(),
+                            )
+                        },
+                    )
+                }
+            }
+
             Spacer(Modifier.height(24.dp))
 
             SettingSection(
@@ -318,6 +349,29 @@ private fun SearchProviderOption(
 
 @Composable
 private fun ThemeModeOption(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(selected = selected, role = Role.RadioButton, onClick = onClick)
+            .padding(vertical = 4.dp),
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(start = 8.dp),
+        )
+    }
+}
+
+
+@Composable
+private fun TranslationProviderOption(
     label: String,
     selected: Boolean,
     onClick: () -> Unit,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ protobuf = "3.25.3"
 protobufPlugin = "0.9.6"
 paparazzi = "1.3.5"
 composablePreviewScanner = "0.8.1"
+mlkitTranslate = "17.0.3"
+coroutinesPlayServices = "1.10.2"
+mlkitLanguageId = "17.0.6"
 
 [libraries]
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
@@ -34,6 +37,9 @@ androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "d
 protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protobuf" }
 
 composable-preview-scanner = { module = "io.github.sergio-sastre.ComposablePreviewScanner:android", version.ref = "composablePreviewScanner" }
+mlkit-translate = { module = "com.google.mlkit:translate", version.ref = "mlkitTranslate" }
+mlkit-language-id = { module = "com.google.mlkit:language-id", version.ref = "mlkitLanguageId" }
+kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutinesPlayServices" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/proto/src/main/proto/browser_settings.proto
+++ b/proto/src/main/proto/browser_settings.proto
@@ -21,6 +21,11 @@ enum ThemeMode {
   THEME_DARK = 2;
 }
 
+enum TranslationProvider {
+  TRANSLATION_PROVIDER_GECKO = 0;
+  TRANSLATION_PROVIDER_LOCAL_AI = 1;
+}
+
 message BrowserSettings {
   HomepageType homepage_type = 1;
   string custom_homepage_url = 2;
@@ -29,6 +34,7 @@ message BrowserSettings {
   repeated BrowserTabState tab_states = 5;
   int32 selected_tab_index = 6;
   ThemeMode theme_mode = 7;
+  TranslationProvider translation_provider = 8;
 }
 
 message BrowserTabState {


### PR DESCRIPTION
## Summary
This PR adds comprehensive translation state management to the browser tab, including a visual status bar that displays translation progress, success, and error states with appropriate user actions.

## Key Changes
- **Translation State Enum**: Introduced `TranslationState` enum with four states (Idle, Loading, Translated, Error) to track the translation lifecycle
- **State Variables**: Added `translationState` and `originalPageUrlForRevert` state variables to track translation status and enable reverting to the original page
- **Auto-reset on Navigation**: Implemented logic to automatically reset translation state when users manually navigate to a different page (excluding data URIs and revert URLs)
- **Enhanced Translation Handler**: Updated the `onTranslatePage` callback to:
  - Prevent duplicate translation requests while loading
  - Track the original URL before translation
  - Update state based on translation success/failure
- **TranslationStatusBar Composable**: Created a new UI component that:
  - Displays a loading progress indicator during translation
  - Shows success message with a "元に戻す" (revert) button when translation completes
  - Shows error message with a close button on failure
  - Uses Material Design 3 color schemes (secondaryContainer for success/loading, errorContainer for errors)
  - Automatically hides when in Idle state

## Implementation Details
- The status bar uses `LinearProgressIndicator` from Material 3 for visual feedback during translation
- Color and text styling adapts based on the current translation state
- The revert functionality restores the original page URL and clears translation state
- Error dismissal clears both the error state and the saved URL

https://claude.ai/code/session_01QwjwDZf23m68p2JgyRbe2T