### PR TITLE
Add background playback settings with domain allowlist

### DIFF
--- a/app/src/main/assets/web_extensions/background_playback_bridge/content.js
+++ b/app/src/main/assets/web_extensions/background_playback_bridge/content.js
@@ -1,0 +1,34 @@
+// バックグラウンド再生を維持するために Page Visibility API を偽装するコンテンツスクリプト。
+// ネイティブアプリからドメインごとの有効設定を受け取り、許可されたドメインでのみパッチを適用する。
+(function () {
+  // トップフレームのみで動作させる
+  if (window !== window.top) return;
+
+  const port = browser.runtime.connectNative('backgroundPlaybackBridge');
+
+  port.onMessage.addListener(function (msg) {
+    if (msg.enabled === true) {
+      applyPatch();
+    }
+  });
+
+  // 現在のホスト名をネイティブに送信して有効かどうかを問い合わせる
+  port.postMessage({ hostname: window.location.hostname });
+
+  function applyPatch() {
+    // document.hidden を常に false に見せかける
+    Object.defineProperty(document, 'hidden', {
+      get: function () { return false; },
+      configurable: true,
+    });
+    // document.visibilityState を常に 'visible' に見せかける
+    Object.defineProperty(document, 'visibilityState', {
+      get: function () { return 'visible'; },
+      configurable: true,
+    });
+    // visibilitychange イベントの伝播を止めてサイト側のポーズ処理を無効化する
+    document.addEventListener('visibilitychange', function (e) {
+      e.stopImmediatePropagation();
+    }, true);
+  }
+})();

--- a/app/src/main/assets/web_extensions/background_playback_bridge/manifest.json
+++ b/app/src/main/assets/web_extensions/background_playback_bridge/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 2,
+  "name": "Background Playback Bridge",
+  "version": "1.0",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "background-playback-bridge@browsem"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "exclude_matches": ["about:*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [
+    "geckoViewAddons",
+    "nativeMessaging",
+    "nativeMessagingFromContent"
+  ]
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -59,6 +59,7 @@ import net.matsudamper.browser.navigation.NavController
 import net.matsudamper.browser.screen.browser.BrowserScreenViewModel
 import net.matsudamper.browser.screen.extensions.ExtensionsScreenViewModel
 import net.matsudamper.browser.screen.history.HistoryScreenViewModel
+import net.matsudamper.browser.screen.backgroundplayback.BackgroundPlaybackSettingsScreenViewModel
 import net.matsudamper.browser.screen.notificationpermissions.NotificationPermissionsScreenViewModel
 import net.matsudamper.browser.screen.downloads.DownloadManagementScreenViewModel
 import net.matsudamper.browser.screen.settings.SettingsScreenViewModel
@@ -69,6 +70,7 @@ import net.matsudamper.browser.ui.downloads.DownloadManagementScreen
 import net.matsudamper.browser.ui.extensions.ExtensionsScreen
 import net.matsudamper.browser.ui.history.HistoryScreen
 import net.matsudamper.browser.ui.notifications.NotificationPermissionsScreen
+import net.matsudamper.browser.ui.settings.BackgroundPlaybackSettingsScreen
 import net.matsudamper.browser.ui.settings.SettingsScreen
 import net.matsudamper.browser.ui.tabs.TabsScreen
 import org.koin.compose.koinInject
@@ -380,11 +382,25 @@ private fun BrowserAppContent(
                                 onOpenNotificationPermissions = {
                                     backStack.add(AppDestination.NotificationPermissions)
                                 },
+                                onOpenBackgroundPlaybackSettings = {
+                                    backStack.add(AppDestination.BackgroundPlaybackSettings)
+                                },
                                 onOpenHistory = { backStack.add(AppDestination.History) },
                                 onOpenDownloads = { backStack.add(AppDestination.Downloads) },
                                 onBack = { backStack.removeLastOrNull() },
                             )
                         }
