### PR TITLE
Disable artifact archiving for lint reports in CI workflows

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           name: app-lint-report
           path: app/build/reports/lint-results-debug.html
+          archive: false
 
   android-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           name: app-lint-report
           path: app/build/reports/lint-results-debug.html
+          archive: false
 
       - name: Comment APK download URL
         uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflows to disable automatic artifact archiving for lint reports, reducing storage overhead while maintaining report accessibility during workflow runs.

## Changes
- Added `archive: false` parameter to the `upload-artifact` action for lint reports in both `main-build.yml` and `pr-build.yml` workflows
- This prevents GitHub Actions from archiving the lint HTML reports after the workflow completes, while keeping them available as temporary artifacts during the workflow execution

## Details
The lint reports (`app/build/reports/lint-results-debug.html`) are now uploaded as non-archived artifacts. This reduces unnecessary storage consumption in GitHub Actions artifact storage while still allowing developers to view the reports during active workflow runs. The reports will be automatically cleaned up after the default retention period.

https://claude.ai/code/session_016mXLG1NRFCGbVjXcy12nJk