### PR TITLE
Add drag-and-drop tab reordering functionality

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/BrowserSessionController.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserSessionController.kt
@@ -121,6 +121,13 @@ class BrowserSessionController(runtime: GeckoRuntime) {
         )
     }
 
+    fun moveTab(fromIndex: Int, toIndex: Int) {
+        if (fromIndex == toIndex) return
+        if (fromIndex < 0 || fromIndex >= tabList.size) return
+        if (toIndex < 0 || toIndex >= tabList.size) return
+        tabList.add(toIndex, tabList.removeAt(fromIndex))
+    }
+
     fun closeTab(tabId: String) {
         val index = tabList.indexOfFirst { it.tabId == tabId }
         if (index < 0) {

--- a/app/src/main/java/net/matsudamper/browser/screen/tab/TabsScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/tab/TabsScreen.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -18,8 +19,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -35,20 +38,29 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.round
+import androidx.compose.ui.unit.toOffset
 import androidx.lifecycle.viewmodel.compose.viewModel
 import net.matsudamper.browser.BrowserSessionController
 import net.matsudamper.browser.R
@@ -91,8 +103,109 @@ internal fun TabsScreen(
         onSelectTab = onSelectTab,
         onCloseTab = onCloseTab,
         onOpenNewTab = onOpenNewTab,
+        onReorderTabs = viewModel::reorderTabs,
         modifier = modifier,
     )
+}
+
+/** ドラッグ&ドロップの状態を管理するクラス */
+private class DragDropState(
+    val gridState: LazyGridState,
+    private val onMove: (fromIndex: Int, toIndex: Int) -> Unit,
+) {
+    /** ドラッグ中のアイテムのキー */
+    var draggedItemKey: Any? by mutableStateOf(null)
+        private set
+
+    /** グリッドのビューポート座標でのドラッグオーバーレイの左上位置 */
+    var draggedItemOffset: IntOffset by mutableStateOf(IntOffset.Zero)
+        private set
+
+    /** ドラッグ中アイテムのサイズ（ピクセル） */
+    var draggedItemSize: IntSize by mutableStateOf(IntSize.Zero)
+        private set
+
+    /** ドラッグ中の現在のインデックス（並び替え時に更新） */
+    private var currentDragIndex: Int by mutableIntStateOf(-1)
+
+    /** ドラッグ中かどうか */
+    val isDragging: Boolean get() = draggedItemKey != null
+
+    /** ドラッグ開始時の処理 */
+    fun onDragStart(offset: Offset) {
+        val viewportOffset = gridState.layoutInfo.viewportStartOffset
+        val item = gridState.layoutInfo.visibleItemsInfo.firstOrNull { info ->
+            // visibleItemsInfo の offset は絶対座標なのでビューポート相対に変換して比較する
+            val itemTop = info.offset.y - viewportOffset
+            val itemBottom = itemTop + info.size.height
+            val itemLeft = info.offset.x.toFloat()
+            val itemRight = itemLeft + info.size.width
+            offset.x >= itemLeft && offset.x <= itemRight &&
+                offset.y >= itemTop && offset.y <= itemBottom
+        } ?: return
+
+        draggedItemKey = item.key
+        draggedItemOffset = IntOffset(item.offset.x, item.offset.y - viewportOffset)
+        draggedItemSize = item.size
+        currentDragIndex = item.index
+    }
+
+    /** ドラッグ中の移動処理 */
+    fun onDrag(dragAmount: Offset) {
+        if (!isDragging) return
+
+        draggedItemOffset = (draggedItemOffset.toOffset() + dragAmount).round()
+
+        // ドラッグ中アイテムの中心座標（ビューポート相対）
+        val centerX = draggedItemOffset.x + draggedItemSize.width / 2f
+        val centerY = draggedItemOffset.y + draggedItemSize.height / 2f
+
+        val viewportOffset = gridState.layoutInfo.viewportStartOffset
+
+        // 中心に最も近い別のアイテムを探す
+        val targetItem = gridState.layoutInfo.visibleItemsInfo
+            .filter { it.key != draggedItemKey }
+            .minByOrNull { info ->
+                val itemTop = info.offset.y - viewportOffset
+                val itemCenterX = info.offset.x + info.size.width / 2f
+                val itemCenterY = itemTop + info.size.height / 2f
+                val dx = centerX - itemCenterX
+                val dy = centerY - itemCenterY
+                dx * dx + dy * dy
+            } ?: return
+
+        // ドラッグ中アイテムの中心が別のアイテムの領域内に入ったら並び替え
+        val targetTop = (targetItem.offset.y - viewportOffset).toFloat()
+        val targetBottom = targetTop + targetItem.size.height
+        val targetLeft = targetItem.offset.x.toFloat()
+        val targetRight = targetLeft + targetItem.size.width
+
+        if (centerX in targetLeft..targetRight &&
+            centerY in targetTop..targetBottom &&
+            targetItem.index != currentDragIndex
+        ) {
+            onMove(currentDragIndex, targetItem.index)
+            currentDragIndex = targetItem.index
+        }
+    }
+
+    /** ドラッグ終了時の処理 */
+    fun onDragEnd() {
+        draggedItemKey = null
+        draggedItemOffset = IntOffset.Zero
+        draggedItemSize = IntSize.Zero
+        currentDragIndex = -1
+    }
+}
+
+@Composable
+private fun rememberDragDropState(
+    gridState: LazyGridState,
+    onMove: (fromIndex: Int, toIndex: Int) -> Unit,
+): DragDropState {
+    return remember(gridState) {
+        DragDropState(gridState = gridState, onMove = onMove)
+    }
 }
 
 @Composable
@@ -102,6 +215,7 @@ private fun TabsScreenContent(
     onSelectTab: (String) -> Unit,
     onCloseTab: (String) -> Unit,
     onOpenNewTab: () -> Unit,
+    onReorderTabs: (fromIndex: Int, toIndex: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -145,6 +259,11 @@ private fun TabsScreenContent(
             ) {
                 val columns = TabsLayoutDefaults.calculateColumns(maxWidth)
                 val gridState = rememberLazyGridState()
+                val dragDropState = rememberDragDropState(
+                    gridState = gridState,
+                    onMove = onReorderTabs,
+                )
+
                 LaunchedEffect(Unit) {
                     val selectedIndex = tabs.indexOfFirst { it.id == selectedTabId }
                     if (selectedIndex >= 0) {
@@ -152,10 +271,25 @@ private fun TabsScreenContent(
                         gridState.scrollToItem(targetRow * columns)
                     }
                 }
+
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(columns),
                     state = gridState,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .pointerInput(dragDropState) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = { offset ->
+                                    dragDropState.onDragStart(offset)
+                                },
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    dragDropState.onDrag(dragAmount)
+                                },
+                                onDragEnd = { dragDropState.onDragEnd() },
+                                onDragCancel = { dragDropState.onDragEnd() },
+                            )
+                        },
                     contentPadding = PaddingValues(TabsLayoutDefaults.gridPadding),
                     verticalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
                     horizontalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
@@ -165,88 +299,42 @@ private fun TabsScreenContent(
                         key = { tab -> tab.id },
                     ) { tab ->
                         val selected = tab.id == selectedTabId
-                        Card(
-                            onClick = { onSelectTab(tab.id) },
+                        // ドラッグ中のアイテムはグリッド上で非表示（透明）にする
+                        val isDraggingThis = dragDropState.draggedItemKey == tab.id
+                        TabCard(
+                            tab = tab,
+                            selected = selected,
+                            onSelectTab = onSelectTab,
+                            onCloseTab = onCloseTab,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .aspectRatio(TabsLayoutDefaults.cardAspectRatio),
-                            border = BorderStroke(
-                                width = if (selected) 2.dp else 1.dp,
-                                color = if (selected) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    MaterialTheme.colorScheme.outlineVariant
-                                },
-                            ),
-                            colors = CardDefaults.cardColors(
-                                containerColor = if (selected) {
-                                    MaterialTheme.colorScheme.primaryContainer
-                                } else {
-                                    MaterialTheme.colorScheme.surfaceVariant
-                                }
-                            ),
-                            elevation = CardDefaults.cardElevation(
-                                defaultElevation = if (selected) 8.dp else 1.dp
-                            ),
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxSize(),
-                            ) {
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(start = 12.dp, end = 4.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Text(
-                                        text = tab.title.ifBlank { "Untitled" },
-                                        style = MaterialTheme.typography.titleSmall,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                        modifier = Modifier.weight(1f),
-                                    )
-                                    IconButton(
-                                        onClick = { onCloseTab(tab.id) },
-                                        modifier = Modifier.offset { IntOffset(4, -4) },
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.close_24dp),
-                                            contentDescription = "close"
-                                        )
-                                    }
-                                }
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .weight(1f)
-                                        .padding(horizontal = 8.dp)
-                                        .padding(bottom = 8.dp)
-                                        .clip(RoundedCornerShape(8.dp)),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    var bitmap: Bitmap? by remember { mutableStateOf(null) }
-                                    LaunchedEffect(tab.previewBitmapArray) {
-                                        val array = tab.previewBitmapArray ?: return@LaunchedEffect
-                                        bitmap = BitmapFactory.decodeByteArray(array, 0, array.size)
-                                    }
+                                .aspectRatio(TabsLayoutDefaults.cardAspectRatio)
+                                .animateItem()
+                                .then(if (isDraggingThis) Modifier.alpha(0f) else Modifier),
+                        )
+                    }
+                }
 
