### PR TITLE
Fix APK naming to use repository name only

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,8 +44,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
-          # リポジトリ名・ブランチ名のスラッシュをハイフンに置換してファイル名に使えるようにする
-          SAFE_REPO="${REPOSITORY//\//-}"
+          # リポジトリ名のみ取得（org名を除去）し、ブランチ名のスラッシュをハイフンに置換してファイル名に使えるようにする
+          SAFE_REPO="${REPOSITORY##*/}"
           SAFE_BRANCH="${BRANCH_NAME//\//-}"
           APK_NAME="app-${SAFE_REPO}-${SAFE_BRANCH}-${SHORT_SHA}.apk"
           mv app/build/outputs/apk/debug/app-debug.apk \


### PR DESCRIPTION
## Summary
Updated the APK naming logic in the PR build workflow to extract only the repository name (excluding the organization prefix) instead of the full repository path.

## Key Changes
- Modified the `SAFE_REPO` variable extraction to use `${REPOSITORY##*/}` instead of `${REPOSITORY//\//-}`
- This change extracts only the repository name portion after the last slash, rather than replacing all slashes with hyphens in the full `org/repo` path
- Updated the corresponding comment to clarify the new behavior

## Implementation Details
The previous implementation would transform a repository like `myorg/myrepo` into `myorg-myrepo`, resulting in APK names like `app-myorg-myrepo-branch-sha.apk`. The new implementation extracts just `myrepo`, resulting in cleaner APK names like `app-myrepo-branch-sha.apk`.

This simplifies the APK naming scheme and makes the filenames more concise while still maintaining uniqueness through the branch name and commit SHA.

https://claude.ai/code/session_01GhwycDmyFMoWu8NtmYuLNE