### PR TITLE
Include branch name and commit hash in debug APK artifact

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -41,11 +41,13 @@ jobs:
       - name: Rename APK with branch and short hash
         env:
           BRANCH_NAME: ${{ github.head_ref }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
-          # ブランチ名のスラッシュをハイフンに置換してファイル名に使えるようにする
+          # リポジトリ名・ブランチ名のスラッシュをハイフンに置換してファイル名に使えるようにする
+          SAFE_REPO="${REPOSITORY//\//-}"
           SAFE_BRANCH="${BRANCH_NAME//\//-}"
-          APK_NAME="app-${SAFE_BRANCH}-${SHORT_SHA}.apk"
+          APK_NAME="app-${SAFE_REPO}-${SAFE_BRANCH}-${SHORT_SHA}.apk"
           mv app/build/outputs/apk/debug/app-debug.apk \
              "app/build/outputs/apk/debug/${APK_NAME}"
           echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
Enhanced the debug APK build artifact naming to include the git branch name and short commit hash, making it easier to identify which branch and commit a particular APK was built from.

## Key Changes
- Added a new workflow step that renames the debug APK from `app-debug.apk` to `app-{branch}-{short-sha}.apk`
- Branch names with slashes are converted to hyphens to ensure valid filenames
- Updated the artifact upload step to use the dynamically generated APK path
- Updated the PR comment to display the actual APK name instead of a static string

## Implementation Details
- The short commit hash is extracted from `GITHUB_SHA` (first 7 characters)
- Branch name sanitization replaces forward slashes with hyphens using bash parameter expansion
- Environment variables (`APK_NAME` and `APK_PATH`) are set for use in subsequent workflow steps
- The artifact name in PR comments now dynamically reflects the actual uploaded file name

https://claude.ai/code/session_01KbzeSnRahScCRL13ExWmKQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build artifacts are now renamed to include repository, branch and short commit identifiers for clearer tracing.
  * CI uploads and pull request notes now reference the dynamically named artifact instead of a fixed filename.
  * Environment variables export the artifact name and path so downstream steps and PR feedback display accurate build info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->