### PR TITLE
Use StandardCharsets.UTF_8 for URL encoding in WebSuggestionRepository

### DIFF
--- a/data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt
+++ b/data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt
@@ -6,6 +6,7 @@ import net.matsudamper.browser.data.SearchProvider
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.Locale
 
 interface WebSuggestionRepository {
@@ -76,7 +77,7 @@ internal fun buildSuggestionRequest(
     if (trimmed.isBlank()) {
         return null
     }
-    val encodedQuery = URLEncoder.encode(trimmed, "UTF-8")
+    val encodedQuery = URLEncoder.encode(trimmed, StandardCharsets.UTF_8.name())
     return when (searchProvider) {
         SearchProvider.GOOGLE -> SuggestionRequest(
             searchProvider = searchProvider,


### PR DESCRIPTION
### Motivation
- Replace the hardcoded charset string with the standard `StandardCharsets.UTF_8` reference to avoid relying on a literal charset name and improve clarity.

### Description
- Added `import java.nio.charset.StandardCharsets` and changed `URLEncoder.encode(trimmed, "UTF-8")` to `URLEncoder.encode(trimmed, StandardCharsets.UTF_8.name())` in `WebSuggestionRepository`.

### Testing
- No automated tests were added or modified for this trivial change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b325247c44832581e1a6c647b0acc4)