### PR TITLE
Move setupComplete signal to ViewModel for configuration change safety

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -32,7 +32,6 @@ import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.defaultPopTransitionSpec
 import androidx.navigation3.ui.defaultTransitionSpec
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import net.matsudamper.browser.BrowserTab
@@ -84,8 +83,8 @@ internal fun BrowserApp(
 
     val backStack = rememberNavBackStack(AppDestination.Setup)
     val navController = remember(backStack) { NavController(backStack = backStack) }
-    // タブ復元完了を待機するためのシグナル
-    val setupComplete = remember { CompletableDeferred<Unit>() }
+    // タブ復元完了シグナルは ViewModel で保持（構成変更後も有効）
+    val setupComplete = viewModel.setupComplete
 
     // ナビゲーションとViewModelの両方にタブ選択を通知するヘルパー
     val selectTab: (String, AppDestination.Browser?) -> Unit = remember(navController, viewModel) {
@@ -179,7 +178,7 @@ internal fun BrowserApp(
                         LaunchedEffect(Unit) {
                             val tabId = viewModel.restoreTabs()
                             selectTab(tabId, null)
-                            setupComplete.complete(Unit) // 復元完了を通知
+                            // setupComplete は restoreTabs() 内で complete 済み
                         }
                     }
 

--- a/app/src/main/java/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserViewModel.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -54,6 +55,9 @@ internal class BrowserViewModel(
     val browserSessionController: BrowserSessionController
         get() = runtimeCoordinator.browserSessionController
 
+    // 構成変更を経ても破棄されないよう ViewModel で保持するセットアップ完了シグナル
+    val setupComplete = CompletableDeferred<Unit>()
+
     private val settings: StateFlow<BrowserSettings?> = settingsRepository.settings
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
     val settingsUiState: StateFlow<SettingsUiState?> = settings
@@ -81,6 +85,7 @@ internal class BrowserViewModel(
                 scope = viewModelScope,
                 browserSessionController = browserSessionController,
             )
+            setupComplete.complete(Unit)
         }
     }
 


### PR DESCRIPTION
## Summary
Moved the `setupComplete` CompletableDeferred signal from the composable function to the ViewModel to ensure it persists across configuration changes (e.g., screen rotation) and maintains its completion state properly.

## Key Changes
- Removed `CompletableDeferred` import from AppNavigation.kt
- Moved `setupComplete` from a local `remember` block in `BrowserApp()` composable to a property in `BrowserViewModel`
- Updated `setupComplete.complete(Unit)` call to be invoked inside `restoreTabs()` method in the ViewModel instead of in the composable's LaunchedEffect
- Updated comments to reflect the new ownership and completion location

## Implementation Details
- The `setupComplete` signal is now a ViewModel property, ensuring it survives configuration changes since ViewModels are retained across activity/fragment recreation
- The completion logic is now centralized in `BrowserViewModel.restoreTabs()`, making the flow clearer and preventing potential race conditions
- This change maintains the same external behavior while improving lifecycle safety and code organization

https://claude.ai/code/session_01S8Nxny6Befn7edCU19xGXv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal tab restoration coordination system. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->