-                                    val preview = bitmap?.asImageBitmap()
-                                    if (preview != null) {
-                                        Image(
-                                            bitmap = preview,
-                                            contentDescription = "Tab preview",
-                                            contentScale = ContentScale.Crop,
-                                            modifier = Modifier.fillMaxSize(),
-                                        )
-                                    } else {
-                                        Text(
-                                            text = "No Preview",
-                                            style = MaterialTheme.typography.bodySmall,
-                                        )
-                                    }
-                                }
-                            }
+                // ドラッグ中のオーバーレイ表示
+                if (dragDropState.isDragging) {
+                    val overlayTab = tabs.firstOrNull { it.id == dragDropState.draggedItemKey }
+                    if (overlayTab != null) {
+                        val density = LocalDensity.current
+                        val widthDp = with(density) { dragDropState.draggedItemSize.width.toDp() }
+                        val heightDp = with(density) { dragDropState.draggedItemSize.height.toDp() }
+                        Box(
+                            modifier = Modifier
+                                .offset { dragDropState.draggedItemOffset }
+                                .size(width = widthDp, height = heightDp)
+                                .shadow(elevation = 16.dp, shape = RoundedCornerShape(12.dp)),
+                        ) {
+                            TabCard(
+                                tab = overlayTab,
+                                selected = overlayTab.id == selectedTabId,
+                                onSelectTab = {},
+                                onCloseTab = {},
+                                modifier = Modifier.fillMaxSize(),
+                            )
                         }
                     }
                 }
