### PR TITLE
Add download notification permission request support

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
+++ b/app/src/main/java/net/matsudamper/browser/AppNavigation.kt
@@ -69,6 +69,7 @@ internal fun BrowserApp(
     openDownloadsFlow: Flow<Unit>,
     onInstallExtensionRequest: (String) -> Unit,
     onDesktopNotificationPermissionRequest: () -> GeckoResult<Int>,
+    onRequestDownloadNotificationPermission: () -> Unit,
 ) {
     val currentSettings by viewModel.settingsUiState.collectAsState()
     val settingsUiState = currentSettings ?: return
@@ -245,6 +246,7 @@ internal fun BrowserApp(
                             mediaWebExtension = mediaWebExtension,
                             onInstallExtensionRequest = onInstallExtensionRequest,
                             handleNotificationPermission = handleNotificationPermission,
+                            onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
                             onSelectTab = { tabId, beforeTab ->
                                 selectTab(tabId, beforeTab)
                             },

--- a/app/src/main/java/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -43,6 +43,7 @@ internal fun rememberBrowserTabScreenState(
     searchTemplate: String,
     onHistoryRecord: (suspend (url: String, title: String) -> Long)? = null,
     onHistoryTitleUpdate: (suspend (id: Long, title: String) -> Unit)? = null,
+    onRequestDownloadNotificationPermission: () -> Unit = {},
 ): BrowserTabScreenState {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -59,6 +60,7 @@ internal fun rememberBrowserTabScreenState(
             context = context,
             onHistoryRecord = onHistoryRecord,
             onHistoryTitleUpdate = onHistoryTitleUpdate,
+            onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
         )
     }
     state.homepageUrl = homepageUrl
@@ -77,6 +79,7 @@ internal class BrowserTabScreenState(
     private val geckoDownloadManager: GeckoDownloadManager,
     private val readabilityWebExtension: ReadabilityWebExtension,
     private val context: Context,
+    private val onRequestDownloadNotificationPermission: () -> Unit = {},
     var onHistoryRecord: (suspend (url: String, title: String) -> Long)? = null,
     var onHistoryTitleUpdate: (suspend (id: Long, title: String) -> Unit)? = null,
 ) : BrowserSessionStateCallbacks {
@@ -311,6 +314,8 @@ internal class BrowserTabScreenState(
 
     fun downloadImage(imageUrl: String) {
         imageContextMenuUrl = null
+        // ダウンロード進捗を通知で表示するためにパーミッションを要求する
+        onRequestDownloadNotificationPermission()
         // WorkManagerにエンキューして通知で進捗表示
         geckoDownloadManager.enqueueDownload(
             url = imageUrl,
@@ -328,6 +333,8 @@ internal class BrowserTabScreenState(
     fun confirmPendingDownload() {
         val response = pendingDownloadResponse ?: return
         pendingDownloadResponse = null
+        // ダウンロード進捗を通知で表示するためにパーミッションを要求する
+        onRequestDownloadNotificationPermission()
         geckoDownloadManager.enqueueDownloadFromResponse(
             response = response,
             referrerUrl = currentPageUrl,

--- a/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/CustomTabActivity.kt
@@ -94,6 +94,7 @@ class CustomTabActivity : ComponentActivity() {
                     onClose = ::finish,
                     onOpenInBrowser = ::openInMainBrowser,
                     onDesktopNotificationPermissionRequest = { requestNotificationPermissionIfNeeded() },
+                    onRequestDownloadNotificationPermission = { requestDownloadNotificationPermission() },
                 )
             }
         }
@@ -108,6 +109,22 @@ class CustomTabActivity : ComponentActivity() {
             runtimeCoordinator.close()
         }
         super.onDestroy()
+    }
+
+    /**
+     * ダウンロード通知を表示するために POST_NOTIFICATIONS パーミッションを要求する。
+     * GeckoView の通知パーミッション要求が保留中の場合はスキップする。
+     */
+    private fun requestDownloadNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) return
+        // GeckoView の通知パーミッション要求が保留中の場合は競合を避けるためスキップ
+        if (pendingNotificationPermissionResult != null) return
+        requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun requestNotificationPermissionIfNeeded(): GeckoResult<Int> {
@@ -161,6 +178,7 @@ private fun CustomTabScreen(
     onClose: () -> Unit,
     onOpenInBrowser: (String) -> Unit,
     onDesktopNotificationPermissionRequest: () -> GeckoResult<Int>,
+    onRequestDownloadNotificationPermission: () -> Unit,
 ) {
     val viewModel = viewModel(initializer = {
         BrowserScreenViewModel(
@@ -203,6 +221,7 @@ private fun CustomTabScreen(
         onDesktopNotificationPermissionRequest = { _ ->
             onDesktopNotificationPermissionRequest()
         },
+        onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
         onOpenSettings = {},
         onOpenTabs = {},
         enableTabUi = false,

--- a/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -68,6 +68,7 @@ internal fun GeckoBrowserTab(
     tabCount: Int,
     onInstallExtensionRequest: (String) -> Unit,
     onDesktopNotificationPermissionRequest: (String) -> GeckoResult<Int>,
+    onRequestDownloadNotificationPermission: () -> Unit = {},
     onOpenSettings: () -> Unit,
     onOpenTabs: () -> Unit,
     enableTabUi: Boolean = true,
@@ -94,6 +95,7 @@ internal fun GeckoBrowserTab(
         searchTemplate = searchTemplate,
         onHistoryRecord = onHistoryRecord,
         onHistoryTitleUpdate = onHistoryTitleUpdate,
+        onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
     )
 
     // ツールバー色の輝度に応じてステータスバーアイコン色（黒/白）を動的に切り替える

--- a/app/src/main/java/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/MainActivity.kt
@@ -186,6 +186,9 @@ class MainActivity : ComponentActivity() {
                     onDesktopNotificationPermissionRequest = {
                         requestNotificationPermissionIfNeeded()
                     },
+                    onRequestDownloadNotificationPermission = {
+                        requestDownloadNotificationPermission()
+                    },
                 )
             }
             extensionInstaller.installPromptState?.let { prompt ->
@@ -221,6 +224,22 @@ class MainActivity : ComponentActivity() {
                 Log.e("MainActivity", "URL の送信に失敗: $url, reason=${result.exceptionOrNull()}")
             }
         }
+    }
+
+    /**
+     * ダウンロード通知を表示するために POST_NOTIFICATIONS パーミッションを要求する。
+     * GeckoView の通知パーミッション要求が保留中の場合はスキップする。
+     */
+    private fun requestDownloadNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) return
+        // GeckoView の通知パーミッション要求が保留中の場合は競合を避けるためスキップ
+        if (pendingNotificationPermissionResult != null) return
+        requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun requestNotificationPermissionIfNeeded(): GeckoResult<Int> {

--- a/app/src/main/java/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/java/net/matsudamper/browser/WebAppActivity.kt
@@ -86,6 +86,7 @@ class WebAppActivity : ComponentActivity() {
                     themeColorExtension = runtimeCoordinator.themeColorExtension,
                     mediaWebExtension = runtimeCoordinator.mediaWebExtension,
                     onDesktopNotificationPermissionRequest = { requestNotificationPermissionIfNeeded() },
+                    onRequestDownloadNotificationPermission = { requestDownloadNotificationPermission() },
                 )
             }
         }
@@ -114,6 +115,22 @@ class WebAppActivity : ComponentActivity() {
         val scheme = data.scheme ?: return null
         if (scheme != "http" && scheme != "https") return null
         return data.toString()
+    }
+
+    /**
+     * ダウンロード通知を表示するために POST_NOTIFICATIONS パーミッションを要求する。
+     * GeckoView の通知パーミッション要求が保留中の場合はスキップする。
+     */
+    private fun requestDownloadNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) return
+        // GeckoView の通知パーミッション要求が保留中の場合は競合を避けるためスキップ
+        if (pendingNotificationPermissionResult != null) return
+        requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun requestNotificationPermissionIfNeeded(): GeckoResult<Int> {

--- a/app/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/browser/BrowserScreen.kt
@@ -59,6 +59,7 @@ internal fun BrowserScreen(
     mediaWebExtension: MediaWebExtension,
     onInstallExtensionRequest: (String) -> Unit,
     handleNotificationPermission: (uri: String) -> GeckoResult<Int>,
+    onRequestDownloadNotificationPermission: () -> Unit,
     onSelectTab: (tabId: String, beforeTab: AppDestination.Browser?) -> Unit,
     /** グループ順に並べたタブリスト。アドレスバースワイプ時の前後タブ判定に使用する。 */
     orderedTabs: List<BrowserTab>,
@@ -126,6 +127,7 @@ internal fun BrowserScreen(
             tabCount = tabs.size,
             onInstallExtensionRequest = onInstallExtensionRequest,
             onDesktopNotificationPermissionRequest = handleNotificationPermission,
+            onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
             onOpenSettings = { backStack.add(AppDestination.Settings) },
             onOpenTabs = { backStack.add(AppDestination.Tabs) },
             browserSessionController = browserSessionController,

--- a/app/src/main/java/net/matsudamper/browser/screen/webapp/WebAppScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/webapp/WebAppScreen.kt
@@ -31,6 +31,7 @@ internal fun WebAppScreen(
     themeColorExtension: ThemeColorWebExtension,
     mediaWebExtension: MediaWebExtension,
     onDesktopNotificationPermissionRequest: () -> GeckoResult<Int>,
+    onRequestDownloadNotificationPermission: () -> Unit,
 ) {
     val viewModel = viewModel(initializer = {
         BrowserScreenViewModel(
@@ -58,6 +59,7 @@ internal fun WebAppScreen(
         onDesktopNotificationPermissionRequest = { _ ->
             onDesktopNotificationPermissionRequest()
         },
+        onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
         onOpenSettings = {},
         onOpenTabs = {},
         enableTabUi = false,


### PR DESCRIPTION
## Summary
This PR adds support for requesting the POST_NOTIFICATIONS permission when initiating downloads, ensuring that download progress notifications can be displayed to users on Android 13+ devices.

## Key Changes
- **New permission request method**: Added `requestDownloadNotificationPermission()` method to `MainActivity`, `CustomTabActivity`, and `WebAppActivity` that:
  - Checks Android version (only applies to TIRAMISU/Android 13+)
  - Verifies if POST_NOTIFICATIONS permission is already granted
  - Avoids conflicts with pending GeckoView notification permission requests
  - Launches the permission request if needed

- **Updated composable callbacks**: Added `onRequestDownloadNotificationPermission` parameter to:
  - `BrowserApp()` - top-level navigation composable
  - `BrowserScreen()` - main browser screen
  - `GeckoBrowserTab()` - individual tab component
  - `WebAppScreen()` - web app screen
  - `CustomTabScreen()` - custom tab screen
  - `rememberBrowserTabScreenState()` - state management

- **Download trigger points**: Integrated permission requests in `BrowserTabScreenState`:
  - `downloadImage()` - when user downloads an image
  - `confirmPendingDownload()` - when user confirms a pending download

## Implementation Details
- The permission request is skipped if `pendingNotificationPermissionResult` is not null, preventing conflicts with GeckoView's own notification permission handling
- The implementation is consistent across all activity types (MainActivity, CustomTabActivity, WebAppActivity)
- Permission requests are only made on Android 13+ (TIRAMISU) as required by the notification permission model

https://claude.ai/code/session_01QP5jMQnj1cJcy6CbBWAsCo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download-related notification permission prompt: the app will request notification permission when initiating downloads on supported Android versions (Android 13/Tiramisu+).
  * The prompt avoids duplicate requests if a permission request is already pending, reducing redundant dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->