### PR TITLE
レビュー指摘対応: Webサジェストの即時クリアと安全なデフォルトへ変更

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -154,7 +154,7 @@ internal fun BrowserApp(
                     }
 
                     is AppDestination.Browser -> navEntry(key) {
-                        val browserScreenViewModel = remember(viewModel) {
+                        val browserScreenViewModel = remember(viewModel, key.tabId) {
                             BrowserScreenViewModel(
                                 historyRepository = historyRepository,
                                 settingsRepository = settingsRepository,

--- a/data/src/main/java/net/matsudamper/browser/data/SettingsRepository.kt
+++ b/data/src/main/java/net/matsudamper/browser/data/SettingsRepository.kt
@@ -143,6 +143,6 @@ fun BrowserSettings.resolvedEnableWebSuggestions(): Boolean {
     return if (hasEnableWebSuggestions()) {
         enableWebSuggestions
     } else {
-        true
+        false
     }
 }

--- a/data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt
+++ b/data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt
@@ -6,6 +6,7 @@ import net.matsudamper.browser.data.SearchProvider
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
+import java.util.Locale
 
 interface WebSuggestionRepository {
     suspend fun getSuggestions(
@@ -124,7 +125,7 @@ private fun parseDuckDuckGoSuggestions(body: String): List<String> {
 
 private fun List<String>.distinctPreservingOrder(): List<String> {
     val seen = mutableSetOf<String>()
-    return filter { seen.add(it.lowercase()) }
+    return filter { seen.add(it.lowercase(Locale.ROOT)) }
 }
 
 private fun parseTopLevelArrayValues(body: String): List<String> {

--- a/data/src/test/java/net/matsudamper/browser/data/WebSuggestionRepositoryTest.kt
+++ b/data/src/test/java/net/matsudamper/browser/data/WebSuggestionRepositoryTest.kt
@@ -4,7 +4,7 @@ import net.matsudamper.browser.data.websuggestion.buildSuggestionRequest
 import net.matsudamper.browser.data.websuggestion.parseSuggestionResponse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class WebSuggestionRepositoryTest {
@@ -64,8 +64,8 @@ class WebSuggestionRepositoryTest {
     }
 
     @Test
-    fun webSuggestionsDefaultToEnabledWhenUnset() {
-        assertTrue(BrowserSettings.getDefaultInstance().resolvedEnableWebSuggestions())
+    fun webSuggestionsDefaultToDisabledWhenUnset() {
+        assertFalse(BrowserSettings.getDefaultInstance().resolvedEnableWebSuggestions())
     }
 
     @Test

--- a/feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
+++ b/feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -57,8 +57,7 @@ class BrowserScreenViewModel(
     private val webSuggestions: StateFlow<WebSuggestionState> = combine(
         suggestionQuery
             .map(String::trim)
-            .distinctUntilChanged()
-            .debounce(WEB_SUGGESTION_DEBOUNCE_MILLIS),
+            .distinctUntilChanged(),
         settingsRepository.settings,
     ) { query, settings ->
         WebSuggestionParams(
@@ -67,23 +66,25 @@ class BrowserScreenViewModel(
             enabled = settings.resolvedEnableWebSuggestions(),
         )
     }
+        .distinctUntilChanged()
         .flatMapLatest { params ->
-            if (!params.enabled || !shouldFetchWebSuggestions(params.query)) {
-                flow {
-                    emit(WebSuggestionState())
+            flow {
+                emit(WebSuggestionState())
+
+                if (!params.enabled || !shouldFetchWebSuggestions(params.query)) {
+                    return@flow
                 }
-            } else {
-                flow {
-                    emit(WebSuggestionState(isLoading = true))
-                    emit(
-                        WebSuggestionState(
-                            suggestions = webSuggestionRepository.getSuggestions(
-                                searchProvider = params.searchProvider,
-                                query = params.query,
-                            ),
+
+                delay(WEB_SUGGESTION_DEBOUNCE_MILLIS)
+                emit(WebSuggestionState(isLoading = true))
+                emit(
+                    WebSuggestionState(
+                        suggestions = webSuggestionRepository.getSuggestions(
+                            searchProvider = params.searchProvider,
+                            query = params.query,
                         ),
-                    )
-                }
+                    ),
+                )
             }
         }
         .stateIn(
@@ -132,7 +133,7 @@ internal fun shouldFetchWebSuggestions(query: String): Boolean {
     if (trimmed.isBlank()) {
         return false
     }
-    if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    if (SCHEME_PREFIX_REGEX.containsMatchIn(trimmed)) {
         return false
     }
     if (!trimmed.contains(" ") && trimmed.contains(".")) {
@@ -140,6 +141,8 @@ internal fun shouldFetchWebSuggestions(query: String): Boolean {
     }
     return true
 }
+
+private val SCHEME_PREFIX_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
 private data class WebSuggestionParams(
     val query: String,

--- a/feature-browser/src/test/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModelPolicyTest.kt
+++ b/feature-browser/src/test/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModelPolicyTest.kt
@@ -17,6 +17,13 @@ class BrowserScreenViewModelPolicyTest {
     }
 
     @Test
+    fun webSuggestionsAreDisabledForAnySchemeUrl() {
+        assertFalse(shouldFetchWebSuggestions("about:blank"))
+        assertFalse(shouldFetchWebSuggestions("file:///storage/emulated/0/Download/test.html"))
+        assertFalse(shouldFetchWebSuggestions("HTTPS://example.com"))
+    }
+
+    @Test
     fun webSuggestionsAreDisabledForHostLikeInput() {
         assertFalse(shouldFetchWebSuggestions("example.com"))
     }


### PR DESCRIPTION
### Motivation
- PR のレビュー指摘に基づき、入力変更直後に古い Web サジェストが残る問題を解消する必要がある。
- タブ間で `BrowserScreenViewModel` が共有されて入力状態がリークする問題を防止する必要がある。
- 未設定時に Web サジェストを既定で有効にする実装はプライバシー上好ましくないため opt-in に切り替える。
- サジェストの重複除去や URL 判定でロケールやスキームの差異に起因する誤動作を修正する。 

### Description
- `feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt` の Web サジェストフローを変更し、クエリ変更時にまず空状態を emit して stale な候補を即時クリアし、条件を満たす場合にのみ遅延してローディング→取得を行うようにした（`delay` を利用、`distinctUntilChanged()` を追加）。
- URL 判定を `http/https` 固定から任意のスキームを除外する正規表現に拡張して `about:`, `file:`, 大文字スキームなどを除外するようにした（`SCHEME_PREFIX_REGEX` を追加）。
- `app/src/main/java/net/matsudamper/browser/AppNavigation.kt` で `BrowserScreenViewModel` を `remember(viewModel, key.tabId)` としてタブ単位で再生成するようにして入力状態のリークを防止した。
- `data/src/main/java/net/matsudamper/browser/data/SettingsRepository.kt` で `resolvedEnableWebSuggestions()` の未設定時デフォルトを `true` から `false` に変更し opt-in 化した。
- `data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt` の重複除去で `lowercase(Locale.ROOT)` を使用するように修正してロケール依存を回避した。
- 関連テストを更新し（`data/src/test/java/.../WebSuggestionRepositoryTest.kt` と `feature-browser/src/test/java/.../BrowserScreenViewModelPolicyTest.kt`）、期待値とスキーム除外ケースを追加した。

### Testing
- 実行したコマンドは `./gradlew :data:test :feature-browser:testDebugUnitTest` で、ローカル環境の Gradle プラグイン解決（`org.gradle.toolchains.foojay-resolver-convention:1.0.0`）に失敗しビルドが中断したためユニットテストは実行できませんでした。
- 変更内容に合わせてユニットテストを修正・追加しており、テスト実行が可能な環境ではテストが通る想定です（ただし今回の実行はプラグイン解決エラーで失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b31bea83ec83258010fed64945c0c0)