### PR TITLE
Standardize artifact naming in GitHub Actions workflows

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload release APK
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: app-release-apk
+          name: app-release.apk
           path: app/build/outputs/apk/release/app-release.apk
 
       - name: Run Android Lint

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -57,7 +57,7 @@ jobs:
         id: upload_apk
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: app-debug-apk
+          name: ${{ env.APK_NAME }}
           path: ${{ env.APK_PATH }}
 
       - name: Run Android Lint


### PR DESCRIPTION
## Summary
Updated artifact naming conventions in GitHub Actions workflows to use environment variables and consistent file extension formatting for better maintainability and clarity.

## Key Changes
- **main-build.yml**: Changed artifact name from `app-release-apk` to `app-release.apk` to include the file extension in the artifact name, making it more descriptive of the actual artifact type
- **pr-build.yml**: Replaced hardcoded artifact name `app-debug-apk` with `${{ env.APK_NAME }}` environment variable reference, enabling dynamic naming and reducing duplication

## Implementation Details
These changes improve consistency across workflows by:
- Using environment variables for artifact naming in the PR build workflow, allowing centralized configuration
- Including file extensions in artifact names to make the artifact type immediately clear
- Reducing maintenance burden by referencing environment variables instead of hardcoding values

https://claude.ai/code/session_01JJLQTwdyYwjTarU7N4Ymt7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow artifact naming conventions for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->