### PR TITLE
Enable user-scalable zoom for GeckoSession instances

### DIFF
--- a/app/src/main/java/net/matsudamper/browser/CustomTabsWarmupStore.kt
+++ b/app/src/main/java/net/matsudamper/browser/CustomTabsWarmupStore.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.browser.customtabs.CustomTabsSessionToken
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoSessionSettings
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -54,7 +55,7 @@ object CustomTabsWarmupStore {
                     entry.preparedUrl = targetUrl
                     existing
                 } else {
-                    GeckoSession().also { newSession ->
+                    GeckoSession(GeckoSessionSettings.Builder().forceUserScalable(true).build()).also { newSession ->
                         newSession.open(runtime)
                         entry.preparedSession = newSession
                         entry.preparedUrl = targetUrl

--- a/browser-engine-gecko/src/main/java/net/matsudamper/browser/BrowserSessionController.kt
+++ b/browser-engine-gecko/src/main/java/net/matsudamper/browser/BrowserSessionController.kt
@@ -16,6 +16,7 @@ import net.matsudamper.browser.core.TabStoreState
 import net.matsudamper.browser.core.TabSummary
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoSessionSettings
 import java.util.UUID
 
 @Stable
@@ -84,7 +85,7 @@ class BrowserSessionController(runtime: GeckoRuntime) : TabStore {
         openerTabId: String? = null,
     ): BrowserTab {
         val normalizedInitialUrl = initialUrl.ifBlank { "about:blank" }
-        val session = GeckoSession()  // open() はここでは呼ばない（遅延ロード）
+        val session = GeckoSession(GeckoSessionSettings.Builder().forceUserScalable(true).build())  // open() はここでは呼ばない（遅延ロード）
         val tab = appendTab(
             tabId = tabId,
             session = session,
@@ -120,7 +121,7 @@ class BrowserSessionController(runtime: GeckoRuntime) : TabStore {
 
     fun createTabForNewSession(initialUrl: String, openerTabId: String? = null): BrowserTab {
         val normalizedInitialUrl = initialUrl.ifBlank { "about:blank" }
-        val session = GeckoSession()
+        val session = GeckoSession(GeckoSessionSettings.Builder().forceUserScalable(true).build())
         // リンクから開く新しいタブはオープナーの次に挿入する
         val insertIndex = TabInsertionPolicy.resolveInsertionIndex(
             tabIds = tabList.map { it.tabId },


### PR DESCRIPTION
## Summary
This change enables user-scalable zoom functionality across all GeckoSession instances by configuring `forceUserScalable(true)` in the session settings.

## Key Changes
- Added `GeckoSessionSettings` import to both `BrowserSessionController.kt` and `CustomTabsWarmupStore.kt`
- Updated `BrowserSessionController.createTab()` to initialize GeckoSession with user-scalable settings enabled
- Updated `BrowserSessionController.createTabForNewSession()` to initialize GeckoSession with user-scalable settings enabled
- Updated `CustomTabsWarmupStore` to initialize GeckoSession with user-scalable settings enabled for warmup sessions

## Implementation Details
All GeckoSession instantiations now use `GeckoSessionSettings.Builder().forceUserScalable(true).build()` to ensure users can pinch-to-zoom and perform other scaling gestures on web content, improving the browsing experience across regular tabs, new session tabs, and custom tabs warmup sessions.

https://claude.ai/code/session_01HUK7aa2JFoWoh7y3csPBRY