+                    }
+
+                    AppDestination.BackgroundPlaybackSettings -> navEntry(key) {
+                        val backgroundPlaybackViewModel = remember(settingsRepository) {
+                            BackgroundPlaybackSettingsScreenViewModel(settingsRepository)
+                        }
+                        val backgroundPlaybackUiState by backgroundPlaybackViewModel.uiState.collectAsState()
+                        BackgroundPlaybackSettingsScreen(
+                            uiState = backgroundPlaybackUiState,
+                            onBack = { backStack.removeLastOrNull() },
+                        )
                     }
 
                     AppDestination.History -> navEntry(key) {

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
@@ -20,6 +20,7 @@ import net.matsudamper.browser.data.TabGroupRepository
 import net.matsudamper.browser.data.TabRepository
 import net.matsudamper.browser.data.ThemeMode
 import net.matsudamper.browser.data.TranslationProvider
+import net.matsudamper.browser.data.resolvedBackgroundPlaybackDomains
 import net.matsudamper.browser.data.resolvedBrowserSettings
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
@@ -53,6 +54,7 @@ internal class BrowserViewModel(
     private val settingsRepository: SettingsRepository,
     private val tabRepository: TabRepository,
     private val tabGroupRepository: TabGroupRepository,
+    private val backgroundPlaybackWebExtension: BackgroundPlaybackWebExtension,
 ) : ViewModel() {
     val browserTabController = BrowserTabController(
         tabRepository = tabRepository,
@@ -90,6 +92,13 @@ internal class BrowserViewModel(
                 .collect { enableThirdPartyCa ->
                     runtime.settings.setEnterpriseRootsEnabled(enableThirdPartyCa)
                 }
+        }
+        viewModelScope.launch {
+            settingsRepository.settings.collectLatest { settings ->
+                backgroundPlaybackWebExtension.updateAllowedDomains(
+                    settings.resolvedBackgroundPlaybackDomains()
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.collectLatest
 import net.matsudamper.browser.data.TranslationProvider
 import net.matsudamper.browser.media.GeckoMediaSessionDelegate
 import net.matsudamper.browser.media.MediaWebExtension
+import net.matsudamper.browser.BackgroundPlaybackWebExtension
 import net.matsudamper.browser.FindInPageWebExtension
 import net.matsudamper.browser.ui.common.resolveBrowserToolbarColors
 import net.matsudamper.browser.ui.browser.SimpleViewScreen
@@ -103,6 +104,7 @@ internal fun GeckoBrowserTab(
     val context = LocalContext.current
     val readabilityWebExtension: ReadabilityWebExtension = koinInject()
     val findInPageWebExtension: FindInPageWebExtension = koinInject()
+    val backgroundPlaybackWebExtension: BackgroundPlaybackWebExtension = koinInject()
     // URLバーフォーカス時にクリップボードから読み取ったURL
     var clipboardUrl by remember { mutableStateOf<String?>(null) }
     // タブ履歴BottomSheetの表示状態
@@ -211,6 +213,14 @@ internal fun GeckoBrowserTab(
         }
         onDispose {
             readabilityWebExtension.unregisterSession(session)
+        }
+    }
+
+    // BackgroundPlaybackWebExtension のセッション登録
+    DisposableEffect(session, backgroundPlaybackWebExtension) {
+        backgroundPlaybackWebExtension.registerSession(session)
+        onDispose {
+            backgroundPlaybackWebExtension.unregisterSession(session)
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser.di
 
+import net.matsudamper.browser.BackgroundPlaybackWebExtension
 import net.matsudamper.browser.BrowserViewModel
 import net.matsudamper.browser.DownloadWorker
 import net.matsudamper.browser.FindInPageWebExtension
@@ -45,7 +46,8 @@ val appModule = module {
     single { MediaWebExtension(androidContext()).also { it.install(get()) } }
     single { ReadabilityWebExtension().also { it.install(get()) } }
     single { FindInPageWebExtension().also { it.install(get()) } }
+    single { BackgroundPlaybackWebExtension().also { it.install(get()) } }
     factory { GeckoDownloadManager(androidContext(), get()) }
-    viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get(), get()) }
     worker { DownloadWorker(get(), get(), get()) }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/navigation/AppDestination.kt
@@ -28,4 +28,7 @@ sealed interface AppDestination : NavKey, java.io.Serializable {
 
     @Serializable
     data object Downloads : AppDestination, java.io.Serializable
+
+    @Serializable
+    data object BackgroundPlaybackSettings : AppDestination, java.io.Serializable
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/backgroundplayback/BackgroundPlaybackSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/backgroundplayback/BackgroundPlaybackSettingsScreenViewModel.kt
@@ -1,0 +1,50 @@
+package net.matsudamper.browser.screen.backgroundplayback
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import net.matsudamper.browser.data.SettingsRepository
+import net.matsudamper.browser.data.resolvedBackgroundPlaybackDomains
+import net.matsudamper.browser.ui.settings.BackgroundPlaybackSettingsScreenUiState
+
+internal class BackgroundPlaybackSettingsScreenViewModel(
+    private val settingsRepository: SettingsRepository,
+) : ViewModel() {
+
+    private val callbacks = object : BackgroundPlaybackSettingsScreenUiState.Callbacks {
+        override fun addDomain(domain: String) {
+            viewModelScope.launch { settingsRepository.addBackgroundPlaybackDomain(domain) }
+        }
+
+        override fun removeDomain(domain: String) {
+            viewModelScope.launch { settingsRepository.removeBackgroundPlaybackDomain(domain) }
+        }
+
+        override fun resetToDefaults() {
+            viewModelScope.launch { settingsRepository.resetBackgroundPlaybackDomains() }
+        }
+    }
+
+    val uiState: StateFlow<BackgroundPlaybackSettingsScreenUiState> = MutableStateFlow(
+        BackgroundPlaybackSettingsScreenUiState(
+            callbacks = callbacks,
+            allowedDomains = emptyList(),
+        )
+    ).also { uiStateFlow ->
+        viewModelScope.launch {
+            settingsRepository.settings.collectLatest { settings ->
+                uiStateFlow.update {
+                    BackgroundPlaybackSettingsScreenUiState(
+                        callbacks = callbacks,
+                        allowedDomains = settings.resolvedBackgroundPlaybackDomains(),
+                    )
+                }
+            }
+        }
+    }.asStateFlow()
+}

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BackgroundPlaybackWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BackgroundPlaybackWebExtension.kt
@@ -1,0 +1,160 @@
+package net.matsudamper.browser
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.WebExtension
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * バックグラウンド再生を維持するための組み込み WebExtension。
+ * Page Visibility API を偽装し、アプリがバックグラウンドに移行しても
+ * YouTube 等の動画再生が継続できるようにする。
+ * 許可ドメインは [updateAllowedDomains] で更新でき、サブドメインにも一致する。
+ */
+class BackgroundPlaybackWebExtension {
+    private var extension: WebExtension? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // セッションごとの接続ポート
+    private val sessionPorts = ConcurrentHashMap<GeckoSession, WebExtension.Port>()
+
+    // セッションごとの最後に受信したホスト名（設定変更時の再送に使用）
+    private val sessionHostnames = ConcurrentHashMap<GeckoSession, String>()
+
+    // 現在の許可ドメインセット
+    @Volatile
+    private var allowedDomains: Set<String> = emptySet()
+
+    // registerSession 呼び出し済みのセッション（extension インストール前の登録を保持）
+    private val registeredSessions: MutableSet<GeckoSession> =
+        Collections.newSetFromMap(ConcurrentHashMap())
+
+    // setMessageDelegate 設定済みのセッション（二重設定を防ぐ）
+    private val attachedSessions: MutableSet<GeckoSession> =
+        Collections.newSetFromMap(ConcurrentHashMap())
+
+    fun install(runtime: GeckoRuntime) {
+        Log.d(TAG, "install() 開始: uri=$EXTENSION_URI")
+        runtime.webExtensionController
+            .installBuiltIn(EXTENSION_URI)
+            .accept(
+                { ext ->
+                    Log.d(TAG, "インストール完了: id=${ext?.id}")
+                    if (ext == null) return@accept
+                    extension = ext
+                    registeredSessions.toList().forEach { session ->
+                        attachSessionDelegate(session, ext)
+                    }
+                },
+                { error ->
+                    Log.e(TAG, "インストール失敗", error)
+                },
+            )
+    }
+
+    fun registerSession(session: GeckoSession) {
+        registeredSessions.add(session)
+        extension?.also { ext ->
+            attachSessionDelegate(session, ext)
+        }
+    }
+
+    fun unregisterSession(session: GeckoSession) {
+        registeredSessions.remove(session)
+        attachedSessions.remove(session)
+        sessionPorts.remove(session)
+        sessionHostnames.remove(session)
+        extension?.let { ext ->
+            session.webExtensionController.setMessageDelegate(ext, null, NATIVE_APP_ID)
+        }
+    }
+
+    /**
+     * 許可ドメインリストを更新する。
+     * 登録済みの全セッションに対して即座に有効/無効を再送信する。
+     */
+    fun updateAllowedDomains(domains: List<String>) {
+        allowedDomains = domains.toSet()
+        mainHandler.post {
+            sessionPorts.forEach { (session, port) ->
+                val hostname = sessionHostnames[session] ?: return@forEach
+                try {
+                    port.postMessage(JSONObject().apply {
+                        put("enabled", isAllowed(hostname))
+                    })
+                } catch (e: Exception) {
+                    Log.w(TAG, "updateAllowedDomains: メッセージ送信失敗 hostname=$hostname", e)
+                }
+            }
+        }
+    }
+
+    /**
+     * hostname がドメインリストに一致するかを判定する。
+     * 完全一致またはサブドメインに一致する場合に true を返す。
+     * 例: "youtube.com" は "www.youtube.com" にも一致する。
+     */
+    private fun isAllowed(hostname: String): Boolean {
+        return allowedDomains.any { domain ->
+            hostname == domain || hostname.endsWith(".$domain")
+        }
+    }
+
+    private fun attachSessionDelegate(session: GeckoSession, ext: WebExtension) {
+        if (!attachedSessions.add(session)) return
+        session.webExtensionController.setMessageDelegate(
+            ext,
+            object : WebExtension.MessageDelegate {
+                override fun onMessage(
+                    nativeApp: String,
+                    message: Any,
+                    sender: WebExtension.MessageSender,
+                ): GeckoResult<Any>? = null
+
+                override fun onConnect(port: WebExtension.Port) {
+                    Log.d(TAG, "onConnect: ポート接続")
+                    sessionPorts[session] = port
+                    port.setDelegate(object : WebExtension.PortDelegate {
+                        override fun onPortMessage(message: Any, port: WebExtension.Port) {
+                            val json = message as? JSONObject ?: return
+                            val hostname = json.optString("hostname")
+                                .takeUnless { it.isEmpty() } ?: return
+                            sessionHostnames[session] = hostname
+                            Log.d(TAG, "onPortMessage: hostname=$hostname allowed=${isAllowed(hostname)}")
+                            mainHandler.post {
+                                try {
+                                    port.postMessage(JSONObject().apply {
+                                        put("enabled", isAllowed(hostname))
+                                    })
+                                } catch (e: Exception) {
+                                    Log.w(TAG, "onPortMessage: 応答送信失敗", e)
+                                }
+                            }
+                        }
+
+                        override fun onDisconnect(port: WebExtension.Port) {
+                            Log.d(TAG, "onDisconnect: ポート切断")
+                            if (sessionPorts[session] === port) {
+                                sessionPorts.remove(session)
+                            }
+                        }
+                    })
+                }
+            },
+            NATIVE_APP_ID,
+        )
+    }
+
+    companion object {
+        private const val TAG = "BackgroundPlaybackExt"
+        private const val NATIVE_APP_ID = "backgroundPlaybackBridge"
+        private const val EXTENSION_URI =
+            "resource://android/assets/web_extensions/background_playback_bridge/"
+    }
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
@@ -112,6 +112,40 @@ class SettingsRepository(context: Context) {
         }
     }
 
+    suspend fun addBackgroundPlaybackDomain(domain: String) {
+        dataStore.updateData { current ->
+            val currentList = current.backgroundPlaybackAllowedDomainsList.ifEmpty {
+                DEFAULT_BACKGROUND_PLAYBACK_DOMAINS
+            }
+            if (currentList.contains(domain)) return@updateData current
+            current.toBuilder()
+                .clearBackgroundPlaybackAllowedDomains()
+                .addAllBackgroundPlaybackAllowedDomains(currentList + domain)
+                .build()
+        }
+    }
+
+    suspend fun removeBackgroundPlaybackDomain(domain: String) {
+        dataStore.updateData { current ->
+            val currentList = current.backgroundPlaybackAllowedDomainsList.ifEmpty {
+                DEFAULT_BACKGROUND_PLAYBACK_DOMAINS
+            }
+            val newList = currentList.filter { it != domain }
+            current.toBuilder()
+                .clearBackgroundPlaybackAllowedDomains()
+                .addAllBackgroundPlaybackAllowedDomains(newList)
+                .build()
+        }
+    }
+
+    suspend fun resetBackgroundPlaybackDomains() {
+        dataStore.updateData { current ->
+            current.toBuilder()
+                .clearBackgroundPlaybackAllowedDomains()
+                .build()
+        }
+    }
+
     suspend fun removeNotificationAllowedOrigin(origin: String) {
         dataStore.updateData { current ->
             if (!current.notificationAllowedOriginsList.contains(origin)) {
@@ -164,3 +198,15 @@ fun BrowserSettings.resolvedEnableWebSuggestions(): Boolean {
         false
     }
 }
+
+/** 空の場合はデフォルトの YouTube 関連ドメインを返す */
+fun BrowserSettings.resolvedBackgroundPlaybackDomains(): List<String> {
+    return backgroundPlaybackAllowedDomainsList.ifEmpty {
+        DEFAULT_BACKGROUND_PLAYBACK_DOMAINS
+    }
+}
+
+val DEFAULT_BACKGROUND_PLAYBACK_DOMAINS = listOf(
+    "youtube.com",
+    "youtu.be",
+)

--- a/proto/src/main/proto/browser_settings.proto
+++ b/proto/src/main/proto/browser_settings.proto
@@ -38,4 +38,5 @@ message BrowserSettings {
   TranslationProvider translation_provider = 9;
   bool enable_third_party_ca = 10;
   optional bool enable_web_suggestions = 11;
+  repeated string background_playback_allowed_domains = 12;
 }

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/BackgroundPlaybackSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/BackgroundPlaybackSettingsScreen.kt
@@ -1,0 +1,191 @@
+package net.matsudamper.browser.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BackgroundPlaybackSettingsScreen(
+    uiState: BackgroundPlaybackSettingsScreenUiState,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("バックグラウンド再生") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "戻る",
+                        )
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+        ) {
+            item {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "許可ドメイン",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = "バックグラウンドでの動画再生を継続するドメインを設定します。サブドメインも自動的に許可されます（例: youtube.com は www.youtube.com にも適用）。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            items(
+                items = uiState.allowedDomains,
+                key = { it },
+            ) { domain ->
+                DomainRow(
+                    domain = domain,
+                    onRemove = { uiState.callbacks.removeDomain(domain) },
+                )
+            }
+
+            item {
+                AddDomainRow(onAdd = uiState.callbacks::addDomain)
+            }
+
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    contentAlignment = Alignment.CenterEnd,
+                ) {
+                    TextButton(onClick = uiState.callbacks::resetToDefaults) {
+                        Text("デフォルトに戻す")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DomainRow(
+    domain: String,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = domain,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 8.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        TextButton(onClick = onRemove) {
+            Text("削除")
+        }
+    }
+}
+
+@Composable
+private fun AddDomainRow(onAdd: (String) -> Unit) {
+    var input by remember { mutableStateOf("") }
+    val trimmed = input.trim()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("ドメインを追加") },
+            placeholder = { Text("example.com") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    if (trimmed.isNotEmpty()) {
+                        onAdd(trimmed)
+                        input = ""
+                    }
+                },
+            ),
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(8.dp))
+        TextButton(
+            onClick = {
+                if (trimmed.isNotEmpty()) {
+                    onAdd(trimmed)
+                    input = ""
+                }
+            },
+            enabled = trimmed.isNotEmpty(),
+        ) {
+            Text("追加")
+        }
+    }
+}

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/BackgroundPlaybackSettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/BackgroundPlaybackSettingsScreenUiState.kt
@@ -1,0 +1,12 @@
+package net.matsudamper.browser.ui.settings
+
+data class BackgroundPlaybackSettingsScreenUiState(
+    val callbacks: Callbacks,
+    val allowedDomains: List<String>,
+) {
+    interface Callbacks {
+        fun addDomain(domain: String)
+        fun removeDomain(domain: String)
+        fun resetToDefaults()
+    }
+}

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ fun SettingsScreen(
     uiState: SettingsScreenUiState,
     onOpenExtensions: () -> Unit,
     onOpenNotificationPermissions: () -> Unit,
+    onOpenBackgroundPlaybackSettings: () -> Unit,
     onOpenHistory: () -> Unit,
     onOpenDownloads: () -> Unit,
     onBack: () -> Unit,
@@ -296,6 +297,17 @@ fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text("通知を許可したサイト")
+                }
+            }
+
+            Spacer(Modifier.height(betweenPadding))
+
+            SettingSection(title = "バックグラウンド再生") {
+                TextButton(
+                    onClick = onOpenBackgroundPlaybackSettings,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("バックグラウンド再生を許可するドメイン")
                 }
             }
 


### PR DESCRIPTION
## Summary
Implements background video playback functionality by adding a settings screen to manage allowed domains and a WebExtension that spoofs the Page Visibility API for permitted sites.

## Key Changes

- **Settings UI**: Added `BackgroundPlaybackSettingsScreen` composable with domain management interface
  - Display list of allowed domains with remove buttons
  - Input field to add new domains
  - Reset to defaults button
  - Japanese localization for all UI text

- **ViewModel & State Management**: Created `BackgroundPlaybackSettingsScreenViewModel` to handle domain list operations
  - Integrates with `SettingsRepository` for persistence
  - Provides callbacks for add, remove, and reset operations

- **Data Layer**: Extended `SettingsRepository` with background playback domain management
  - `addBackgroundPlaybackDomain()` - adds domain to allowlist
  - `removeBackgroundPlaybackDomain()` - removes domain from allowlist
  - `resetBackgroundPlaybackDomains()` - clears custom domains (reverts to defaults)
  - Default domains: youtube.com and youtu.be
  - Added protobuf field `background_playback_allowed_domains` for persistence

- **WebExtension**: Implemented `BackgroundPlaybackWebExtension` for native-side domain management
  - Installs built-in WebExtension that patches Page Visibility API
  - Maintains per-session port connections with content scripts
  - Dynamically updates enabled/disabled state when domain list changes
  - Supports subdomain matching (e.g., youtube.com matches www.youtube.com)

- **Content Script**: Added `content.js` WebExtension that spoofs visibility properties
  - Patches `document.hidden` to always return false
  - Patches `document.visibilityState` to always return 'visible'
  - Blocks `visibilitychange` events to prevent site-side pause logic
  - Only applies patches for allowed domains

- **Navigation & Integration**: 
  - Added `BackgroundPlaybackSettings` destination to app navigation
  - Integrated settings screen into main settings menu
  - Registered WebExtension in dependency injection and lifecycle management

## Implementation Details

- Subdomain matching uses suffix matching: `hostname.endsWith(".$domain")`
- WebExtension uses concurrent collections for thread-safe session management
- Settings changes are immediately propagated to all active sessions via port messaging
- Content script runs at `document_idle` to ensure DOM is ready
- Uses native messaging bridge between content script and native code

https://claude.ai/code/session_01VdYTb355u5UjPLK7Uyhr19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Background playback settings screen allowing users to configure which domains are permitted for background media playback
  * Users can add custom domains, remove existing entries, or reset to default configurations
  * Pre-configured default domains included for popular video and audio platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->