### PR TITLE
Handle back navigation for externally opened tabs

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser
 
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
@@ -18,8 +19,11 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
@@ -30,6 +34,7 @@ import androidx.navigation3.ui.defaultPopTransitionSpec
 import androidx.navigation3.ui.defaultTransitionSpec
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import net.matsudamper.browser.BrowserTab
 import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.data.TabGroupRepository
@@ -90,11 +95,18 @@ internal fun BrowserApp(
         }
     }
 
+    // 外部 Intent から開いたタブの ID を追跡する
+    val externalTabIds = remember { mutableStateSetOf<String>() }
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     LaunchedEffect(newTabUrlFlow) {
         // タブ復元完了を待ってから外部URLを処理する（レースコンディション防止）
         setupComplete.await()
         newTabUrlFlow.collect { url ->
             val newTab = browserSessionController.createAndAppendTab(initialUrl = url)
+            // 外部から開いたタブとして記録する
+            externalTabIds.add(newTab.tabId)
             selectTab(newTab.tabId, null)
         }
     }
@@ -108,6 +120,21 @@ internal fun BrowserApp(
 
     BackHandler(enabled = navController.isLastBackHandled) {
         navController.back()
+    }
+
+    // 外部 URL で開いたタブをバックで閉じる処理。
+    // タブ移動・ホーム遷移等の操作なしにバックされた場合（isLastBackHandled == false）にのみ発火し、
+    // タブを閉じて即座に保存してからアプリを終了する。
+    val currentExternalTabId = run {
+        val currentTabId = backStack.filterIsInstance<AppDestination.Browser>().lastOrNull()?.tabId
+        currentTabId?.takeIf { it in externalTabIds }
+    }
+    BackHandler(enabled = !navController.isLastBackHandled && currentExternalTabId != null) {
+        val tabId = currentExternalTabId ?: return@BackHandler
+        scope.launch {
+            viewModel.closeTabAndSaveImmediately(tabId, homepageUrl)
+            (context as ComponentActivity).finish()
+        }
     }
 
     BrowserTheme(themeMode = settingsUiState.themeMode) {

--- a/app/src/main/java/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserViewModel.kt
@@ -100,6 +100,16 @@ internal class BrowserViewModel(
         }
     }
 
+    /** タブを閉じ、即座に永続化する（外部URL タブをバックで閉じるときに使用）。 */
+    suspend fun closeTabAndSaveImmediately(tabId: String, homepageUrl: String) {
+        browserSessionController.closeTab(tabId)
+        // タブが空になった場合はホームタブを作成して空状態での保存を避ける
+        if (browserSessionController.tabs.isEmpty()) {
+            browserSessionController.createAndAppendTab(initialUrl = homepageUrl)
+        }
+        tabPersistenceCoordinator.saveNow(browserSessionController)
+    }
+
     fun applyRuntimeSettings() {
         runtimeCoordinator.applyRuntimeSettings(settings.value?.enableThirdPartyCa ?: false)
     }

--- a/browser-engine-gecko/src/main/java/net/matsudamper/browser/TabPersistenceCoordinator.kt
+++ b/browser-engine-gecko/src/main/java/net/matsudamper/browser/TabPersistenceCoordinator.kt
@@ -58,6 +58,12 @@ class TabPersistenceCoordinator(
         }
     }
 
+    /** 遅延なしで即座にタブ状態を保存する（外部URL タブを閉じてアプリ終了する際に使用）。 */
+    suspend fun saveNow(browserSessionController: BrowserSessionController) {
+        if (!restorationComplete) return
+        saveInternal(browserSessionController)
+    }
+
     fun bind(
         scope: CoroutineScope,
         browserSessionController: BrowserSessionController,


### PR DESCRIPTION
## Summary
Add special handling for tabs opened via external intents. When a user presses back on a tab that was opened externally (without any intermediate navigation), the app now closes the tab, saves state immediately, and exits gracefully.

## Key Changes
- **AppNavigation.kt**: 
  - Track externally opened tabs using `mutableStateSetOf<String>()` to store their IDs
  - Add a `BackHandler` that detects when the user presses back on an external tab without intermediate navigation (`!navController.isLastBackHandled`)
  - On back press, close the tab, save state immediately, and finish the activity
  
- **BrowserViewModel.kt**:
  - Add `closeTabAndSaveImmediately()` suspend function to close a tab and persist state without delay
  - Ensure at least one tab exists after closing (create home tab if needed) to avoid empty state
  
- **TabPersistenceCoordinator.kt**:
  - Add `saveNow()` suspend function for immediate tab state persistence (bypasses normal debouncing)

## Implementation Details
- External tab IDs are recorded when tabs are created via `newTabUrlFlow`
- The back handler only activates when `isLastBackHandled` is false, meaning no intermediate navigation occurred
- Immediate save is necessary to ensure state is persisted before the activity finishes
- Home tab creation prevents saving an empty tab state when closing the last tab

https://claude.ai/code/session_015S6tKPPHPsQJntun2q5gLN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back button handling for externally opened tabs. When you press back while viewing a tab that was opened from another app or external link, the browser now properly closes that tab, saves your complete browsing session, and exits the app cleanly instead of potentially losing your data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->