### PR TITLE
Add clipboard URL suggestion to URL bar

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/BrowserTabSurface.kt
+++ b/app/src/main/java/net/matsudamper/browser/BrowserTabSurface.kt
@@ -151,6 +151,8 @@ internal fun BrowserTabOverlayLayer(
     urlBarSuggestions: UrlBarSuggestionsUiState,
     onHistorySuggestionClick: (net.matsudamper.browser.data.history.HistoryEntry) -> Unit,
     onWebSuggestionClick: (String) -> Unit,
+    clipboardUrl: String?,
+    onClipboardUrlClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
@@ -167,7 +169,8 @@ internal fun BrowserTabOverlayLayer(
                 isUrlInputFocused = state.isUrlInputFocused,
                 suggestionCount = urlBarSuggestions.historySuggestions.size +
                     urlBarSuggestions.webSuggestions.size +
-                    if (urlBarSuggestions.isLoadingWebSuggestions) 1 else 0,
+                    if (urlBarSuggestions.isLoadingWebSuggestions) 1 else 0 +
+                    if (clipboardUrl != null) 1 else 0,
                 currentPageUrl = state.currentPageUrl,
             )
         ) {
@@ -180,6 +183,8 @@ internal fun BrowserTabOverlayLayer(
                 onWebSuggestionClick = onWebSuggestionClick,
                 onCopyCurrentUrl = state::copyCurrentPageUrl,
                 onRestoreCurrentUrl = state::restoreCurrentPageUrlToInput,
+                clipboardUrl = clipboardUrl,
+                onClipboardUrlClick = onClipboardUrlClick,
                 modifier = Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.surface)
@@ -199,6 +204,8 @@ internal fun UrlSuggestionList(
     onWebSuggestionClick: (String) -> Unit,
     onCopyCurrentUrl: () -> Unit,
     onRestoreCurrentUrl: () -> Unit,
+    clipboardUrl: String?,
+    onClipboardUrlClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val hasHistorySuggestions = historySuggestions.isNotEmpty()
@@ -211,6 +218,18 @@ internal fun UrlSuggestionList(
                     currentPageUrl = currentPageUrl,
                     onCopyCurrentUrl = onCopyCurrentUrl,
                     onRestoreCurrentUrl = onRestoreCurrentUrl,
+                )
+                if (clipboardUrl != null || hasHistorySuggestions || hasWebSuggestions) {
+                    HorizontalDivider()
+                }
+            }
+        }
+
+        if (clipboardUrl != null) {
+            item(key = "clipboard_url") {
+                ClipboardUrlListItem(
+                    clipboardUrl = clipboardUrl,
+                    onClick = { onClipboardUrlClick(clipboardUrl) },
                 )
                 if (hasHistorySuggestions || hasWebSuggestions) {
                     HorizontalDivider()
@@ -297,6 +316,31 @@ private fun SuggestionSectionHeader(
             modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp),
         )
     }
+}
+
+@Composable
+private fun ClipboardUrlListItem(
+    clipboardUrl: String,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(text = "コピーしたリンク")
+        },
+        supportingContent = {
+            androidx.compose.runtime.CompositionLocalProvider(
+                LocalContentColor provides MaterialTheme.colorScheme.onSurfaceVariant,
+            ) {
+                Text(
+                    text = clipboardUrl,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        modifier = Modifier.clickable { onClick() },
+    )
 }
 
 @Composable

--- a/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/java/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -89,6 +89,8 @@ internal fun GeckoBrowserTab(
 ) {
     val context = LocalContext.current
     val readabilityWebExtension: ReadabilityWebExtension = koinInject()
+    // URLバーフォーカス時にクリップボードから読み取ったURL
+    var clipboardUrl by remember { mutableStateOf<String?>(null) }
     val state = rememberBrowserTabScreenState(
         browserTab = browserTab,
         homepageUrl = homepageUrl,
@@ -384,11 +386,26 @@ internal fun GeckoBrowserTab(
                             if (!state.isUrlInputFocused) {
                                 state.urlInput = ""
                             }
+                            // クリップボードからURLを読み取り、現在のページと異なる場合に表示
+                            val clipManager = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                                as android.content.ClipboardManager
+                            val clipped = clipManager.primaryClip?.getItemAt(0)
+                                ?.coerceToText(context)?.toString()?.trim()
+                            clipboardUrl = if (
+                                clipped != null &&
+                                (clipped.startsWith("http://") || clipped.startsWith("https://")) &&
+                                clipped != state.currentPageUrl
+                            ) {
+                                clipped
+                            } else {
+                                null
+                            }
                             runCatching { session.setFocused(false) }
                             geckoView?.clearFocus()
                             keyboardController?.show()
                         } else {
                             state.restoreCurrentPageUrlToInput()
+                            clipboardUrl = null
                         }
                         state.isUrlInputFocused = hasFocus
                     },
@@ -483,6 +500,11 @@ internal fun GeckoBrowserTab(
                 },
                 onWebSuggestionClick = { query ->
                     state.onUrlSubmit(query)
+                    closeUrlInput(false)
+                },
+                clipboardUrl = clipboardUrl,
+                onClipboardUrlClick = { url ->
+                    state.onUrlSubmit(url)
                     closeUrlInput(false)
                 },
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## Summary
Added functionality to display a clipboard URL suggestion in the URL bar when the user focuses on the URL input field. If a valid URL is detected in the clipboard and differs from the current page URL, it will be shown as a suggestion that users can click to navigate to.

## Key Changes
- **BrowserTabSurface.kt**: 
  - Added `clipboardUrl` and `onClipboardUrlClick` parameters to `BrowserTabOverlayLayer()` and `UrlSuggestionList()` composables
  - Created new `ClipboardUrlListItem()` composable to display the clipboard URL with headline "コピーしたリンク" (Copied Link) and the URL as supporting text
  - Updated suggestion count calculation to include clipboard URL when present
  - Added horizontal divider logic to properly separate clipboard URL from other suggestions

- **GeckoBrowserTab.kt**:
  - Added `clipboardUrl` state variable to track the URL from clipboard
  - Implemented clipboard reading logic when URL input gains focus:
    - Reads from system clipboard manager
    - Validates that the content is a valid HTTP/HTTPS URL
    - Ensures the URL differs from the current page URL before displaying
    - Clears clipboard URL when input loses focus
  - Connected clipboard URL click handler to navigate to the selected URL

## Implementation Details
- Clipboard URL validation checks for `http://` or `https://` prefixes and trims whitespace
- The suggestion only appears when the clipboard contains a valid URL different from the currently loaded page
- The clipboard URL suggestion is positioned at the top of the suggestion list with proper divider handling
- Japanese localization used for the clipboard URL label ("コピーしたリンク")

https://claude.ai/code/session_01LdoZ8cnBvJmgoDsS5Nuamu