### PR TITLE
Swap toolbar menu refresh and forward actions

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt
@@ -332,16 +332,17 @@ private fun ToolbarMenu(
                 IconButton(
                     onClick = {
                         onDismissRequest()
-                        onRefresh()
-                    }
+                        onForward()
+                    },
+                    enabled = canGoForward,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.ic_refresh_24dp),
-                        contentDescription = "更新",
+                        painter = painterResource(R.drawable.ic_arrow_forward_24dp),
+                        contentDescription = "進む",
                     )
                 }
                 Text(
-                    text = "更新",
+                    text = "進む",
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
@@ -366,17 +367,16 @@ private fun ToolbarMenu(
                 IconButton(
                     onClick = {
                         onDismissRequest()
-                        onForward()
-                    },
-                    enabled = canGoForward,
+                        onRefresh()
+                    }
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.ic_arrow_forward_24dp),
-                        contentDescription = "進む",
+                        painter = painterResource(R.drawable.ic_refresh_24dp),
+                        contentDescription = "更新",
                     )
                 }
                 Text(
-                    text = "進む",
+                    text = "更新",
                     style = MaterialTheme.typography.labelSmall,
                 )
             }


### PR DESCRIPTION
### Motivation
- Swap the positions of the "更新" (refresh) and "進む" (forward) quick actions in the toolbar dropdown so the forward action appears first and the refresh action appears third, matching the requested UI change.

### Description
- Modified `app/src/main/java/net/matsudamper/browser/BrowserToolBar.kt` to make the first menu item call `onForward()` and show `ic_arrow_forward_24dp` with `contentDescription` "進む" and `enabled = canGoForward`.
- Changed the third menu item to call `onRefresh()` and show `ic_refresh_24dp` with `contentDescription` "更新" and the text "更新".

### Testing
- Started `./gradlew :app:compileDebugKotlin --console=plain` and observed Gradle tasks begin, but the compile did not complete within this environment; no automated unit tests were run to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5286537083258cc8b227cce3c2d6)