### PR TITLE
Use built-in WebExtension for theme-color updates

### DIFF
--- a/app/src/main/assets/theme_color_extension/manifest.json
+++ b/app/src/main/assets/theme_color_extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 2,
+  "name": "Browsem Theme Color",
+  "version": "1.0",
+  "applications": {
+    "gecko": {
+      "id": "theme-color@browsem"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "theme-color.js"
+      ],
+      "run_at": "document_idle",
+      "all_frames": false
+    }
+  ]
+}

--- a/app/src/main/assets/theme_color_extension/theme-color.js
+++ b/app/src/main/assets/theme_color_extension/theme-color.js
@@ -1,0 +1,17 @@
+(function () {
+  const sendThemeColor = () => {
+    const meta = document.querySelector('meta[name="theme-color"]');
+    const color = meta ? (meta.getAttribute('content') || '').trim() : '';
+    browser.runtime.sendNativeMessage('theme-color', { color });
+  };
+
+  const observer = new MutationObserver(sendThemeColor);
+  observer.observe(document.documentElement, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['content', 'name']
+  });
+
+  sendThemeColor();
+})();

--- a/app/src/main/java/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -3,8 +3,6 @@ package net.matsudamper.browser
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.os.Handler
-import android.os.Looper
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -16,7 +14,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.graphics.toColorInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -28,8 +25,6 @@ import org.mozilla.geckoview.GeckoSessionSettings
 import org.mozilla.geckoview.GeckoView
 import org.mozilla.geckoview.TranslationsController
 import java.io.ByteArrayOutputStream
-import java.net.URL
-import java.util.concurrent.Executors
 
 @Composable
 internal fun rememberBrowserTabScreenState(
@@ -490,14 +485,19 @@ internal class BrowserTabScreenState(
             }
 
             override fun onPageStop(session: GeckoSession, success: Boolean) {
-                val pageUrl = currentPageUrl
-                resolveThemeColor(pageUrl) { resolvedUrl, color ->
-                    if (resolvedUrl == currentPageUrl) {
-                        toolbarColor = color
-                    }
-                }
+                // theme-color updates are pushed from ThemeColorWebExtension.
             }
         }
+
+    fun startThemeColorObservation() {
+        ThemeColorWebExtension.observe(session) { color ->
+            toolbarColor = color
+        }
+    }
+
+    fun stopThemeColorObservation() {
+        ThemeColorWebExtension.removeObserver(session)
+    }
 
     fun createTranslationsDelegate(): TranslationsController.SessionTranslation.Delegate =
         object : TranslationsController.SessionTranslation.Delegate {
@@ -584,56 +584,4 @@ internal class BrowserTabScreenState(
             }
         }
 
-    companion object {
-        private val themeColorHandler = Handler(Looper.getMainLooper())
-        private val themeColorExecutor = Executors.newSingleThreadExecutor()
-
-        private fun resolveThemeColor(
-            pageUrl: String,
-            onColorResolved: (String, Color?) -> Unit,
-        ) {
-            if (pageUrl.isBlank()) {
-                onColorResolved(pageUrl, null)
-                return
-            }
-            themeColorExecutor.execute {
-                val colorText = runCatching {
-                    URL(pageUrl).openConnection().getInputStream().bufferedReader().use { reader ->
-                        reader.readText()
-                    }
-                }.getOrNull()?.let(::findThemeColorMetaContent)
-
-                val parsedColor = colorText?.let(::parseManifestColor)
-                themeColorHandler.post {
-                    onColorResolved(pageUrl, parsedColor)
-                }
-            }
-        }
-
-        private fun findThemeColorMetaContent(html: String): String? {
-            val metaTagRegex =
-                Regex("""<meta\b[^>]*>""", setOf(RegexOption.IGNORE_CASE))
-            val nameRegex =
-                Regex("""\bname\s*=\s*(["'])theme-color\1""", setOf(RegexOption.IGNORE_CASE))
-            val contentRegex =
-                Regex("""\bcontent\s*=\s*(["'])(.*?)\1""", setOf(RegexOption.IGNORE_CASE))
-
-            return metaTagRegex.findAll(html).firstNotNullOfOrNull { matchResult ->
-                val tag = matchResult.value
-                if (!nameRegex.containsMatchIn(tag)) {
-                    return@firstNotNullOfOrNull null
-                }
-                contentRegex.find(tag)?.groupValues?.getOrNull(2)?.trim()
-                    ?.takeIf { it.isNotEmpty() }
-            }
-        }
-
-        private fun parseManifestColor(colorValue: String): Color? {
-            return try {
-                Color(colorValue.toColorInt())
-            } catch (_: IllegalArgumentException) {
-                null
-            }
-        }
-    }
 }

