### PR TITLE
Fix race condition in tab restoration and external URL handling

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -30,6 +30,7 @@ import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.defaultPopTransitionSpec
 import androidx.navigation3.ui.defaultTransitionSpec
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import net.matsudamper.browser.navigation.AppDestination
@@ -65,8 +66,12 @@ internal fun BrowserApp(
 
     val backStack = rememberNavBackStack(AppDestination.Setup)
     val navController = remember(backStack) { NavController(backStack = backStack) }
+    // タブ復元完了を待機するためのシグナル
+    val setupComplete = remember { CompletableDeferred<Unit>() }
 
     LaunchedEffect(newTabUrlFlow) {
+        // タブ復元完了を待ってから外部URLを処理する（レースコンディション防止）
+        setupComplete.await()
         newTabUrlFlow.collect { url ->
             val newTab = browserSessionController.createAndAppendTab(initialUrl = url)
             navController.selectTab(newTab.tabId)
@@ -74,9 +79,14 @@ internal fun BrowserApp(
     }
 
     LaunchedEffect(browserSessionController) {
-        val currentTab = navController.getSelectedTab()
-        snapshotFlow { browserSessionController.stateChanged }
-            .collectLatest { viewModel.saveTabStates(currentTab) }
+        snapshotFlow {
+            browserSessionController.stateChanged
+            viewModel.tabPersistenceSignal
+        }.collectLatest {
+            // 保存時に最新の選択タブIDを取得する
+            val currentTab = navController.getSelectedTab()
+            viewModel.saveTabStates(currentTab)
+        }
     }
 
     val handleNotificationPermission: (uri: String) -> GeckoResult<Int> = { uri ->
@@ -132,6 +142,7 @@ internal fun BrowserApp(
                         LaunchedEffect(Unit) {
                             val tabId = viewModel.restoreTabs()
                             navController.selectTab(tabId)
+                            setupComplete.complete(Unit) // 復元完了を通知
                         }
                     }
 


### PR DESCRIPTION
## Summary
This PR fixes a race condition that could occur when handling external URLs during app startup. The issue was that external URLs could be processed before tab restoration was complete, potentially creating tabs in an inconsistent state.

## Key Changes
- Added `CompletableDeferred<Unit>()` signal (`setupComplete`) to synchronize tab restoration completion
- Modified `newTabUrlFlow` collection to await `setupComplete` before processing external URLs, ensuring tabs are restored first
- Refactored tab state persistence logic to capture the current selected tab at save time rather than at effect initialization, preventing stale tab references
- Moved `navController.getSelectedTab()` call inside the `collectLatest` block to ensure the latest tab selection is used during saves

## Implementation Details
- The `setupComplete` deferred is signaled in the Setup destination's `LaunchedEffect` after `viewModel.restoreTabs()` completes
- Tab state persistence now reacts to both `browserSessionController.stateChanged` and `viewModel.tabPersistenceSignal` to ensure timely saves with current state
- This approach prevents external URL handling from interfering with the initial tab restoration process while maintaining proper state synchronization

https://claude.ai/code/session_01PGQMYou7tmePJQYwdepGCf