### PR TITLE
Add Firefox-like SVG app icon and set as launcher icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
 
     <application
         android:allowBackup="true"
+        android:icon="@drawable/ic_firefox_like"
+        android:roundIcon="@drawable/ic_firefox_like"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Browser">

--- a/app/src/main/res/drawable/ic_firefox_like.xml
+++ b/app/src/main/res/drawable/ic_firefox_like.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#1E2A78"
+        android:pathData="M54,6C27.5,6 6,27.5 6,54s21.5,48 48,48 48,-21.5 48,-48S80.5,6 54,6z" />
+    <path
+        android:fillColor="#4D7CFF"
+        android:pathData="M54,20C35.2,20 20,35.2 20,54s15.2,34 34,34 34,-15.2 34,-34S72.8,20 54,20z" />
+    <path
+        android:fillColor="#FF8A00"
+        android:pathData="M70,16c6.2,3.1 11.5,8 15.3,14.1 -6.8,-1.3 -12.7,0.5 -17.5,5.2 -3.7,3.6 -5.9,8.3 -6.5,13.1 -2.5,-4.3 -3.8,-9.3 -3.8,-14.6 0,-6.9 2.2,-13.4 6,-18.6 2.2,-0.2 4.5,-0 6.5,0.8z" />
+    <path
+        android:fillColor="#FF5A36"
+        android:pathData="M53.8,94c-16.9,0 -30.7,-13.8 -30.7,-30.7 0,-11.8 6.8,-22.2 16.6,-27.4 -1.1,3 -1.8,6.2 -1.8,9.5 0,15.3 12.5,27.8 27.8,27.8 8.3,0 15.8,-3.6 20.8,-9.4 -0.2,16.8 -13.9,30.2 -30.7,30.2z" />
+    <path
+        android:fillColor="#FFD15C"
+        android:pathData="M61.6,34.4c8.8,0 15.9,7.1 15.9,15.9s-7.1,15.9 -15.9,15.9 -15.9,-7.1 -15.9,-15.9 7.1,-15.9 15.9,-15.9z" />
+</vector>


### PR DESCRIPTION
### Motivation
- Provide a Firefox-inspired launcher icon for the app and apply it as the application icon so the app has a custom branded launcher appearance.

### Description
- Added a new vector drawable at `app/src/main/res/drawable/ic_firefox_like.xml` containing layered paths (background circles and warm-color swash) with `108dp` size and `viewport 108x108`.
- Updated `app/src/main/AndroidManifest.xml` to set `android:icon` and `android:roundIcon` to `@drawable/ic_firefox_like` on the `<application>` element.

### Testing
- Built the app with `./gradlew :app:assembleDebug` and the build completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8bfeae95c832598e07ddf045ebd79)