### PR TITLE
2曲めのメディアの再生時間が正しく反映されない問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Proto → DataStore/Room → Repository → ViewModel(ViewModelStateFlow) → Ui
 - repository等のデータを直接データをいじらない。全てUI操作で行う
 - テキストを監視する場合を除いて`hasText`を使わない。コンポーネントを特定するには`hasTestTag`を使用する
 - TestTagは直接stringを使用せず、他のtestTagのパターンに合わせる
+- GMDデバイスを使用する。起動に失敗した場合、名前、IDを一時的に変えて再実行する
 
 ## 作業フロー
 

--- a/app/src/androidTest/assets/test-media/playlist.html
+++ b/app/src/androidTest/assets/test-media/playlist.html
@@ -14,10 +14,10 @@
 <body>
   <h1>Media Playlist Test</h1>
   <div id="status">idle (tap anywhere to start)</div>
-  <video id="track1" preload="metadata" playsinline controls data-title="Track 1">
+  <video id="track1" preload="metadata" playsinline controls muted data-title="Track 1">
     <source src="./test.webm" type="video/webm" />
   </video>
-  <video id="track2" preload="metadata" playsinline controls data-title="Track 2">
+  <video id="track2" preload="metadata" playsinline controls muted data-title="Track 2">
     <source src="./test.webm" type="video/webm" />
   </video>
 
@@ -89,6 +89,10 @@
         }
       });
     });
