### PR TITLE
Display download enqueue timestamp in download management screen

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/screen/downloads/DownloadManagementScreen.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/downloads/DownloadManagementScreen.kt
@@ -21,6 +21,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -98,6 +102,7 @@ private fun DownloadItemRow(
     onCancel: () -> Unit,
     onOpenFile: (String) -> Unit,
 ) {
+    val dateFormat = remember { SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault()) }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -169,5 +174,11 @@ private fun DownloadItemRow(
             }
             is DownloadManagementScreenUiState.DownloadStatus.Failed -> Unit
         }
+        // ダウンロード開始時刻（完了後も常に表示）
+        Text(
+            text = dateFormat.format(Date(item.enqueuedAt)),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/app/src/main/java/net/matsudamper/browser/screen/downloads/DownloadManagementScreenUiState.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/downloads/DownloadManagementScreenUiState.kt
@@ -30,6 +30,8 @@ internal data class DownloadManagementScreenUiState(
         val id: UUID,
         val fileName: String,
         val status: DownloadStatus,
+        /** ダウンロードを開始した時刻（エポックミリ秒） */
+        val enqueuedAt: Long,
     )
 
     @Stable

--- a/app/src/main/java/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/java/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -87,6 +87,7 @@ internal class DownloadManagementScreenViewModel(
                 if (status == DownloadRecordStatus.FAILED) "ダウンロード失敗" else "ダウンロード中..."
             },
             status = uiStatus,
+            enqueuedAt = enqueuedAt,
         )
     }
 


### PR DESCRIPTION
## Summary
Added display of download start time in the download management screen. Each download item now shows when it was enqueued, formatted as "yyyy/MM/dd HH:mm".

## Key Changes
- Added `enqueuedAt` field to `DownloadItem` data class to store the download start time in epoch milliseconds
- Updated `DownloadItemRow` composable to display the formatted enqueue timestamp using `SimpleDateFormat`
- Modified `DownloadManagementScreenViewModel` to pass the `enqueuedAt` value when creating `DownloadItem` instances
- Added necessary imports for date formatting (`SimpleDateFormat`, `Date`, `Locale`) and Compose utilities (`remember`)

## Implementation Details
- The timestamp is displayed using `Text` composable with `MaterialTheme.typography.bodySmall` styling and `onSurfaceVariant` color for visual consistency
- `SimpleDateFormat` is memoized using `remember` to avoid recreating the formatter on every recomposition
- The timestamp is shown for all download statuses (in progress, completed, and failed)
- Uses device locale for date formatting via `Locale.getDefault()`

https://claude.ai/code/session_01GMmZhCf23Dt7sKvvBMKZK2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download items now display the timestamp showing when each download was initiated, automatically formatted according to your device's date and time preferences.
  * The enqueue timestamp is visible for all downloads regardless of their current state—completed, in progress, or failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->