### PR TITLE
Refactor ViewModels: encapsulate internal methods and fix event ordering

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
@@ -167,7 +167,7 @@ private fun CustomTabScreen(
             webSuggestionRepository = webSuggestionRepository,
         )
     })
-    val urlBarSuggestions by viewModel.urlBarSuggestions.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
     val prewarmedSession = remember(customTabsSessionToken, initialUrl) {
         customTabsSessionToken?.let { token ->
             CustomTabsWarmupStore.consumePreparedSession(
@@ -214,9 +214,9 @@ private fun CustomTabScreen(
             browserTab.session
         },
         onCloseTab = onClose,
-        onHistoryRecord = { url, title -> historyRepository.recordVisit(url, title) },
-        onHistoryTitleUpdate = { id, title -> historyRepository.updateTitle(id, title) },
-        urlBarSuggestions = urlBarSuggestions,
-        onUrlInputChanged = viewModel::onUrlInputChanged,
+        onHistoryRecord = uiState.callbacks::onHistoryRecord,
+        onHistoryTitleUpdate = uiState.callbacks::onHistoryTitleUpdate,
+        urlBarSuggestions = uiState.urlBarSuggestions,
+        onUrlInputChanged = uiState.callbacks::onUrlInputChanged,
     )
 }

--- a/feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
+++ b/feature-browser/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
@@ -125,7 +125,7 @@ class BrowserScreenViewModel(
             initialValue = WebSuggestionState(),
         )
 
-    val urlBarSuggestions: StateFlow<UrlBarSuggestionsUiState> = combine(
+    private val urlBarSuggestions: StateFlow<UrlBarSuggestionsUiState> = combine(
         historySuggestions,
         webSuggestions,
     ) { history, web ->
@@ -158,18 +158,6 @@ class BrowserScreenViewModel(
         )
 
     interface Event
-
-    suspend fun recordHistory(url: String, title: String): Long {
-        return historyRepository.recordVisit(url, title)
-    }
-
-    suspend fun updateHistoryTitle(id: Long, title: String) {
-        historyRepository.updateTitle(id, title)
-    }
-
-    fun onUrlInputChanged(query: String) {
-        suggestionQuery.value = query
-    }
 
     companion object {
         private const val HISTORY_SUGGESTION_LIMIT = 8

--- a/feature-tabs/src/main/java/net/matsudamper/browser/screen/tab/TabsScreenViewModel.kt
+++ b/feature-tabs/src/main/java/net/matsudamper/browser/screen/tab/TabsScreenViewModel.kt
@@ -89,8 +89,9 @@ class TabsScreenViewModel(
 
     private val callbacks = object : TabsScreenUiState.Callbacks {
         override fun onCloseTab(tabId: String) {
-            onTabClosed(tabId)
+            // イベントを先に送信してタブを閉じてから、グループ割り当てを解除する
             eventHandler.trySend { it.closeTab(tabId) }
+            onTabClosed(tabId)
         }
 
         override fun onReorderTabs(groupIndex: Int, fromLocalIndex: Int, toLocalIndex: Int) {
@@ -102,11 +103,11 @@ class TabsScreenViewModel(
         }
 
         override fun onGroupSelected(index: Int) {
-            onGroupSelected(index)
+            this@TabsScreenViewModel.onGroupSelected(index)
         }
 
         override fun onGroupPageChanged(page: Int) {
-            onGroupPageChanged(page)
+            this@TabsScreenViewModel.onGroupPageChanged(page)
         }
 
         override fun onAddGroup() {
@@ -139,7 +140,8 @@ class TabsScreenViewModel(
                 TabsScreenUiState.LoadingState.Loaded(
                     groupedTabs = currentGroupedTabs,
                     groups = currentGroups,
-                    activeGroupIndex = currentActiveIndex,
+                    // グループが空になる場合も含めて有効範囲にクランプする
+                    activeGroupIndex = currentActiveIndex.coerceIn(0, (currentGroups.size - 1).coerceAtLeast(0)),
                 )
             },
         )
@@ -215,7 +217,7 @@ class TabsScreenViewModel(
      * Pager のプログラム的アニメーション中に settledPage が中間ページを報告しても
      * _activeGroupIndex が上書きされないよう、programmaticScrollTarget を設定する。
      */
-    fun onGroupSelected(index: Int) {
+    private fun onGroupSelected(index: Int) {
         if (_activeGroupIndex.value == index) return
         val coerced = index.coerceIn(0, groups.value.lastIndex.coerceAtLeast(0))
         programmaticScrollTarget = coerced
@@ -227,7 +229,7 @@ class TabsScreenViewModel(
      * プログラム的アニメーション中（onGroupSelected 経由）は中間ページを無視し、
      * 目標ページに到達したときのみターゲットをクリアする。
      */
-    fun onGroupPageChanged(page: Int) {
+    private fun onGroupPageChanged(page: Int) {
         val target = programmaticScrollTarget
         if (target != null) {
             if (page == target) {
@@ -242,7 +244,7 @@ class TabsScreenViewModel(
     }
 
     /** 新しいグループを追加する */
-    fun addGroup() {
+    private fun addGroup() {
         viewModelScope.launch {
             val currentGroups = groups.value
             val newSortOrder = currentGroups.size
@@ -261,7 +263,7 @@ class TabsScreenViewModel(
      * グループを長押しドラッグで並び替える。
      * ローカル順序をすぐに更新して UI を即時反映し、DB へも非同期で保存する。
      */
-    fun reorderGroups(fromIndex: Int, toIndex: Int) {
+    private fun reorderGroups(fromIndex: Int, toIndex: Int) {
         val currentGroups = (_localGroupOrder.value ?: groups.value).toMutableList()
         if (fromIndex !in currentGroups.indices || toIndex !in currentGroups.indices) return
         currentGroups.add(toIndex, currentGroups.removeAt(fromIndex))
@@ -282,14 +284,14 @@ class TabsScreenViewModel(
     }
 
     /** タブが閉じられたときにグループ割り当てを解除する */
-    fun onTabClosed(tabId: String) {
+    private fun onTabClosed(tabId: String) {
         viewModelScope.launch {
             tabGroupRepository.removeTabFromGroup(tabId)
         }
     }
 
     /** タブを別のグループへ移動する */
-    fun moveTabToGroup(tabId: String, targetGroupIndex: Int) {
+    private fun moveTabToGroup(tabId: String, targetGroupIndex: Int) {
         val targetGroup = groups.value.getOrNull(targetGroupIndex) ?: return
         viewModelScope.launch {
             tabGroupRepository.assignTabToGroup(tabId, targetGroup.id)
@@ -300,7 +302,7 @@ class TabsScreenViewModel(
      * グループ内でタブを並び替える。
      * グローバルリストはグループ順に連結した順序で同期する。
      */
-    fun reorderTabs(groupIndex: Int, fromLocalIndex: Int, toLocalIndex: Int) {
+    private fun reorderTabs(groupIndex: Int, fromLocalIndex: Int, toLocalIndex: Int) {
         val currentGroupedTabs = groupedTabs.value
         val tabsInGroup = currentGroupedTabs.getOrNull(groupIndex) ?: return
         if (fromLocalIndex !in tabsInGroup.indices || toLocalIndex !in tabsInGroup.indices) return
@@ -321,7 +323,7 @@ class TabsScreenViewModel(
     }
 
     /** グループ名を変更する */
-    fun renameGroup(groupIndex: Int, newName: String) {
+    private fun renameGroup(groupIndex: Int, newName: String) {
         val currentGroups = groups.value
         val group = currentGroups.getOrNull(groupIndex) ?: return
         // ローカル順序を即座に更新して UI に反映する
@@ -334,7 +336,7 @@ class TabsScreenViewModel(
     }
 
     /** グループを削除する。タブは隣接グループへ再割り当てされる。 */
-    fun deleteGroup(groupIndex: Int) {
+    private fun deleteGroup(groupIndex: Int) {
         val currentGroups = groups.value
         val group = currentGroups.getOrNull(groupIndex) ?: return
         val fallback = currentGroups.firstOrNull { it.id != group.id }


### PR DESCRIPTION
## Summary
This PR refactors the ViewModel classes to improve encapsulation by making internal methods private and fixes event handling order in tab closure. It also updates the CustomTabActivity to use the new ViewModel API structure.

## Key Changes

### TabsScreenViewModel
- **Event ordering fix**: Reordered `onCloseTab` to send the close event before calling `onTabClosed`, ensuring proper event sequencing
- **Encapsulation**: Made the following methods private (were public):
  - `onGroupSelected()`, `onGroupPageChanged()` - now called via explicit `this@TabsScreenViewModel` reference in callbacks
  - `addGroup()`, `reorderGroups()`, `onTabClosed()`, `moveTabToGroup()`, `reorderTabs()`, `renameGroup()`, `deleteGroup()`
- **Bug fix**: Added bounds checking for `activeGroupIndex` to clamp it within valid range `[0, max(0, groupSize-1)]` to prevent invalid indices when groups become empty

### BrowserScreenViewModel
- **Encapsulation**: Made `urlBarSuggestions` StateFlow private (was public)
- **API cleanup**: Removed public methods that were only used internally:
  - `recordHistory()`, `updateHistoryTitle()`, `onUrlInputChanged()`

### CustomTabActivity
- **API migration**: Updated to use the new ViewModel structure:
  - Changed from direct `viewModel.urlBarSuggestions` to `viewModel.uiState.urlBarSuggestions`
  - Changed from direct method calls to callback-based API: `uiState.callbacks::onHistoryRecord`, `uiState.callbacks::onHistoryTitleUpdate`, `uiState.callbacks::onUrlInputChanged`

## Implementation Details
- The callback-based approach in TabsScreenViewModel ensures proper encapsulation while maintaining the ability to call internal methods from the UI callback interface
- The bounds clamping for `activeGroupIndex` prevents crashes when the active group is deleted or all groups are removed
- These changes improve the public API surface by hiding implementation details and making the ViewModels more maintainable

https://claude.ai/code/session_01LJs7vEy43o3sytYuLUcsnE