### PR TITLE
Validate fallback URL scheme to prevent javascript: execution

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/ExternalAppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/ExternalAppNavigation.kt
@@ -35,7 +35,13 @@ internal fun resolveExternalAppNavigationAction(
 
     val intent = buildExternalIntent(uri = uri, parsedUri = parsedUri, scheme = scheme)
         ?: return ExternalAppNavigationAction.AllowInBrowser
-    val fallbackUrl = intent.getStringExtra(EXTRA_BROWSER_FALLBACK_URL)?.takeIf { it.isNotBlank() }
+    val fallbackUrl = intent.getStringExtra(EXTRA_BROWSER_FALLBACK_URL)
+        ?.takeIf { it.isNotBlank() }
+        ?.takeIf { url ->
+            // javascript: などの危険なスキームを排除し、http/https のみ許可する
+            val urlScheme = runCatching { Uri.parse(url).scheme?.lowercase(Locale.US) }.getOrNull()
+            urlScheme == "http" || urlScheme == "https"
+        }
     intent.removeExtra(EXTRA_BROWSER_FALLBACK_URL)
 
     val packageManager = context.packageManager


### PR DESCRIPTION
## Summary
Added security validation for the browser fallback URL to prevent execution of dangerous URL schemes like `javascript:`.

## Key Changes
- Enhanced fallback URL validation to check that the URL scheme is either `http` or `https`
- Dangerous schemes (e.g., `javascript:`, `data:`, `file:`) are now rejected and the fallback URL is discarded
- Uses safe URI parsing with error handling to extract and validate the URL scheme

## Implementation Details
- The validation is performed using `Uri.parse()` with `runCatching()` to safely handle malformed URLs
- Only URLs with `http` or `https` schemes are accepted as valid fallback URLs
- The scheme comparison is case-insensitive using `lowercase(Locale.US)` to handle edge cases
- If the fallback URL fails validation, it's treated as if no fallback URL was provided

https://claude.ai/code/session_01PZrcFYyCZjQvN7UdTrC4zV