### PR TITLE
Enable edge-to-edge layout for CustomTabActivity

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.customtabs.CustomTabsSessionToken
 import androidx.compose.foundation.layout.fillMaxSize
@@ -61,6 +62,7 @@ class CustomTabActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         runtime.settings.setExtensionsWebAPIEnabled(true)
 
         // 拡張機能は Koin の single で管理されるため、ここではセッション管理のみ担当する

--- a/app/src/main/java/net/matsudamper/browser/CustomTabToolbar.kt
+++ b/app/src/main/java/net/matsudamper/browser/CustomTabToolbar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -53,6 +54,8 @@ internal fun CustomTabToolbar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                // ステータスバー領域はSurfaceの背景色で塗りつぶし、コンテンツをその下に押し出す
+                .statusBarsPadding()
                 .padding(horizontal = 4.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
## Summary
This PR enables edge-to-edge layout support for the CustomTabActivity, allowing the UI to extend behind system bars while properly managing insets.

## Key Changes
- Added `enableEdgeToEdge()` call in `CustomTabActivity.onCreate()` to enable edge-to-edge rendering
- Imported `androidx.activity.enableEdgeToEdge` in CustomTabActivity
- Added `statusBarsPadding()` modifier to the toolbar Row in CustomTabToolbar to prevent content from overlapping with the status bar
- Imported `androidx.compose.foundation.layout.statusBarsPadding` in CustomTabToolbar
- Added Japanese comment explaining that the status bar area is filled with the Surface background color and content is pushed below it

## Implementation Details
The changes follow the modern Android edge-to-edge layout pattern:
1. `enableEdgeToEdge()` enables the system to draw behind system bars
2. `statusBarsPadding()` on the toolbar ensures the custom tab toolbar content respects the status bar inset, maintaining proper spacing and preventing overlap

https://claude.ai/code/session_01Bj4Zq3UhKELpxLck7UiFjF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enabled edge-to-edge rendering for the custom tab interface, allowing content to extend to screen edges
  * Improved toolbar layout with proper system status bar spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->