### PR TITLE
Replace custom JSON parsing with org.json library

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/BrowserTabSurface.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserTabSurface.kt
@@ -397,7 +397,7 @@ internal fun PageLoadErrorOverlay(
 }
 
 const val TEST_TAG_GECKO_CONTAINER = "gecko_container"
-const val TEST_TAG_URL_SUGGESTION_LIST = "history_suggestion_list"
+const val TEST_TAG_URL_SUGGESTION_LIST = "url_suggestion_list"
 const val TEST_TAG_WEB_SUGGESTION_SECTION = "web_suggestion_section"
 const val TEST_TAG_CURRENT_URL_ACTIONS = "current_url_actions"
 const val TEST_TAG_CURRENT_URL_TEXT = "current_url_text"

--- a/data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt
+++ b/data/src/main/java/net/matsudamper/browser/data/websuggestion/WebSuggestionRepository.kt
@@ -2,8 +2,10 @@ package net.matsudamper.browser.data.websuggestion
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import net.matsudamper.browser.data.SearchProvider
+import org.json.JSONArray
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
@@ -42,11 +44,13 @@ class HttpWebSuggestionRepository(
                     return@runCatching emptyList()
                 }
 
-                connection.inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
-                    parseSuggestionResponse(
-                        searchProvider = request.searchProvider,
-                        body = reader.readText(),
-                    )
+                runInterruptible {
+                    connection.inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
+                        parseSuggestionResponse(
+                            searchProvider = request.searchProvider,
+                            body = reader.readText(),
+                        )
+                    }
                 }
             } finally {
                 connection.disconnect()
@@ -113,251 +117,34 @@ internal fun parseSuggestionResponse(
 }
 
 private fun parseGoogleSuggestions(body: String): List<String> {
-    val suggestionsArray = extractTopLevelValue(body, index = 1) ?: return emptyList()
-    return parseJsonStringArray(suggestionsArray)
-        .map(String::trim)
-        .filter(String::isNotEmpty)
-        .distinctPreservingOrder()
+    return try {
+        val topArray = JSONArray(body)
+        val suggestionsArray = topArray.getJSONArray(1)
+        (0 until suggestionsArray.length())
+            .map { suggestionsArray.getString(it).trim() }
+            .filter { it.isNotEmpty() }
+            .distinctPreservingOrder()
+    } catch (_: Exception) {
+        emptyList()
+    }
 }
 
 private fun parseDuckDuckGoSuggestions(body: String): List<String> {
-    return parseTopLevelArrayValues(body)
-        .mapNotNull { extractObjectStringValue(it, key = "phrase") }
-        .map(String::trim)
-        .filter(String::isNotEmpty)
-        .distinctPreservingOrder()
+    return try {
+        val array = JSONArray(body)
+        (0 until array.length())
+            .mapNotNull { array.getJSONObject(it).optString("phrase").takeIf { s -> s.isNotEmpty() } }
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinctPreservingOrder()
+    } catch (_: Exception) {
+        emptyList()
+    }
 }
 
 private fun List<String>.distinctPreservingOrder(): List<String> {
     val seen = mutableSetOf<String>()
     return filter { seen.add(it.lowercase(Locale.ROOT)) }
-}
-
-private fun parseTopLevelArrayValues(body: String): List<String> {
-    val values = mutableListOf<String>()
-    var index = skipWhitespace(body, 0)
-    if (index >= body.length || body[index] != '[') {
-        return emptyList()
-    }
-    index++
-
-    while (true) {
-        index = skipWhitespace(body, index)
-        if (index >= body.length || body[index] == ']') {
-            return values
-        }
-
-        val endIndex = skipJsonValue(body, index)
-        values += body.substring(index, endIndex)
-
-        index = skipWhitespace(body, endIndex)
-        if (index < body.length && body[index] == ',') {
-            index++
-            continue
-        }
-        return values
-    }
-}
-
-private fun extractTopLevelValue(body: String, index: Int): String? {
-    return parseTopLevelArrayValues(body).getOrNull(index)
-}
-
-private fun parseJsonStringArray(body: String): List<String> {
-    val values = mutableListOf<String>()
-    var index = skipWhitespace(body, 0)
-    if (index >= body.length || body[index] != '[') {
-        return emptyList()
-    }
-    index++
-
-    while (true) {
-        index = skipWhitespace(body, index)
-        if (index >= body.length || body[index] == ']') {
-            return values
-        }
-        if (body[index] != '"') {
-            val endIndex = skipJsonValue(body, index)
-            index = skipWhitespace(body, endIndex)
-            if (index < body.length && body[index] == ',') {
-                index++
-                continue
-            }
-            return values
-        }
-
-        val endIndex = skipJsonString(body, index)
-        values += decodeJsonString(body.substring(index + 1, endIndex - 1))
-
-        index = skipWhitespace(body, endIndex)
-        if (index < body.length && body[index] == ',') {
-            index++
-            continue
-        }
-        return values
-    }
-}
-
-private fun extractObjectStringValue(
-    body: String,
-    key: String,
-): String? {
-    var index = skipWhitespace(body, 0)
-    if (index >= body.length || body[index] != '{') {
-        return null
-    }
-    index++
-
-    while (true) {
-        index = skipWhitespace(body, index)
-        if (index >= body.length || body[index] == '}') {
-            return null
-        }
-        if (body[index] != '"') {
-            return null
-        }
-
-        val keyEndIndex = skipJsonString(body, index)
-        val currentKey = decodeJsonString(body.substring(index + 1, keyEndIndex - 1))
-
-        index = skipWhitespace(body, keyEndIndex)
-        if (index >= body.length || body[index] != ':') {
-            return null
-        }
-        index = skipWhitespace(body, index + 1)
-        if (index >= body.length) {
-            return null
-        }
-
-        val valueEndIndex = skipJsonValue(body, index)
-        if (currentKey == key && body[index] == '"') {
-            return decodeJsonString(body.substring(index + 1, valueEndIndex - 1))
-        }
-
-        index = skipWhitespace(body, valueEndIndex)
-        if (index < body.length && body[index] == ',') {
-            index++
-            continue
-        }
-        return null
-    }
-}
-
-private fun skipJsonValue(
-    body: String,
-    startIndex: Int,
-): Int {
-    var index = skipWhitespace(body, startIndex)
-    if (index >= body.length) {
-        return index
-    }
-    return when (body[index]) {
-        '"' -> skipJsonString(body, index)
-        '[' -> skipJsonContainer(body, index, '[', ']')
-        '{' -> skipJsonContainer(body, index, '{', '}')
-        else -> {
-            while (index < body.length && body[index] !in ",]}") {
-                index++
-            }
-            index
-        }
-    }
-}
-
-private fun skipJsonString(
-    body: String,
-    startIndex: Int,
-): Int {
-    var index = startIndex + 1
-    while (index < body.length) {
-        when (body[index]) {
-            '\\' -> index += 2
-            '"' -> return index + 1
-            else -> index++
-        }
-    }
-    return body.length
-}
-
-private fun skipJsonContainer(
-    body: String,
-    startIndex: Int,
-    openChar: Char,
-    closeChar: Char,
-): Int {
-    var index = startIndex
-    var depth = 0
-    var inString = false
-
-    while (index < body.length) {
-        val currentChar = body[index]
-        if (inString) {
-            if (currentChar == '\\') {
-                index += 2
-                continue
-            }
-            if (currentChar == '"') {
-                inString = false
-            }
-            index++
-            continue
-        }
-
-        when (currentChar) {
-            '"' -> inString = true
-            openChar -> depth++
-            closeChar -> {
-                depth--
-                if (depth == 0) {
-                    return index + 1
-                }
-            }
-        }
-        index++
-    }
-    return body.length
-}
-
-private fun decodeJsonString(value: String): String {
-    val result = StringBuilder(value.length)
-    var index = 0
-    while (index < value.length) {
-        val currentChar = value[index]
-        if (currentChar != '\\' || index == value.lastIndex) {
-            result.append(currentChar)
-            index++
-            continue
-        }
-
-        when (val escaped = value[index + 1]) {
-            '"', '\\', '/' -> result.append(escaped)
-            'b' -> result.append('\b')
-            'f' -> result.append('\u000C')
-            'n' -> result.append('\n')
-            'r' -> result.append('\r')
-            't' -> result.append('\t')
-            'u' -> {
-                val unicodeEnd = (index + 6).coerceAtMost(value.length)
-                val unicodeValue = value.substring(index + 2, unicodeEnd)
-                result.append(unicodeValue.toInt(16).toChar())
-                index += 4
-            }
-            else -> result.append(escaped)
-        }
-        index += 2
-    }
-    return result.toString()
-}
-
-private fun skipWhitespace(
-    body: String,
-    startIndex: Int,
-): Int {
-    var index = startIndex
-    while (index < body.length && body[index].isWhitespace()) {
-        index++
-    }
-    return index
 }
 
 private const val USER_AGENT = "browsem/1.0"

--- a/feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
+++ b/feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
@@ -86,7 +86,7 @@ class BrowserScreenViewModel(
             flow {
                 emit(WebSuggestionState())
 
-                if (!params.enabled || !shouldFetchWebSuggestions(params.query)) {
+                if (!params.enabled || !params.searchProvider.supportsWebSuggestions() || !shouldFetchWebSuggestions(params.query)) {
                     return@flow
                 }
 
@@ -158,6 +158,10 @@ internal fun shouldFetchWebSuggestions(query: String): Boolean {
 }
 
 private val SCHEME_PREFIX_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+private fun SearchProvider.supportsWebSuggestions(): Boolean {
+    return this == SearchProvider.GOOGLE || this == SearchProvider.DUCKDUCKGO
+}
 
 private data class WebSuggestionParams(
     val query: String,


### PR DESCRIPTION
## Summary
Replaced custom JSON parsing implementation with the standard `org.json` library for improved maintainability and reliability. This refactoring simplifies the codebase by removing ~200 lines of custom parsing logic.

## Key Changes
- **WebSuggestionRepository**: 
  - Added `runInterruptible` wrapper around input stream reading to properly handle coroutine cancellation
  - Replaced custom JSON parsing functions with `org.json.JSONArray` API
  - Simplified `parseGoogleSuggestions()` to use `JSONArray.getJSONArray()` and direct indexing
  - Simplified `parseDuckDuckGoSuggestions()` to use `JSONArray.getJSONObject()` and `optString()`
  - Removed 217 lines of custom parsing utilities: `parseTopLevelArrayValues()`, `extractTopLevelValue()`, `parseJsonStringArray()`, `extractObjectStringValue()`, `skipJsonValue()`, `skipJsonString()`, `skipJsonContainer()`, `decodeJsonString()`, and `skipWhitespace()`

- **BrowserScreenViewModel**:
  - Added `supportsWebSuggestions()` extension function to `SearchProvider` to explicitly check if a provider supports web suggestions (currently Google and DuckDuckGo)
  - Updated web suggestion flow to skip fetching when the search provider doesn't support suggestions

- **BrowserTabSurface**:
  - Fixed test tag constant from `"history_suggestion_list"` to `"url_suggestion_list"` for better semantic accuracy

## Implementation Details
- Both Google and DuckDuckGo suggestion parsers now wrap parsing logic in try-catch blocks to gracefully handle malformed JSON responses
- The `runInterruptible` wrapper ensures that blocking I/O operations respect coroutine cancellation, improving responsiveness when requests are cancelled
- The new implementation maintains the same filtering and deduplication behavior (case-insensitive, preserving order)

https://claude.ai/code/session_01Lb9yKTMuAAxSprxa9HzsVJ