+
+    track1.addEventListener('loadedmetadata', () => {
+      window.setTimeout(startPlaylist, 0);
+    }, { once: true });
 
     function startPlaylist() {
       if (activeTrack) return;

--- a/app/src/androidTest/assets/test-media/playlist.html
+++ b/app/src/androidTest/assets/test-media/playlist.html
@@ -22,6 +22,9 @@
   </video>
 
   <script>
+    const TRACK1_START_POSITION_SECONDS = 30;
+    const TRACK2_SWITCH_POSITION_SECONDS = 33;
+    const TRACK1_PLAYBACK_RATE = 1;
     const status = document.getElementById('status');
     const track1 = document.getElementById('track1');
     const track2 = document.getElementById('track2');
@@ -81,7 +84,7 @@
       });
       video.addEventListener('timeupdate', () => {
         updatePositionState(video);
-        if (video === track1 && !switched && video.currentTime >= 6) {
+        if (video === track1 && !switched && video.currentTime >= TRACK2_SWITCH_POSITION_SECONDS) {
           switchToTrack2();
         }
       });
@@ -89,8 +92,8 @@
 
     function startPlaylist() {
       if (activeTrack) return;
-      track1.playbackRate = 4;
-      track1.currentTime = 4;
+      track1.playbackRate = TRACK1_PLAYBACK_RATE;
+      track1.currentTime = TRACK1_START_POSITION_SECONDS;
       activeTrack = track1;
       updateMetadata('Track 1');
       updatePlaybackState();

--- a/app/src/androidTest/assets/test-media/playlist.html
+++ b/app/src/androidTest/assets/test-media/playlist.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Media Playlist Test</title>
+  <style>
+    body { font-family: sans-serif; max-width: 720px; margin: 24px auto; padding: 0 16px; background: #111; color: #eee; }
+    h1 { font-size: 1.25rem; }
+    video { width: 100%; margin-top: 16px; background: #000; border-radius: 8px; }
+    #status { margin-top: 12px; color: #bfbfbf; }
+  </style>
+</head>
+<body>
+  <h1>Media Playlist Test</h1>
+  <div id="status">idle (tap anywhere to start)</div>
+  <video id="track1" preload="metadata" playsinline controls data-title="Track 1">
+    <source src="./test.webm" type="video/webm" />
+  </video>
+  <video id="track2" preload="metadata" playsinline controls data-title="Track 2">
+    <source src="./test.webm" type="video/webm" />
+  </video>
+
+  <script>
+    const status = document.getElementById('status');
+    const track1 = document.getElementById('track1');
+    const track2 = document.getElementById('track2');
+    const tracks = [track1, track2];
+    let activeTrack = null;
+    let switched = false;
+
+    function updateMetadata(title) {
+      if (!('mediaSession' in navigator)) return;
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title,
+        artist: 'Browsem',
+        album: 'Playlist Test',
+      });
+    }
+
+    function updatePlaybackState() {
+      if (!('mediaSession' in navigator)) return;
+      navigator.mediaSession.playbackState =
+        activeTrack && !activeTrack.paused && !activeTrack.ended ? 'playing' : 'paused';
+    }
+
+    function updatePositionState(video) {
+      if (!('mediaSession' in navigator)) return;
+      if (activeTrack !== video) return;
+      if (!Number.isFinite(video.duration) || video.duration <= 0) return;
+      navigator.mediaSession.setPositionState({
+        duration: video.duration,
+        playbackRate: video.playbackRate,
+        position: video.currentTime,
+      });
+    }
+
+    function switchToTrack2() {
+      if (switched) return;
+      switched = true;
+      status.textContent = 'switching to track 2';
+      track1.pause();
+      activeTrack = track2;
+      updateMetadata('Track 2');
+      updatePlaybackState();
+      track2.currentTime = 0;
+      track2.play().catch(() => {});
+    }
+
+    tracks.forEach((video) => {
+      video.addEventListener('play', () => {
+        activeTrack = video;
+        updateMetadata(video.dataset.title || document.title);
+        updatePlaybackState();
+        status.textContent = `playing ${video.dataset.title}`;
+      });
+      video.addEventListener('pause', () => {
+        if (activeTrack === video) {
+          updatePlaybackState();
+        }
+      });
+      video.addEventListener('timeupdate', () => {
+        updatePositionState(video);
+        if (video === track1 && !switched && video.currentTime >= 6) {
+          switchToTrack2();
+        }
+      });
+    });
+
+    function startPlaylist() {
+      if (activeTrack) return;
+      track1.playbackRate = 4;
+      track1.currentTime = 4;
+      activeTrack = track1;
+      updateMetadata('Track 1');
+      updatePlaybackState();
+      track1.play().catch((error) => {
+        status.textContent = `play blocked: ${error?.name ?? 'unknown'}`;
+      });
+    }
+
+    document.addEventListener('pointerdown', startPlaylist, { once: true });
+    document.addEventListener('click', startPlaylist, { once: true });
+  </script>
+</body>
+</html>

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -60,8 +61,7 @@ class MediaPrimarySelectionTest {
         val mediaPageUri = prepareLocalMediaPageUri(LOCAL_MEDIA_PLAYLIST_FILE_NAME)
 
         openMediaPage(mediaPageUri)
-        Thread.sleep(PAGE_READY_DELAY_MS)
-        tapMediaPage()
+        ensureMediaPlaybackStarted()
 
         val firstTrackState =
             waitUntil(timeoutMs = FIRST_TRACK_TIMEOUT_MS) { state ->
@@ -136,10 +136,30 @@ class MediaPrimarySelectionTest {
         }
     }
 
-    private fun tapMediaPage() {
+    private fun ensureMediaPlaybackStarted() {
+        waitUntil(timeoutMs = AUTOSTART_GRACE_PERIOD_MS, ::hasPlaybackStarted)?.let {
+            return
+        }
         val geckoNode = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.GeckoContainer.testTag)
-        geckoNode.performTouchInput { click() }
-        composeRule.waitForIdle()
+        listOf<Offset?>(null, Offset(100f, 100f), Offset(200f, 200f)).forEach { offset ->
+            if (offset == null) {
+                geckoNode.performTouchInput { click() }
+            } else {
+                geckoNode.performTouchInput { click(offset) }
+            }
+            composeRule.waitForIdle()
+            waitUntil(timeoutMs = PLAYBACK_START_CONFIRM_TIMEOUT_MS, ::hasPlaybackStarted)?.let {
+                return
+            }
+        }
+    }
+
+    private fun hasPlaybackStarted(state: MediaPlaybackState): Boolean {
+        return state.isActive ||
+            state.isPlaying ||
+            state.positionMs > 0L ||
+            state.title == EXPECTED_FIRST_TITLE ||
+            state.title == EXPECTED_SECOND_TITLE
     }
 
     private fun waitUntil(
@@ -161,7 +181,8 @@ class MediaPrimarySelectionTest {
 
     companion object {
         private const val TEST_TIMEOUT_MS = 180_000L
-        private const val PAGE_READY_DELAY_MS = 3_000L
+        private const val AUTOSTART_GRACE_PERIOD_MS = 2_000L
+        private const val PLAYBACK_START_CONFIRM_TIMEOUT_MS = 2_500L
         private const val FIRST_TRACK_TIMEOUT_MS = 20_000L
         private const val TRACK_SWITCH_TIMEOUT_MS = 20_000L
         private const val POLL_INTERVAL_MS = 100L

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -140,9 +140,6 @@ class MediaPrimarySelectionTest {
     private fun tapMediaPage() {
         val geckoNode = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.GeckoContainer.testTag)
         geckoNode.performTouchInput { click() }
-        geckoNode.performTouchInput {
-            click(Offset(x = 100f, y = 100f))
-        }
         composeRule.waitForIdle()
     }
 

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -1,0 +1,129 @@
+package net.matsudamper.browser.media
+
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import net.matsudamper.browser.MainActivity
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Timeout
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class MediaPrimarySelectionTest {
+    private lateinit var activity: MainActivity
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @get:Rule
+    val timeoutRule: Timeout = Timeout.millis(TEST_TIMEOUT_MS)
+
+    @Before
+    fun setUp() {
+        activityRule.scenario.onActivity { launchedActivity ->
+            activity = launchedActivity
+        }
+        MediaSessionBridge.deactivate()
+    }
+
+    @After
+    fun tearDown() {
+        val latch = CountDownLatch(1)
+        Handler(Looper.getMainLooper()).post {
+            runCatching { MediaSessionBridge.deactivate() }
+            runCatching { activity.stopService(Intent(activity, MediaPlaybackService::class.java)) }
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack()
+    }
+
+    @Test
+    fun 再生中の別media要素へ切り替わった時はpositionが新しい要素に追従する() {
+        val mediaPageUri = prepareLocalMediaPageUri(LOCAL_MEDIA_PLAYLIST_FILE_NAME)
+        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        openMediaPage(mediaPageUri)
+        Thread.sleep(PAGE_READY_DELAY_MS)
+        tapScreenCenter(uiDevice)
+
+        val switched =
+            waitUntil(timeoutMs = TRACK_SWITCH_TIMEOUT_MS) {
+                val state = MediaSessionBridge.playbackState.value
+                state.title == EXPECTED_SECOND_TITLE && state.positionMs <= MAX_SECOND_TRACK_POSITION_MS
+            }
+
+        assertTrue("2曲目へ切り替わってもpositionがリセットされない", switched)
+        assertEquals(EXPECTED_SECOND_TITLE, MediaSessionBridge.playbackState.value.title)
+    }
+
+    private fun openMediaPage(mediaPageUri: String) {
+        activityRule.scenario.onActivity { currentActivity ->
+            currentActivity.startActivity(
+                Intent(Intent.ACTION_VIEW).apply {
+                    data = android.net.Uri.parse(mediaPageUri)
+                    addCategory(Intent.CATEGORY_BROWSABLE)
+                    setClass(currentActivity, MainActivity::class.java)
+                }
+            )
+        }
+    }
+
+    private fun tapScreenCenter(uiDevice: UiDevice) {
+        val displayWidth = uiDevice.displayWidth
+        val displayHeight = uiDevice.displayHeight
+        uiDevice.click(displayWidth / 2, displayHeight / 2)
+    }
+
+    private fun prepareLocalMediaPageUri(indexFileName: String): String {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val targetContext = instrumentation.targetContext
+        val destinationDir = File(targetContext.cacheDir, LOCAL_MEDIA_DIR_NAME).apply { mkdirs() }
+        val assetManager = instrumentation.context.assets
+        assetManager.list(LOCAL_MEDIA_ASSET_DIR)?.forEach { name ->
+            val destination = File(destinationDir, name)
+            assetManager.open("$LOCAL_MEDIA_ASSET_DIR/$name").use { input ->
+                destination.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+        return File(destinationDir, indexFileName).toURI().toString()
+    }
+
+    private fun waitUntil(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+        val startTime = SystemClock.elapsedRealtime()
+        while (SystemClock.elapsedRealtime() - startTime < timeoutMs) {
+            if (predicate()) {
+                return true
+            }
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        return false
+    }
+
+    companion object {
+        private const val TEST_TIMEOUT_MS = 180_000L
+        private const val PAGE_READY_DELAY_MS = 3_000L
+        private const val TRACK_SWITCH_TIMEOUT_MS = 20_000L
+        private const val POLL_INTERVAL_MS = 250L
+        private const val MAX_SECOND_TRACK_POSITION_MS = 2_000L
+        private const val LOCAL_MEDIA_ASSET_DIR = "test-media"
+        private const val LOCAL_MEDIA_DIR_NAME = "test-media"
+        private const val LOCAL_MEDIA_PLAYLIST_FILE_NAME = "playlist.html"
+        private const val EXPECTED_SECOND_TITLE = "Track 2"
+    }
+}

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -53,7 +53,7 @@ class MediaPrimarySelectionTest {
             runCatching { composeRule.activity.stopService(Intent(composeRule.activity, MediaPlaybackService::class.java)) }
             latch.countDown()
         }
-        latch.await(5, TimeUnit.SECONDS)
+        assertTrue("tearDown がタイムアウトしました", latch.await(5, TimeUnit.SECONDS))
     }
 
     @Test

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -4,11 +4,22 @@ import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
-import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
+import net.matsudamper.browser.GeckoBrowserTabTestTags
 import net.matsudamper.browser.MainActivity
+import net.matsudamper.browser.openUrlFromUrlBar
+import net.matsudamper.browser.openUrlViaViewIntent
+import net.matsudamper.browser.waitForTabsScreenLoaded
+import net.matsudamper.browser.waitForUrlBarContains
+import net.matsudamper.browser.waitForUrlBarNotFocused
+import net.matsudamper.browser.ui.tabs.TabsScreenTestTags
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -23,19 +34,14 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class MediaPrimarySelectionTest {
-    private lateinit var activity: MainActivity
-
     @get:Rule
-    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+    val composeRule = createAndroidComposeRule<MainActivity>()
 
     @get:Rule
     val timeoutRule: Timeout = Timeout.millis(TEST_TIMEOUT_MS)
 
     @Before
     fun setUp() {
-        activityRule.scenario.onActivity { launchedActivity ->
-            activity = launchedActivity
-        }
         MediaSessionBridge.deactivate()
     }
 
@@ -44,48 +50,56 @@ class MediaPrimarySelectionTest {
         val latch = CountDownLatch(1)
         Handler(Looper.getMainLooper()).post {
             runCatching { MediaSessionBridge.deactivate() }
-            runCatching { activity.stopService(Intent(activity, MediaPlaybackService::class.java)) }
+            runCatching { composeRule.activity.stopService(Intent(composeRule.activity, MediaPlaybackService::class.java)) }
             latch.countDown()
         }
         latch.await(5, TimeUnit.SECONDS)
-        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack()
     }
 
     @Test
     fun 再生中の別media要素へ切り替わった時はpositionが新しい要素に追従する() {
         val mediaPageUri = prepareLocalMediaPageUri(LOCAL_MEDIA_PLAYLIST_FILE_NAME)
-        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         openMediaPage(mediaPageUri)
         Thread.sleep(PAGE_READY_DELAY_MS)
-        tapScreenCenter(uiDevice)
+        tapMediaPage()
 
-        val switched =
-            waitUntil(timeoutMs = TRACK_SWITCH_TIMEOUT_MS) {
-                val state = MediaSessionBridge.playbackState.value
-                state.title == EXPECTED_SECOND_TITLE && state.positionMs <= MAX_SECOND_TRACK_POSITION_MS
+        val firstTrackState =
+            waitUntil(timeoutMs = FIRST_TRACK_TIMEOUT_MS) { state ->
+                state.title == EXPECTED_FIRST_TITLE && state.positionMs >= MIN_FIRST_TRACK_POSITION_MS
             }
+                ?.also { assertEquals(EXPECTED_FIRST_TITLE, it.title) }
+                ?: throw AssertionError("1曲目のpositionを取得できない")
 
-        assertTrue("2曲目へ切り替わってもpositionがリセットされない", switched)
-        assertEquals(EXPECTED_SECOND_TITLE, MediaSessionBridge.playbackState.value.title)
+        val secondTrackState =
+            waitUntil(timeoutMs = TRACK_SWITCH_TIMEOUT_MS) { state ->
+                state.title == EXPECTED_SECOND_TITLE &&
+                    state.positionMs + MIN_POSITION_RESET_DELTA_MS <= firstTrackState.positionMs
+            } ?: throw AssertionError(
+                "2曲目へ切り替わってもpositionが十分に巻き戻らない " +
+                    "(track1=${firstTrackState.positionMs}, current=${MediaSessionBridge.playbackState.value.positionMs})",
+            )
+
+        assertEquals(EXPECTED_SECOND_TITLE, secondTrackState.title)
+        assertTrue(
+            "2曲目へ切り替わってもpositionが十分に巻き戻らない",
+            secondTrackState.positionMs + MIN_POSITION_RESET_DELTA_MS <= firstTrackState.positionMs,
+        )
     }
 
     private fun openMediaPage(mediaPageUri: String) {
-        activityRule.scenario.onActivity { currentActivity ->
-            currentActivity.startActivity(
-                Intent(Intent.ACTION_VIEW).apply {
-                    data = android.net.Uri.parse(mediaPageUri)
-                    addCategory(Intent.CATEGORY_BROWSABLE)
-                    setClass(currentActivity, MainActivity::class.java)
-                }
-            )
+        ensureBrowserScreen()
+        composeRule.openUrlViaViewIntent(mediaPageUri)
+        val openedByIntent =
+            runCatching {
+                composeRule.waitForUrlBarContains(LOCAL_MEDIA_PLAYLIST_FILE_NAME, timeoutMillis = 20_000)
+                true
+            }.getOrDefault(false)
+        if (!openedByIntent) {
+            composeRule.openUrlFromUrlBar(mediaPageUri)
+            composeRule.waitForUrlBarContains(LOCAL_MEDIA_PLAYLIST_FILE_NAME, timeoutMillis = 60_000)
         }
-    }
-
-    private fun tapScreenCenter(uiDevice: UiDevice) {
-        val displayWidth = uiDevice.displayWidth
-        val displayHeight = uiDevice.displayHeight
-        uiDevice.click(displayWidth / 2, displayHeight / 2)
+        composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
     }
 
     private fun prepareLocalMediaPageUri(indexFileName: String): String {
@@ -104,26 +118,63 @@ class MediaPrimarySelectionTest {
         return File(destinationDir, indexFileName).toURI().toString()
     }
 
-    private fun waitUntil(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+    private fun ensureBrowserScreen() {
+        val toolbarReady =
+            runCatching {
+                composeRule.waitForUrlBarNotFocused(timeoutMillis = 5_000)
+                true
+            }.getOrDefault(false)
+        if (toolbarReady) return
+
+        val tabsReady =
+            runCatching {
+                composeRule.waitForTabsScreenLoaded(timeoutMillis = 10_000)
+                true
+            }.getOrDefault(false)
+        if (tabsReady) {
+            composeRule.onNodeWithTag(TabsScreenTestTags.AddTabButton.testTag).performClick()
+            composeRule.waitForIdle()
+        }
+    }
+
+    private fun tapMediaPage() {
+        val geckoNode = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.GeckoContainer.testTag)
+        geckoNode.performTouchInput { click() }
+        geckoNode.performTouchInput {
+            click(Offset(x = 100f, y = 100f))
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun waitUntil(
+        timeoutMs: Long,
+        predicate: (MediaPlaybackState) -> Boolean,
+    ): MediaPlaybackState? {
         val startTime = SystemClock.elapsedRealtime()
+        var lastMatchedState: MediaPlaybackState? = null
         while (SystemClock.elapsedRealtime() - startTime < timeoutMs) {
-            if (predicate()) {
-                return true
+            val state = MediaSessionBridge.playbackState.value
+            if (predicate(state)) {
+                lastMatchedState = state
+                break
             }
             Thread.sleep(POLL_INTERVAL_MS)
         }
-        return false
+        return lastMatchedState
     }
 
     companion object {
         private const val TEST_TIMEOUT_MS = 180_000L
         private const val PAGE_READY_DELAY_MS = 3_000L
+        private const val FIRST_TRACK_TIMEOUT_MS = 20_000L
         private const val TRACK_SWITCH_TIMEOUT_MS = 20_000L
-        private const val POLL_INTERVAL_MS = 250L
-        private const val MAX_SECOND_TRACK_POSITION_MS = 2_000L
+        private const val POLL_INTERVAL_MS = 100L
+        private const val MIN_FIRST_TRACK_POSITION_MS = 30_000L
+        private const val MIN_POSITION_RESET_DELTA_MS = 10_000L
         private const val LOCAL_MEDIA_ASSET_DIR = "test-media"
         private const val LOCAL_MEDIA_DIR_NAME = "test-media"
         private const val LOCAL_MEDIA_PLAYLIST_FILE_NAME = "playlist.html"
+        private const val EXPECTED_FIRST_TITLE = "Track 1"
         private const val EXPECTED_SECOND_TITLE = "Track 2"
     }
 }

--- a/app/src/main/assets/web_extensions/media_bridge/content.js
+++ b/app/src/main/assets/web_extensions/media_bridge/content.js
@@ -6,7 +6,6 @@
   const ATTACHED_MEDIA = new WeakSet();
   const STARTED_MEDIA = new WeakSet();
   const KNOWN_MEDIA = new Set();
-  const LAST_KNOWN_TIMING_BY_KEY = new Map();
   let lastPrimaryMedia = null;
   let lastSerializedPayload = "";
   let publishTimer = null;
@@ -42,6 +41,11 @@
   function listKnownMediaElements() {
     const mediaElements = listMediaElements();
     mediaElements.forEach((media) => KNOWN_MEDIA.add(media));
+    KNOWN_MEDIA.forEach((media) => {
+      if (!media.isConnected && media !== lastPrimaryMedia) {
+        KNOWN_MEDIA.delete(media);
+      }
+    });
     if (lastPrimaryMedia) {
       KNOWN_MEDIA.add(lastPrimaryMedia);
     }
@@ -61,9 +65,17 @@
 
   function pickPrimaryMedia() {
     const mediaElements = listKnownMediaElements();
+    const activelyPlayingMedia = mediaElements.find((media) => !media.paused && !media.ended);
+    const retainableLastPrimary =
+      lastPrimaryMedia &&
+      mediaElements.includes(lastPrimaryMedia) &&
+      isUsableMedia(lastPrimaryMedia) &&
+      !lastPrimaryMedia.ended
+        ? lastPrimaryMedia
+        : null;
     const picked =
-      (isUsableMedia(lastPrimaryMedia) && lastPrimaryMedia) ||
-      mediaElements.find((media) => !media.paused && !media.ended) ||
+      activelyPlayingMedia ||
+      retainableLastPrimary ||
       mediaElements.find((media) => STARTED_MEDIA.has(media) && !media.ended) ||
       mediaElements.find((media) => media.currentTime > 0) ||
       mediaElements.find((media) => Number.isFinite(media.duration) && media.duration > 0) ||
@@ -92,21 +104,12 @@
     };
   }
 
-  function buildTimingKey(metadata) {
-    return [
-      location.href,
-      metadata.title,
-      metadata.artist,
-      metadata.album,
-    ].join("\u0001");
-  }
-
   function readPayload() {
     const media = pickPrimaryMedia();
     const metadata = readMetadata(media);
     const playbackState = readMediaSessionPlaybackState();
     const mediaElements = listMediaElements();
-    const timingKey = buildTimingKey(metadata);
+    const currentSrc = cleanText(media && (media.currentSrc || media.src));
     let durationMs =
       media && Number.isFinite(media.duration) && media.duration > 0
         ? Math.round(media.duration * 1000)
@@ -124,28 +127,13 @@
       playbackState === "playing" ||
       playbackState === "paused" ||
       (!!media && (mediaElementPlaying || hasStarted));
-    const shouldReuseLastKnownTiming =
-      isActive &&
-      durationMs === 0 &&
-      positionMs === 0 &&
-      LAST_KNOWN_TIMING_BY_KEY.has(timingKey);
-
-    if (shouldReuseLastKnownTiming) {
-      const lastKnownTiming = LAST_KNOWN_TIMING_BY_KEY.get(timingKey);
-      durationMs = lastKnownTiming.durationMs;
-      positionMs = lastKnownTiming.positionMs;
-    } else if (durationMs > 0) {
-      LAST_KNOWN_TIMING_BY_KEY.set(timingKey, {
-        durationMs: durationMs,
-        positionMs: positionMs,
-      });
-    }
 
     return {
       url: location.href,
       title: metadata.title,
       artist: metadata.artist,
       album: metadata.album,
+      currentSrc: currentSrc,
       durationMs: durationMs,
       positionMs: positionMs,
       isPlaying: isPlaying,
@@ -159,8 +147,7 @@
       debugMediaPaused: !!media && media.paused,
       debugMediaEnded: !!media && media.ended,
       debugMediaReadyState: media ? media.readyState : -1,
-      debugCurrentSrc: media ? media.currentSrc || media.src || "" : "",
-      debugTimingCacheHit: shouldReuseLastKnownTiming,
+      debugCurrentSrc: currentSrc,
     };
   }
 

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaWebExtension.kt
@@ -244,26 +244,17 @@ class MediaWebExtension(
                     }
                     val json = message as? JSONObject ?: return null
                     val previousSnapshot = sessionStates[session]
-                    val isActive = json.optBoolean("isActive", false)
-                    val isPlaying = json.optBoolean("isPlaying", false)
-                    val incomingDurationMs = json.optLong("durationMs", 0L).coerceAtLeast(0L)
-                    val incomingPositionMs = json.optLong("positionMs", 0L).coerceAtLeast(0L)
-                    val shouldKeepPreviousTiming =
-                        isActive &&
-                            incomingDurationMs == 0L &&
-                            incomingPositionMs == 0L &&
-                            previousSnapshot != null &&
-                            previousSnapshot.durationMs > 0L
-                    val snapshot = SessionPlaybackSnapshot(
-                        isActive = isActive,
-                        isPlaying = isPlaying,
-                        title = json.optString("title", ""),
-                        artist = json.optString("artist", ""),
-                        album = json.optString("album", ""),
-                        durationMs = if (shouldKeepPreviousTiming) previousSnapshot.durationMs else incomingDurationMs,
-                        positionMs = if (shouldKeepPreviousTiming) previousSnapshot.positionMs else incomingPositionMs,
-                        features = previousSnapshot?.features ?: 0L,
-                    )
+                    val payload =
+                        WebExtensionPlaybackPayload(
+                            isActive = json.optBoolean("isActive", false),
+                            isPlaying = json.optBoolean("isPlaying", false),
+                            title = json.optString("title", ""),
+                            artist = json.optString("artist", ""),
+                            album = json.optString("album", ""),
+                            durationMs = json.optLong("durationMs", 0L).coerceAtLeast(0L),
+                            positionMs = json.optLong("positionMs", 0L).coerceAtLeast(0L),
+                        )
+                    val snapshot = buildSessionPlaybackSnapshot(previousSnapshot, payload)
                     mainHandler.post {
                         Log.d(TAG, "raw snapshot: session=${session.logKey()} payload=$json")
                         val debugReason = json.optString("debugReason", "")
@@ -493,3 +484,29 @@ internal data class SessionPlaybackSnapshot(
     val positionMs: Long = 0L,
     val features: Long = 0L,
 )
+
+internal data class WebExtensionPlaybackPayload(
+    val isActive: Boolean,
+    val isPlaying: Boolean,
+    val title: String,
+    val artist: String,
+    val album: String,
+    val durationMs: Long,
+    val positionMs: Long,
+)
+
+internal fun buildSessionPlaybackSnapshot(
+    previousSnapshot: SessionPlaybackSnapshot?,
+    payload: WebExtensionPlaybackPayload,
+): SessionPlaybackSnapshot {
+    return SessionPlaybackSnapshot(
+        isActive = payload.isActive,
+        isPlaying = payload.isPlaying,
+        title = payload.title,
+        artist = payload.artist,
+        album = payload.album,
+        durationMs = payload.durationMs,
+        positionMs = payload.positionMs,
+        features = previousSnapshot?.features ?: 0L,
+    )
+}

--- a/browser-engine-gecko/src/test/kotlin/net/matsudamper/browser/media/MediaWebExtensionSnapshotTest.kt
+++ b/browser-engine-gecko/src/test/kotlin/net/matsudamper/browser/media/MediaWebExtensionSnapshotTest.kt
@@ -1,0 +1,73 @@
+package net.matsudamper.browser.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MediaWebExtensionSnapshotTest {
+
+    @Test
+    fun payloadのタイミング情報をそのまま採用する() {
+        val previousSnapshot =
+            SessionPlaybackSnapshot(
+                isActive = true,
+                isPlaying = true,
+                title = "Song A",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 180_000L,
+                positionMs = 42_000L,
+                features = 123L,
+            )
+
+        val snapshot =
+            buildSessionPlaybackSnapshot(
+                previousSnapshot = previousSnapshot,
+                payload =
+                    WebExtensionPlaybackPayload(
+                        isActive = true,
+                        isPlaying = true,
+                        title = "Song A",
+                        artist = "Artist",
+                        album = "Album",
+                        durationMs = 120_000L,
+                        positionMs = 10_000L,
+                    ),
+            )
+
+        assertEquals(120_000L, snapshot.durationMs)
+        assertEquals(10_000L, snapshot.positionMs)
+        assertEquals(123L, snapshot.features)
+    }
+
+    @Test
+    fun payloadが0を返した時は前回値を引き継がない() {
+        val previousSnapshot =
+            SessionPlaybackSnapshot(
+                isActive = true,
+                isPlaying = true,
+                title = "Song A",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 180_000L,
+                positionMs = 42_000L,
+            )
+
+        val snapshot =
+            buildSessionPlaybackSnapshot(
+                previousSnapshot = previousSnapshot,
+                payload =
+                    WebExtensionPlaybackPayload(
+                        isActive = true,
+                        isPlaying = true,
+                        title = "Song A",
+                        artist = "Artist",
+                        album = "Album",
+                        durationMs = 0L,
+                        positionMs = 0L,
+                    ),
+            )
+
+        assertEquals(0L, snapshot.durationMs)
+        assertEquals(0L, snapshot.positionMs)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added instrumentation tests for media playback and multi-element switching
  * Added unit tests validating playback snapshot merging behavior

* **Test Assets**
  * Added an HTML5 video playlist test page with Media Session integration

* **Improvements**
  * Primary media selection now prioritizes actively playing elements and cleans disconnected entries
  * Published media info now includes a normalized current source

* **Refactor**
  * Playback timing/state propagation made more consistent (payload timing is used directly)

* **Chores**
  * Added an instrumentation testing rule recommending Gradle Managed Devices
<!-- end of auto-generated comment: release notes by coderabbit.ai -->