--- a/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -113,6 +113,7 @@ fun GeckoBrowserTab(
         val translationsDelegate = state.createTranslationsDelegate()
         val promptDelegate = state.createPromptDelegate()
 
+        state.startThemeColorObservation()
         session.permissionDelegate = permissionDelegate
         session.navigationDelegate = navigationDelegate
         session.contentDelegate = contentDelegate
@@ -121,6 +122,7 @@ fun GeckoBrowserTab(
         session.promptDelegate = promptDelegate
 
         onDispose {
+            state.stopThemeColorObservation()
         }
     }
 

--- a/app/src/main/java/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/MainActivity.kt
@@ -137,6 +137,7 @@ class MainActivity : ComponentActivity() {
         runtime.webExtensionController.setPromptDelegate(extensionInstaller.promptDelegate)
         runtime.webExtensionController.setAddonManagerDelegate(extensionInstaller.addonManagerDelegate)
         runtime.webNotificationDelegate = webNotificationDelegate
+        ThemeColorWebExtension.install(runtime)
         warmUpWebExtensionController()
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/net/matsudamper/browser/ThemeColorWebExtension.kt
+++ b/app/src/main/java/net/matsudamper/browser/ThemeColorWebExtension.kt
@@ -1,0 +1,72 @@
+package net.matsudamper.browser
+
+import androidx.compose.ui.graphics.Color
+import androidx.core.graphics.toColorInt
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.WebExtension
+import java.util.WeakHashMap
+
+internal object ThemeColorWebExtension {
+    private const val EXTENSION_ID = "theme-color@browsem"
+    private const val EXTENSION_LOCATION = "resource://android/assets/theme_color_extension/"
+    private const val NATIVE_APP = "theme-color"
+
+    private val listeners = WeakHashMap<GeckoSession, (Color?) -> Unit>()
+
+    fun install(runtime: GeckoRuntime) {
+        runtime.webExtensionController.installBuiltIn(EXTENSION_LOCATION).accept(
+            { extension ->
+                runtime.webExtensionController.setMessageDelegate(
+                    extension,
+                    messageDelegate,
+                    NATIVE_APP,
+                )
+            },
+            {
+                runtime.webExtensionController.list().accept({ installedExtensions ->
+                    val installed = installedExtensions.firstOrNull { it.id == EXTENSION_ID } ?: return@accept
+                    runtime.webExtensionController.setMessageDelegate(
+                        installed,
+                        messageDelegate,
+                        NATIVE_APP,
+                    )
+                }, {})
+            },
+        )
+    }
+
+    fun observe(session: GeckoSession, onThemeColor: (Color?) -> Unit) {
+        listeners[session] = onThemeColor
+    }
+
+    fun removeObserver(session: GeckoSession) {
+        listeners.remove(session)
+    }
+
+    private val messageDelegate = object : WebExtension.MessageDelegate {
+        override fun onMessage(
+            nativeApp: String,
+            message: Any,
+            sender: WebExtension.MessageSender,
+        ): GeckoResult<Any>? {
+            if (nativeApp != NATIVE_APP) return null
+
+            val payload = when (message) {
+                is JSONObject -> message
+                is String -> runCatching { JSONObject(message) }.getOrNull()
+                else -> null
+            } ?: return null
+
+            val colorText = payload.optString("color", "").takeIf { it.isNotBlank() }
+            val color = colorText?.let {
+                runCatching { Color(it.toColorInt()) }.getOrNull()
+            }
+
+            listeners[sender.session]?.invoke(color)
+            return null
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Avoid redundant HTML fetching/parsing for `theme-color` and instead receive updates directly from page context via a built-in WebExtension. 
- Install and wire a small internal WebExtension at startup so theme-color is pushed to the app per session, simplifying and improving reliability.

### Description
- Add a built-in WebExtension under `app/src/main/assets/theme_color_extension/` with `manifest.json` and `theme-color.js` that watches `<meta name="theme-color">` and sends native messages (`sendNativeMessage('theme-color', { color })`).
- Add `ThemeColorWebExtension` (`app/src/main/java/net/matsudamper/browser/ThemeColorWebExtension.kt`) to install the built-in extension at startup and dispatch native messages to per-session listeners.
- Call `ThemeColorWebExtension.install(runtime)` from `MainActivity.onCreate` so the extension is installed and message handling is registered on startup.
- Replace the previous manual URL fetch + regex parsing in `BrowserTabScreenState` with observer-based methods `startThemeColorObservation()` and `stopThemeColorObservation()`, and remove the background fetch/parse helper logic.
- Hook up lifecycle-managed observation in `GeckoBrowserTab` so each tab starts/stops theme-color observation when its session is attached/detached.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin --console=plain`, but the build failed in this environment due to Android SDK target resolution errors (missing `android-36`), so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c1520530832582759cfe4e5e641c)