### PR TITLE
🔒 [security] Add Intent data validation to prevent loading unsafe schemes

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
@@ -66,7 +66,7 @@ class CustomTabActivity : ComponentActivity() {
         // 拡張機能は Koin の single で管理されるため、ここではセッション管理のみ担当する
         runtimeCoordinator = BrowserRuntimeCoordinator(runtime, themeColorExtension, mediaWebExtensionInstance)
 
-        val initialUrl = intent.dataString.orEmpty()
+        val initialUrl = intent.resolveWebUrl().orEmpty()
         val customTabsSessionToken = CustomTabsSessionToken.getSessionTokenFromIntent(intent)
         setContent {
             val settings by settingsRepository.settings.collectAsState(initial = null)

--- a/app/src/main/java/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/MainActivity.kt
@@ -146,7 +146,7 @@ class MainActivity : ComponentActivity() {
         warmUpWebExtensionController()
 
         if (savedInstanceState == null) {
-            val url = intent.dataString
+            val url = intent.resolveWebUrl()
             if (url != null) {
                 createNewTabChannel.trySend(url)
             }
@@ -192,7 +192,7 @@ class MainActivity : ComponentActivity() {
             return
         }
         setIntent(intent)
-        val url = intent.dataString
+        val url = intent.resolveWebUrl()
         if (url != null) {
             createNewTabChannel.trySend(url)
         }

--- a/app/src/main/java/net/matsudamper/browser/UrlUtils.kt
+++ b/app/src/main/java/net/matsudamper/browser/UrlUtils.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser
 
+import android.content.Intent
 import java.net.URLEncoder
 
 /**
@@ -20,4 +21,12 @@ internal fun buildUrlFromInput(
     if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed
     if (!trimmed.contains(" ") && trimmed.contains(".")) return "https://$trimmed"
     return searchTemplate.replace("%s", URLEncoder.encode(trimmed, "UTF-8"))
+}
+
+internal fun Intent.resolveWebUrl(): String? {
+    if (action != Intent.ACTION_VIEW) return null
+    val data = data ?: return null
+    val scheme = data.scheme ?: return null
+    if (scheme != "http" && scheme != "https") return null
+    return data.toString()
 }

--- a/app/src/main/java/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/WebAppActivity.kt
@@ -64,7 +64,7 @@ class WebAppActivity : ComponentActivity() {
         runtimeCoordinator = BrowserRuntimeCoordinator(runtime, themeColorExtension, mediaWebExtension)
 
         // 外部アプリから任意のURLが渡されないよう、http/https スキームのみ許可する
-        val initialUrl = resolveInitialUrl()
+        val initialUrl = intent.resolveWebUrl()
         setContent {
             val settings by settingsRepository.settings.collectAsState(initial = null)
             val browserSettings = settings ?: return@setContent
@@ -101,19 +101,6 @@ class WebAppActivity : ComponentActivity() {
             runtimeCoordinator.close()
         }
         super.onDestroy()
-    }
-
-    /**
-     * Intentのデータから安全なURLを取り出す。
-     * ACTION_VIEW かつ http/https スキームの場合のみURLとして採用し、
-     * それ以外は null を返してホームページにフォールバックさせる。
-     */
-    private fun resolveInitialUrl(): String? {
-        if (intent.action != Intent.ACTION_VIEW) return null
-        val data = intent.data ?: return null
-        val scheme = data.scheme ?: return null
-        if (scheme != "http" && scheme != "https") return null
-        return data.toString()
     }
 
     private fun requestNotificationPermissionIfNeeded(): GeckoResult<Int> {


### PR DESCRIPTION
### 🎯 What:
Fixed a security vulnerability where `CustomTabActivity` and `MainActivity` were loading URLs from incoming Intents without sufficient validation.

### ⚠️ Risk:
Malicious apps could send Intents with unsafe schemes (e.g., `file://`, `content://`, `javascript:`) to gain unauthorized access to local files or execute malicious scripts in the browser context.

### 🛡️ Solution:
Implemented a centralized validation function `Intent.resolveWebUrl()` that ensures:
1. The Intent action is `ACTION_VIEW`.
2. The data scheme is strictly `http` or `https`.

This function is now used across all main entry points (`MainActivity`, `CustomTabActivity`, and `WebAppActivity`) to safely resolve initial URLs.

---
*PR created automatically by Jules for task [2113855977230033092](https://jules.google.com/task/2113855977230033092) started by @matsudamper*