### PR TITLE
設定にサードパーティーCA有効化オプションを追加

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -69,6 +69,10 @@ internal fun BrowserApp(
     val homepageUrl = currentSettings.resolvedHomepageUrl()
     val searchTemplate = currentSettings.resolvedSearchTemplate()
 
+    LaunchedEffect(runtime, currentSettings.enableThirdPartyCa) {
+        runtime.settings.setEnterpriseRootsEnabled(currentSettings.enableThirdPartyCa)
+    }
+
     val scope = rememberCoroutineScope()
     val backStack = rememberNavBackStack(AppDestination.Browser)
     var tabPersistenceSignal by remember { mutableLongStateOf(0L) }

--- a/app/src/main/java/net/matsudamper/browser/SettingsScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -263,6 +264,35 @@ internal fun SettingsScreen(
                             onSettingsChange(
                                 settings.toBuilder()
                                     .setTranslationProvider(TranslationProvider.TRANSLATION_PROVIDER_LOCAL_AI)
+                                    .build(),
+                            )
+                        },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            SettingSection(
+                title = "セキュリティ",
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                ) {
+                    Text(
+                        text = "サードパーティーCAを有効化",
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = settings.enableThirdPartyCa,
+                        onCheckedChange = { enabled ->
+                            onSettingsChange(
+                                settings.toBuilder()
+                                    .setEnableThirdPartyCa(enabled)
                                     .build(),
                             )
                         },

--- a/proto/src/main/proto/browser_settings.proto
+++ b/proto/src/main/proto/browser_settings.proto
@@ -35,6 +35,7 @@ message BrowserSettings {
   int32 selected_tab_index = 6;
   ThemeMode theme_mode = 7;
   TranslationProvider translation_provider = 8;
+  bool enable_third_party_ca = 9;
 }
 
 message BrowserTabState {


### PR DESCRIPTION
### Motivation
- サードパーティーCAをユーザー設定で有効化/無効化できるようにして、その状態を永続化および GeckoRuntime に反映するための実装を追加する。 

### Description
- `BrowserSettings` に `bool enable_third_party_ca = 9;` フィールドを追加し設定を永続化可能にした (`proto/src/main/proto/browser_settings.proto`)。 
- 設定画面に「セキュリティ」セクションと `Switch` を追加し、`settings.enableThirdPartyCa` を切り替えることで `BrowserSettings` を更新する UI を実装した (`app/src/main/java/net/matsudamper/browser/SettingsScreen.kt`)。 
- `AppNavigation.kt` に `LaunchedEffect(runtime, currentSettings.enableThirdPartyCa)` を追加して、設定変更時に `runtime.settings.setEnterpriseRootsEnabled(currentSettings.enableThirdPartyCa)` を呼び出して GeckoRuntime に即時反映させる処理を追加した (`app/src/main/java/net/matsudamper/browser/AppNavigation.kt`)。 

### Testing
- `./gradlew :app:compileDebugKotlin --no-daemon` を実行してビルドを検証し、ビルドは成功した。 
- 自動化されたユニット/UI テストは追加しておらず、今回はコンパイル確認のみ実施した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f608f2dc8325ba4d5aaae523dfe8)