### PR TITLE
Add support for browser prompt dialogs (confirm, prompt, select, color, datetime)

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -101,6 +101,16 @@ internal class BrowserTabScreenState(
     var imageContextMenuUrl by mutableStateOf<String?>(null)
     var pendingAlertPrompt by mutableStateOf<GeckoSession.PromptDelegate.AlertPrompt?>(null)
     var pendingAlertResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+    var pendingButtonPrompt by mutableStateOf<GeckoSession.PromptDelegate.ButtonPrompt?>(null)
+    var pendingButtonResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+    var pendingTextPrompt by mutableStateOf<GeckoSession.PromptDelegate.TextPrompt?>(null)
+    var pendingTextResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+    var pendingChoicePrompt by mutableStateOf<GeckoSession.PromptDelegate.ChoicePrompt?>(null)
+    var pendingChoiceResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+    var pendingColorPrompt by mutableStateOf<GeckoSession.PromptDelegate.ColorPrompt?>(null)
+    var pendingColorResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+    var pendingDateTimePrompt by mutableStateOf<GeckoSession.PromptDelegate.DateTimePrompt?>(null)
+    var pendingDateTimeResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
 
     // --- Scroll / Refresh state ---
     var isRefreshing by mutableStateOf(false)
@@ -272,6 +282,85 @@ internal class BrowserTabScreenState(
         pendingAlertResult = null
     }
 
+    fun confirmButtonPrompt(positive: Boolean) {
+        val prompt = pendingButtonPrompt ?: return
+        val type = if (positive) GeckoSession.PromptDelegate.ButtonPrompt.Type.POSITIVE
+                   else GeckoSession.PromptDelegate.ButtonPrompt.Type.NEGATIVE
+        pendingButtonResult?.complete(prompt.confirm(type))
+        pendingButtonPrompt = null
+        pendingButtonResult = null
+    }
+
+    fun dismissButtonPrompt() {
+        val prompt = pendingButtonPrompt ?: return
+        pendingButtonResult?.complete(prompt.dismiss())
+        pendingButtonPrompt = null
+        pendingButtonResult = null
+    }
+
+    fun confirmTextPrompt(value: String) {
+        val prompt = pendingTextPrompt ?: return
+        pendingTextResult?.complete(prompt.confirm(value))
+        pendingTextPrompt = null
+        pendingTextResult = null
+    }
+
+    fun dismissTextPrompt() {
+        val prompt = pendingTextPrompt ?: return
+        pendingTextResult?.complete(prompt.dismiss())
+        pendingTextPrompt = null
+        pendingTextResult = null
+    }
+
+    fun confirmChoicePromptSingle(choice: GeckoSession.PromptDelegate.ChoicePrompt.Choice) {
+        val prompt = pendingChoicePrompt ?: return
+        pendingChoiceResult?.complete(prompt.confirm(choice))
+        pendingChoicePrompt = null
+        pendingChoiceResult = null
+    }
+
+    fun confirmChoicePromptMultiple(choices: Array<GeckoSession.PromptDelegate.ChoicePrompt.Choice>) {
+        val prompt = pendingChoicePrompt ?: return
+        pendingChoiceResult?.complete(prompt.confirm(choices))
+        pendingChoicePrompt = null
+        pendingChoiceResult = null
+    }
+
+    fun dismissChoicePrompt() {
+        val prompt = pendingChoicePrompt ?: return
+        pendingChoiceResult?.complete(prompt.dismiss())
+        pendingChoicePrompt = null
+        pendingChoiceResult = null
+    }
+
+    fun confirmColorPrompt(color: String) {
+        val prompt = pendingColorPrompt ?: return
+        pendingColorResult?.complete(prompt.confirm(color))
+        pendingColorPrompt = null
+        pendingColorResult = null
+    }
+
+    fun dismissColorPrompt() {
+        val prompt = pendingColorPrompt ?: return
+        pendingColorResult?.complete(prompt.dismiss())
+        pendingColorPrompt = null
+        pendingColorResult = null
+    }
+
+    fun confirmDateTimePrompt(datetime: String) {
+        val prompt = pendingDateTimePrompt ?: return
+        pendingDateTimeResult?.complete(prompt.confirm(datetime))
+        pendingDateTimePrompt = null
+        pendingDateTimeResult = null
+    }
+
+    fun dismissDateTimePrompt() {
+        val prompt = pendingDateTimePrompt ?: return
+        pendingDateTimeResult?.complete(prompt.dismiss())
+        pendingDateTimePrompt = null
+        pendingDateTimeResult = null
+    }
+
     fun captureTabPreview(geckoView: GeckoView) {
         geckoView.capturePixels().accept(
             { bitmap ->
@@ -426,6 +515,56 @@ internal class BrowserTabScreenState(
                 val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
                 pendingAlertPrompt = prompt
                 pendingAlertResult = result
+                return result
+            }
+
+            override fun onButtonPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.ButtonPrompt,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                pendingButtonPrompt = prompt
+                pendingButtonResult = result
+                return result
+            }
+
+            override fun onTextPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.TextPrompt,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                pendingTextPrompt = prompt
+                pendingTextResult = result
+                return result
+            }
+
+            override fun onChoicePrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.ChoicePrompt,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                pendingChoicePrompt = prompt
+                pendingChoiceResult = result
+                return result
+            }
+
+            override fun onColorPrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.ColorPrompt,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                pendingColorPrompt = prompt
+                pendingColorResult = result
+                return result
+            }
+
+            override fun onDateTimePrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.DateTimePrompt,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                pendingDateTimePrompt = prompt
+                pendingDateTimeResult = result
                 return result
             }
         }