@@ -263,6 +351,97 @@ private fun TabsScreenContent(
                 painter = painterResource(R.drawable.ic_add_24dp),
                 contentDescription = "新規タブ",
             )
+        }
+    }
+}
+
+/** タブカード */
+@Composable
+private fun TabCard(
+    tab: TabsScreenTabData,
+    selected: Boolean,
+    onSelectTab: (String) -> Unit,
+    onCloseTab: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = { onSelectTab(tab.id) },
+        modifier = modifier,
+        border = BorderStroke(
+            width = if (selected) 2.dp else 1.dp,
+            color = if (selected) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outlineVariant
+            },
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            }
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = if (selected) 8.dp else 1.dp
+        ),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 12.dp, end = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = tab.title.ifBlank { "Untitled" },
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(
+                    onClick = { onCloseTab(tab.id) },
+                    modifier = Modifier.offset { IntOffset(4, -4) },
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.close_24dp),
+                        contentDescription = "close"
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(horizontal = 8.dp)
+                    .padding(bottom = 8.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                var bitmap: Bitmap? by remember { mutableStateOf(null) }
+                LaunchedEffect(tab.previewBitmapArray) {
+                    val array = tab.previewBitmapArray ?: return@LaunchedEffect
+                    bitmap = BitmapFactory.decodeByteArray(array, 0, array.size)
+                }
+
+                val preview = bitmap?.asImageBitmap()
+                if (preview != null) {
+                    Image(
+                        bitmap = preview,
+                        contentDescription = "Tab preview",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    Text(
+                        text = "No Preview",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
         }
     }
 }
@@ -295,5 +474,6 @@ private fun Preview() {
         onSelectTab = {},
         onCloseTab = {},
         onOpenNewTab = {},
+        onReorderTabs = { _, _ -> },
     )
 }

--- a/app/src/main/java/net/matsudamper/browser/screen/tab/TabsScreenViewModel.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/tab/TabsScreenViewModel.kt
@@ -15,6 +15,10 @@ internal class TabsScreenViewModel(
                 previewBitmapArray = it.previewBitmap,
             )
         }
+
+    fun reorderTabs(fromIndex: Int, toIndex: Int) {
+        browserSessionController.moveTab(fromIndex, toIndex)
+    }
 }
 
 internal data class TabsScreenTabData(


### PR DESCRIPTION
## Summary
Implemented drag-and-drop functionality to allow users to reorder tabs in the tabs screen by long-pressing and dragging tab cards.

## Key Changes
- **DragDropState class**: New state management class that tracks dragging state, including the dragged item's key, offset, size, and current index. Handles drag start, drag movement with collision detection, and drag end events.
- **Drag gesture detection**: Integrated `detectDragGesturesAfterLongPress` to the LazyVerticalGrid to capture long-press and drag interactions.
- **Visual feedback**: 
  - Dragged items become transparent (alpha = 0) in the grid
  - An overlay shadow box follows the cursor during dragging, showing a preview of the tab being moved
- **Tab reordering logic**: Implemented collision detection that triggers reordering when the dragged item's center enters another item's bounds.
- **TabCard composable**: Extracted tab card UI into a reusable composable to avoid duplication between grid items and the drag overlay.
- **ViewModel and Controller integration**: Added `reorderTabs()` method to ViewModel and `moveTab()` method to BrowserSessionController to persist tab order changes.

## Implementation Details
- Drag detection uses viewport-relative coordinates to properly handle scrolling grids
- Reordering is triggered by center-point collision detection rather than edge-based detection for more intuitive UX
- The overlay uses `LocalDensity` to convert pixel sizes to Dp units for proper rendering
- Grid items use `animateItem()` modifier for smooth animations during reordering

https://claude.ai/code/session_011QuRwK6yNRY6Rrze1YzTgv