### PR TITLE
docs: Add Managed Device requirement for instrumentation tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Proto → DataStore/Room → Repository → ViewModel (StateFlow) → Compose
 - **単体テスト**: JUnit 4。`./gradlew test` で実行 (Paparazzi テストは自動除外)
 - **スクリーンショットテスト**: Paparazzi。`@Preview` 付き Composable を自動スキャンしてスナップショット
 - **Instrumentation テスト**: Managed Device (Pixel 6, API 34)。`app/src/androidTest/`
+  - **接続デバイス (実機・通常エミュレータ) の使用は禁止**。必ず Gradle Managed Device (`./gradlew :app:pixel6Api34DebugAndroidTest`) を使用すること
 - **Lint**: `./gradlew :app:lintDebug`
 
 ## 作業フロー


### PR DESCRIPTION
## Summary
Updated the testing documentation to clarify that instrumentation tests must use Gradle Managed Device and prohibit the use of connected physical devices or standard emulators.

## Changes
- Added explicit requirement that instrumentation tests must use Gradle Managed Device (`./gradlew :app:pixel6Api34DebugAndroidTest`)
- Documented prohibition against using connected devices (physical devices or standard emulators) for instrumentation testing
- This ensures consistent test execution environment across the development team

## Details
This documentation update reinforces the testing infrastructure best practices by making it clear that all instrumentation tests should run on the managed Pixel 6 API 34 device configuration rather than ad-hoc connected devices, which can lead to inconsistent results and environment-specific issues.

https://claude.ai/code/session_015pXE4EiWw2Ys2XB78Ue3vk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android instrumentation testing guidance: connected device and emulator testing is no longer permitted; tests must be executed using Gradle Managed Device task instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->