### PR TITLE
バックグラウンドで通知が止まる問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -138,6 +138,7 @@ internal fun GeckoBrowserTab(
     var imeWasVisibleDuringUrlFocus by remember { mutableStateOf(false) }
     var urlBarFocusStartedAtMs by remember { mutableStateOf(0L) }
     var geckoView: GeckoView? by remember { mutableStateOf(null) }
+    var sessionReleasedOnStop by remember(session) { mutableStateOf(false) }
     // ホームに追加ダイアログの表示状態
     var showAddToHomeScreenDialog by remember { mutableStateOf(false) }
     var addToHomeUrl by remember { mutableStateOf("") }
@@ -180,12 +181,20 @@ internal fun GeckoBrowserTab(
                     session.flushSessionState()
                     geckoView?.also {
                         state.captureTabPreview(it)
-                        it.releaseSession()
+                        if (mediaWebExtension.shouldKeepSessionAttached(session)) {
+                            sessionReleasedOnStop = false
+                        } else {
+                            it.releaseSession()
+                            sessionReleasedOnStop = true
+                        }
                     }
                 }
                 Lifecycle.Event.ON_START -> {
                     geckoView?.also { gecko ->
-                        gecko.setSession(session)
+                        if (sessionReleasedOnStop) {
+                            gecko.setSession(session)
+                            sessionReleasedOnStop = false
+                        }
                         // 黒くなる対応。効くかは不明
                         gecko.visibility = View.INVISIBLE
                         gecko.visibility = View.VISIBLE

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaWebExtension.kt
@@ -44,6 +44,8 @@ class MediaWebExtension(
 
     @Volatile
     private var activeSession: GeckoSession? = null
+    private var pendingDeactivateSession: GeckoSession? = null
+    private var pendingDeactivateRunnable: Runnable? = null
 
     fun install(runtime: GeckoRuntime) {
         Log.d(TAG, "install() 開始: uri=$EXTENSION_URI")
@@ -85,6 +87,7 @@ class MediaWebExtension(
     fun onActivated(session: GeckoSession, mediaSession: MediaSession) {
         Log.d(TAG, "onActivated: session=${session.logKey()} mediaSession=${mediaSession.logKey()}")
         MediaTraceLog.d("WX activated session=${session.logKey()} mediaSession=${mediaSession.logKey()}")
+        cancelPendingDeactivation(session)
         activeSession = session
         MediaSessionBridge.activeGeckoMediaSession = mediaSession
         applySessionState(session)
@@ -98,6 +101,7 @@ class MediaWebExtension(
 
     fun onFeatures(session: GeckoSession, features: Long) {
         Log.d(TAG, "onFeatures: session=${session.logKey()} features=$features")
+        cancelPendingDeactivation(session)
         val current = sessionStates[session] ?: SessionPlaybackSnapshot()
         val next = current.copy(features = features)
         sessionStates[session] = next
@@ -112,6 +116,7 @@ class MediaWebExtension(
             TAG,
             "onMetadata: session=${session.logKey()} title=${meta.title}, artist=${meta.artist}, album=${meta.album}, hasArtwork=${meta.artwork != null}",
         )
+        cancelPendingDeactivation(session)
         updateSessionSnapshot(session) { current ->
             current.copy(
                 isActive = true,
@@ -162,6 +167,7 @@ class MediaWebExtension(
 
     fun onPlay(session: GeckoSession, mediaSession: MediaSession) {
         Log.d(TAG, "onPlay fallback: session=${session.logKey()}")
+        cancelPendingDeactivation(session)
         bindMediaSessionIfNeeded(session, mediaSession)
         updateSessionSnapshot(session) { current ->
             current.copy(isActive = true, isPlaying = true)
@@ -171,6 +177,7 @@ class MediaWebExtension(
     fun onPause(session: GeckoSession, mediaSession: MediaSession) {
         Log.d(TAG, "onPause fallback: session=${session.logKey()}")
         MediaTraceLog.d("WX pauseFallback session=${session.logKey()}")
+        cancelPendingDeactivation(session)
         bindMediaSessionIfNeeded(session, mediaSession)
         updateSessionSnapshot(session) { current ->
             current.copy(isActive = true, isPlaying = false)
@@ -189,6 +196,7 @@ class MediaWebExtension(
         MediaTraceLog.d(
             "WX positionFallback session=${session.logKey()} position=${state.position} duration=${state.duration}",
         )
+        cancelPendingDeactivation(session)
         bindMediaSessionIfNeeded(session, mediaSession)
         updateSessionSnapshot(session) { current ->
             current.copy(
@@ -201,7 +209,20 @@ class MediaWebExtension(
 
     fun isInstalled(): Boolean = extension != null
 
+    fun shouldKeepSessionAttached(session: GeckoSession): Boolean {
+        val snapshot = sessionStates[session]
+        val keepAttached =
+            activeSession === session &&
+                (snapshot?.isActive ?: MediaSessionBridge.playbackState.value.isActive)
+        Log.d(
+            TAG,
+            "shouldKeepSessionAttached: session=${session.logKey()} keepAttached=$keepAttached activeSession=${activeSession?.logKey()} snapshotActive=${snapshot?.isActive}",
+        )
+        return keepAttached
+    }
+
     fun cleanup() {
+        cancelPendingDeactivation()
         activeSession = null
         sessionStates.clear()
         sessionArtworkBitmaps.clear()
@@ -270,6 +291,9 @@ class MediaWebExtension(
                             "snapshot: session=${session.logKey()} isActive=${snapshot.isActive}, isPlaying=${snapshot.isPlaying}, " +
                                 "title=${snapshot.title}, durationMs=${snapshot.durationMs}, positionMs=${snapshot.positionMs}, activeSession=${activeSession?.logKey()}",
                         )
+                        if (snapshot.isActive) {
+                            cancelPendingDeactivation(session)
+                        }
                         sessionStates[session] = snapshot
                         promoteSessionFromSnapshotIfNeeded(session, snapshot)
                         if (activeSession === session) {
@@ -374,9 +398,7 @@ class MediaWebExtension(
         if (activeSession !== session) {
             return
         }
-        activeSession = null
-        MediaSessionBridge.deactivate()
-        MediaPlaybackServiceController.stop(context)
+        scheduleDeactivation(session)
     }
 
     private fun invalidateArtwork(session: GeckoSession): Long {
@@ -393,6 +415,7 @@ class MediaWebExtension(
         if (!snapshot.isActive) {
             return
         }
+        cancelPendingDeactivation(session)
         if (activeSession == null) {
             Log.d(TAG, "activeSession を WebExtension snapshot から補完: session=${session.logKey()}")
             activeSession = session
@@ -403,12 +426,51 @@ class MediaWebExtension(
         return sessionArtworkRequestIds[session] == requestId
     }
 
+    private fun scheduleDeactivation(session: GeckoSession) {
+        if (pendingDeactivateSession === session && pendingDeactivateRunnable != null) {
+            return
+        }
+        cancelPendingDeactivation()
+        pendingDeactivateSession = session
+        pendingDeactivateRunnable = Runnable {
+            if (activeSession !== session) {
+                return@Runnable
+            }
+            val snapshot = sessionStates[session]
+            if (snapshot?.isActive == true) {
+                return@Runnable
+            }
+            Log.d(
+                TAG,
+                "deactivateSession grace period elapsed: session=${session.logKey()}",
+            )
+            activeSession = null
+            pendingDeactivateSession = null
+            pendingDeactivateRunnable = null
+            MediaSessionBridge.deactivate()
+            MediaPlaybackServiceController.stop(context)
+        }.also { runnable ->
+            mainHandler.postDelayed(runnable, DEACTIVATION_GRACE_PERIOD_MS)
+        }
+    }
+
+    private fun cancelPendingDeactivation(session: GeckoSession? = null) {
+        val runnable = pendingDeactivateRunnable ?: return
+        if (session != null && pendingDeactivateSession !== session) {
+            return
+        }
+        mainHandler.removeCallbacks(runnable)
+        pendingDeactivateRunnable = null
+        pendingDeactivateSession = null
+    }
+
     companion object {
         private const val TAG = "MediaWebExtension"
         private const val NATIVE_APP_ID = "mediaBridge"
         private const val EXTENSION_URI =
             "resource://android/assets/web_extensions/media_bridge/"
         private const val DEFAULT_ARTWORK_SIZE_PX = 256
+        private const val DEACTIVATION_GRACE_PERIOD_MS = 5_000L
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Media sessions now have a 5-second grace period before deactivation, preventing interruptions during app state transitions.
  * Improved conditional session persistence based on active media playback state during background and foreground transitions.
  * Enhanced lifecycle event handling ensures smoother media playback continuity when backgrounding or foregrounding the application.
  * Deactivation of inactive media sessions is now properly scheduled and cancellable for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->