--- a/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -3,29 +3,46 @@ package net.matsudamper.browser
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.graphics.toColorInt
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -266,5 +283,219 @@ fun GeckoBrowserTab(
                 },
             )
         }
+
+        // Button prompt dialog (window.confirm())
+        state.pendingButtonPrompt?.let { prompt ->
+            AlertDialog(
+                onDismissRequest = state::dismissButtonPrompt,
+                text = { Text(prompt.message ?: "") },
+                confirmButton = {
+                    TextButton(onClick = { state.confirmButtonPrompt(true) }) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { state.confirmButtonPrompt(false) }) {
+                        Text("キャンセル")
+                    }
+                },
+            )
+        }
+
+        // Text prompt dialog (window.prompt())
+        state.pendingTextPrompt?.let { prompt ->
+            var textValue by remember(prompt) { mutableStateOf(prompt.defaultValue ?: "") }
+            AlertDialog(
+                onDismissRequest = state::dismissTextPrompt,
+                title = prompt.message?.takeIf { it.isNotEmpty() }?.let { { Text(it) } },
+                text = {
+                    OutlinedTextField(
+                        value = textValue,
+                        onValueChange = { textValue = it },
+                        singleLine = true,
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = { state.confirmTextPrompt(textValue) }) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = state::dismissTextPrompt) {
+                        Text("キャンセル")
+                    }
+                },
+            )
+        }
+
+        // Choice prompt dialog (<select> elements)
+        state.pendingChoicePrompt?.let { prompt ->
+            ChoicePromptDialog(
+                prompt = prompt,
+                onDismiss = state::dismissChoicePrompt,
+                onConfirmSingle = state::confirmChoicePromptSingle,
+                onConfirmMultiple = state::confirmChoicePromptMultiple,
+            )
+        }
+
+        // Color prompt dialog (<input type="color">)
+        state.pendingColorPrompt?.let { prompt ->
+            var colorText by remember(prompt) { mutableStateOf(prompt.defaultValue ?: "#000000") }
+            val parsedColor = remember(colorText) {
+                runCatching {
+                    androidx.compose.ui.graphics.Color(colorText.toColorInt())
+                }.getOrNull()
+            }
+            AlertDialog(
+                onDismissRequest = state::dismissColorPrompt,
+                title = { Text("色を選択") },
+                text = {
+                    Column {
+                        if (parsedColor != null) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(48.dp)
+                                    .background(parsedColor),
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        OutlinedTextField(
+                            value = colorText,
+                            onValueChange = { colorText = it },
+                            label = { Text("#RRGGBB") },
+                            singleLine = true,
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = { state.confirmColorPrompt(colorText) },
+                        enabled = parsedColor != null,
+                    ) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = state::dismissColorPrompt) {
+                        Text("キャンセル")
+                    }
+                },
+            )
+        }
+
+        // DateTime prompt dialog (<input type="date/time/...">)
+        state.pendingDateTimePrompt?.let { prompt ->
+            var dateTimeText by remember(prompt) { mutableStateOf(prompt.defaultValue ?: "") }
+            val (title, hint) = when (prompt.type) {
+                GeckoSession.PromptDelegate.DateTimePrompt.Type.DATE ->
+                    "日付を選択" to "YYYY-MM-DD"
+                GeckoSession.PromptDelegate.DateTimePrompt.Type.TIME ->
+                    "時刻を選択" to "HH:MM"
+                GeckoSession.PromptDelegate.DateTimePrompt.Type.MONTH ->
+                    "年月を選択" to "YYYY-MM"
+                GeckoSession.PromptDelegate.DateTimePrompt.Type.WEEK ->
+                    "週を選択" to "YYYY-Www"
+                GeckoSession.PromptDelegate.DateTimePrompt.Type.DATETIME_LOCAL ->
+                    "日時を選択" to "YYYY-MM-DDTHH:MM"
+                else -> "値を入力" to ""
+            }
+            AlertDialog(
+                onDismissRequest = state::dismissDateTimePrompt,
+                title = { Text(title) },
+                text = {
+                    OutlinedTextField(
+                        value = dateTimeText,
+                        onValueChange = { dateTimeText = it },
+                        label = { Text(hint) },
+                        singleLine = true,
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = { state.confirmDateTimePrompt(dateTimeText) }) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = state::dismissDateTimePrompt) {
+                        Text("キャンセル")
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChoicePromptDialog(
+    prompt: GeckoSession.PromptDelegate.ChoicePrompt,
+    onDismiss: () -> Unit,
+    onConfirmSingle: (GeckoSession.PromptDelegate.ChoicePrompt.Choice) -> Unit,
+    onConfirmMultiple: (Array<GeckoSession.PromptDelegate.ChoicePrompt.Choice>) -> Unit,
+) {
+    val isMultiple = prompt.type == GeckoSession.PromptDelegate.ChoicePrompt.Type.MULTIPLE
+    val flatChoices = remember(prompt) { flattenChoices(prompt.choices) }
+    val selectedIds = remember(prompt) {
+        mutableStateOf(flatChoices.filter { it.selected }.map { it.id }.toSet())
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = {
+            LazyColumn {
+                items(flatChoices) { choice ->
+                    if (choice.separator) {
+                        HorizontalDivider()
+                    } else {
+                        val isSelected = choice.id in selectedIds.value
+                        ListItem(
+                            headlineContent = { Text(choice.label ?: "") },
+                            leadingContent = {
+                                if (isMultiple) {
+                                    Checkbox(checked = isSelected, onCheckedChange = null)
+                                } else {
+                                    RadioButton(selected = isSelected, onClick = null)
+                                }
+                            },
+                            modifier = Modifier.clickable(enabled = !choice.disabled) {
+                                if (isMultiple) {
+                                    selectedIds.value = if (isSelected) {
+                                        selectedIds.value - choice.id
+                                    } else {
+                                        selectedIds.value + choice.id
+                                    }
+                                } else {
+                                    onConfirmSingle(choice)
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (isMultiple) {
+                TextButton(onClick = {
+                    val selected = flatChoices
+                        .filter { it.id in selectedIds.value }
+                        .toTypedArray()
+                    onConfirmMultiple(selected)
+                }) {
+                    Text("OK")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("キャンセル")
+            }
+        },
+    )
+}
+
+private fun flattenChoices(
+    choices: Array<GeckoSession.PromptDelegate.ChoicePrompt.Choice>,
+): List<GeckoSession.PromptDelegate.ChoicePrompt.Choice> {
+    return choices.flatMap { choice ->
+        if (choice.items != null) choice.items!!.toList() else listOf(choice)
     }
 }


### PR DESCRIPTION
## Summary
Implement comprehensive support for various browser prompt dialogs in the Gecko browser tab, including confirmation dialogs, text input prompts, choice/select dialogs, color pickers, and datetime inputs.

## Key Changes

- **Added prompt state management** in `BrowserTabScreenState`:
  - New mutable state properties for pending prompts: `ButtonPrompt`, `TextPrompt`, `ChoicePrompt`, `ColorPrompt`, and `DateTimePrompt`
  - Corresponding result properties to handle async responses

- **Implemented prompt delegate callbacks** in `BrowserTabScreenState`:
  - `onButtonPrompt()` - handles window.confirm() dialogs
  - `onTextPrompt()` - handles window.prompt() dialogs
  - `onChoicePrompt()` - handles `<select>` element prompts
  - `onColorPrompt()` - handles `<input type="color">` prompts
  - `onDateTimePrompt()` - handles date/time input prompts

- **Added confirmation/dismissal methods** for each prompt type:
  - `confirmButtonPrompt()`, `dismissButtonPrompt()`
  - `confirmTextPrompt()`, `dismissTextPrompt()`
  - `confirmChoicePromptSingle()`, `confirmChoicePromptMultiple()`, `dismissChoicePrompt()`
  - `confirmColorPrompt()`, `dismissColorPrompt()`
  - `confirmDateTimePrompt()`, `dismissDateTimePrompt()`

- **Created UI dialogs** in `GeckoBrowserTab`:
  - Button prompt dialog with OK/Cancel buttons
  - Text prompt dialog with text input field
  - Choice prompt dialog with radio buttons (single) or checkboxes (multiple)
  - Color prompt dialog with hex color input and live preview
  - DateTime prompt dialog with format hints for different input types

- **Added helper composable** `ChoicePromptDialog()` with:
  - Support for both single and multiple selection modes
  - Flattening of nested choice groups
  - Disabled state handling for choices

## Notable Implementation Details

- Color picker validates hex color input and only enables OK button when valid
- DateTime prompts display appropriate format hints based on input type (date, time, month, week, datetime-local)
- Choice prompts support nested groups via `flattenChoices()` utility function
- All dialogs use Japanese labels for cancel/OK buttons
- Text and color inputs use `OutlinedTextField` for consistent Material Design styling

https://claude.ai/code/session_015suGqYqAvDPhnFCJ5tmrwN