### PR TITLE
Add Chromecast support with Cast SDK integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,7 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.androidx.compose)
     implementation(libs.koinAndroidWorkManager)
+    implementation(libs.play.services.cast.framework)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,5 @@
 # Add project specific ProGuard rules here.
+
+# Cast SDK OptionsProvider はAndroidManifest.xmlのmeta-dataから文字列で参照されるため、
+# R8によるリネームや削除を防ぐ。
+-keep class net.matsudamper.browser.cast.CastOptionsProvider { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,11 @@
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
 
+        <!-- Cast SDK OptionsProvider: キャスト機能の設定を提供する -->
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="net.matsudamper.browser.cast.CastOptionsProvider" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app/src/main/assets/web_extensions/cast_bridge/content.js
+++ b/app/src/main/assets/web_extensions/cast_bridge/content.js
@@ -255,15 +255,18 @@
     var apiConfig = null;
     var currentSession = null;
     var requestSessionPending = false;
+    // ネイティブから通知されるデバイス検出状態（デフォルト: 未検出）
+    var nativeAvailability = false;
 
     // メインAPI
     chrome.cast.initialize = function (config, onSuccess, onError) {
       apiConfig = config;
-      chrome.cast.isAvailable = true;
       if (onSuccess) setTimeout(onSuccess, 0);
-      // receiverListener に AVAILABLE を通知してキャストボタンを表示させる
-      if (config && config.receiverListener) {
+      // ネイティブの可用性がすでに判明していれば即時通知、
+      // そうでなければネイティブからの通知を待つ
+      if (nativeAvailability && config && config.receiverListener) {
         setTimeout(function () {
+          chrome.cast.isAvailable = true;
           config.receiverListener(chrome.cast.ReceiverAvailability.AVAILABLE);
         }, 100);
       }
@@ -314,14 +317,26 @@
 
     chrome.cast.setCustomReceivers = function () {};
     chrome.cast.unescape = function (str) { return str; };
-    chrome.cast.isAvailable = true;
+    // ネイティブから可用性が通知されるまでは false
+    chrome.cast.isAvailable = false;
     chrome.cast.VERSION = [1, 2, 0, 0];
 
-    // ネイティブからのメッセージ受信（セッション状態変更等）
+    // ネイティブからのメッセージ受信（セッション状態変更、可用性変更等）
     window.addEventListener("message", function (event) {
       var data = event.data;
       if (!data || !data.__castBridge) return;
-      if (data.action === "messageReceived" && currentSession) {
+      if (data.action === "availability") {
+        // ネイティブからのデバイス検出状態通知
+        nativeAvailability = !!data.isAvailable;
+        chrome.cast.isAvailable = nativeAvailability;
+        if (apiConfig && apiConfig.receiverListener) {
+          apiConfig.receiverListener(
+            nativeAvailability
+              ? chrome.cast.ReceiverAvailability.AVAILABLE
+              : chrome.cast.ReceiverAvailability.UNAVAILABLE
+          );
+        }
+      } else if (data.action === "messageReceived" && currentSession) {
         var listeners = currentSession._messageListeners[data.namespace];
         if (listeners) {
           listeners.forEach(function (listener) {
@@ -342,7 +357,7 @@
 
     // __onGCastApiAvailable のインターセプト
     // cast_sender.js がロードされた場合に false で呼ばれる可能性があるため、
-    // 常に true で呼ぶようにインターセプトする
+    // ネイティブの可用性に基づいて呼ぶようにインターセプトする
     var existingCallback = window.__onGCastApiAvailable;
     var storedCallbacks = [];
     if (typeof existingCallback === "function") {
@@ -351,18 +366,20 @@
 
     Object.defineProperty(window, "__onGCastApiAvailable", {
       get: function () {
-        // cast_sender.js がこの関数を呼ぶ時、常に true を渡すラッパーを返す
         return function () {
+          // ネイティブの可用性に基づいて通知する
           storedCallbacks.forEach(function (cb) {
-            try { cb(true); } catch (e) {}
+            try { cb(nativeAvailability); } catch (e) {}
           });
         };
       },
       set: function (fn) {
         if (typeof fn === "function") {
           storedCallbacks.push(fn);
-          // 設定直後に true で呼び出す
-          setTimeout(function () { fn(true); }, 0);
+          // ネイティブの可用性が既に判明している場合は即時通知
+          if (nativeAvailability) {
+            setTimeout(function () { fn(true); }, 0);
+          }
         }
       },
       configurable: true,

--- a/app/src/main/assets/web_extensions/cast_bridge/content.js
+++ b/app/src/main/assets/web_extensions/cast_bridge/content.js
@@ -1,0 +1,400 @@
+// chrome.cast API シムをページコンテキストに注入し、
+// ネイティブ Cast SDK とのブリッジを提供するコンテンツスクリプト。
+// YouTube 等が chrome.cast API を検出してキャストボタンを表示できるようにする。
+(function () {
+  if (window !== window.top) return;
+
+  // ページコンテキストに注入するスクリプト
+  var shimCode = "(" + function () {
+    // chrome 名前空間の確保
+    if (!window.chrome) window.chrome = {};
+    if (!window.chrome.cast) window.chrome.cast = {};
+    if (!window.chrome.cast.media) window.chrome.cast.media = {};
+
+    // 列挙型定数
+    chrome.cast.AutoJoinPolicy = {
+      TAB_AND_ORIGIN_SCOPED: "tab_and_origin_scoped",
+      ORIGIN_SCOPED: "origin_scoped",
+      PAGE_SCOPED: "page_scoped"
+    };
+    chrome.cast.DefaultActionPolicy = {
+      CREATE_SESSION: "create_session",
+      CAST_THIS_TAB: "cast_this_tab"
+    };
+    chrome.cast.ReceiverAvailability = {
+      AVAILABLE: "available",
+      UNAVAILABLE: "unavailable"
+    };
+    chrome.cast.SessionStatus = {
+      CONNECTED: "connected",
+      DISCONNECTED: "disconnected",
+      STOPPED: "stopped"
+    };
+    chrome.cast.ReceiverType = {
+      CAST: "cast"
+    };
+    chrome.cast.Capability = {
+      VIDEO_OUT: "video_out",
+      AUDIO_OUT: "audio_out"
+    };
+    chrome.cast.ErrorCode = {
+      CANCEL: "cancel",
+      TIMEOUT: "timeout",
+      API_NOT_INITIALIZED: "api_not_initialized",
+      INVALID_PARAMETER: "invalid_parameter",
+      EXTENSION_NOT_COMPATIBLE: "extension_not_compatible",
+      EXTENSION_MISSING: "extension_missing",
+      RECEIVER_UNAVAILABLE: "receiver_unavailable",
+      SESSION_ERROR: "session_error",
+      CHANNEL_ERROR: "channel_error",
+      LOAD_MEDIA_FAILED: "load_media_failed"
+    };
+    chrome.cast.media.StreamType = {
+      BUFFERED: "BUFFERED",
+      LIVE: "LIVE",
+      OTHER: "OTHER"
+    };
+    chrome.cast.media.PlayerState = {
+      IDLE: "IDLE",
+      PLAYING: "PLAYING",
+      PAUSED: "PAUSED",
+      BUFFERING: "BUFFERING"
+    };
+    chrome.cast.media.MetadataType = {
+      GENERIC: 0, MOVIE: 1, TV_SHOW: 2, MUSIC_TRACK: 3, PHOTO: 4
+    };
+
+    // エラークラス
+    chrome.cast.Error = function (code, description, details) {
+      this.code = code;
+      this.description = description || "";
+      this.details = details || null;
+    };
+
+    // Receiver
+    chrome.cast.Receiver = function (label, friendlyName, capabilities) {
+      this.label = label || "";
+      this.friendlyName = friendlyName || "";
+      this.capabilities = capabilities || [];
+      this.receiverType = chrome.cast.ReceiverType.CAST;
+      this.volume = null;
+    };
+
+    // Volume
+    chrome.cast.Volume = function (level, muted) {
+      this.level = level;
+      this.muted = muted;
+    };
+
+    // SessionRequest
+    chrome.cast.SessionRequest = function (appId, capabilities) {
+      this.appId = appId;
+      this.capabilities = capabilities || [chrome.cast.Capability.VIDEO_OUT];
+    };
+
+    // ApiConfig
+    chrome.cast.ApiConfig = function (sessionRequest, sessionListener, receiverListener, autoJoinPolicy) {
+      this.sessionRequest = sessionRequest;
+      this.sessionListener = sessionListener || null;
+      this.receiverListener = receiverListener || null;
+      this.autoJoinPolicy = autoJoinPolicy || chrome.cast.AutoJoinPolicy.TAB_AND_ORIGIN_SCOPED;
+    };
+
+    // Image
+    chrome.cast.Image = function (url) {
+      this.url = url;
+      this.height = null;
+      this.width = null;
+    };
+
+    // メディアメタデータ
+    chrome.cast.media.GenericMediaMetadata = function () {
+      this.metadataType = chrome.cast.media.MetadataType.GENERIC;
+      this.title = null;
+      this.subtitle = null;
+      this.images = [];
+    };
+
+    // MediaInfo
+    chrome.cast.media.MediaInfo = function (contentId, contentType) {
+      this.contentId = contentId;
+      this.contentType = contentType;
+      this.metadata = null;
+      this.duration = null;
+      this.streamType = chrome.cast.media.StreamType.BUFFERED;
+      this.customData = null;
+    };
+
+    // LoadRequest
+    chrome.cast.media.LoadRequest = function (mediaInfo) {
+      this.media = mediaInfo;
+      this.autoplay = true;
+      this.currentTime = null;
+      this.customData = null;
+    };
+
+    // SeekRequest
+    chrome.cast.media.SeekRequest = function () {
+      this.currentTime = null;
+      this.resumeState = null;
+    };
+
+    // Media オブジェクト
+    chrome.cast.media.Media = function (sessionId, mediaSessionId) {
+      this.sessionId = sessionId;
+      this.mediaSessionId = mediaSessionId;
+      this.media = null;
+      this.playbackRate = 1;
+      this.playerState = chrome.cast.media.PlayerState.IDLE;
+      this.volume = new chrome.cast.Volume(1, false);
+      this.currentTime = 0;
+      this._updateListeners = [];
+    };
+    chrome.cast.media.Media.prototype.addUpdateListener = function (listener) {
+      this._updateListeners.push(listener);
+    };
+    chrome.cast.media.Media.prototype.removeUpdateListener = function (listener) {
+      var idx = this._updateListeners.indexOf(listener);
+      if (idx >= 0) this._updateListeners.splice(idx, 1);
+    };
+    chrome.cast.media.Media.prototype.play = function (req, onSuccess, onError) {
+      window.postMessage({ __castBridge: true, action: "mediaPlay" }, "*");
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.media.Media.prototype.pause = function (req, onSuccess, onError) {
+      window.postMessage({ __castBridge: true, action: "mediaPause" }, "*");
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.media.Media.prototype.seek = function (seekReq, onSuccess, onError) {
+      window.postMessage({ __castBridge: true, action: "mediaSeek", currentTime: seekReq.currentTime }, "*");
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.media.Media.prototype.stop = function (req, onSuccess, onError) {
+      window.postMessage({ __castBridge: true, action: "mediaStop" }, "*");
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.media.Media.prototype.getEstimatedTime = function () {
+      return this.currentTime;
+    };
+
+    // Session オブジェクト
+    chrome.cast.Session = function (sessionId, appId, displayName, appImages, receiver) {
+      this.sessionId = sessionId || "";
+      this.appId = appId || "";
+      this.displayName = displayName || "";
+      this.appImages = appImages || [];
+      this.receiver = receiver || new chrome.cast.Receiver("", "", []);
+      this.media = [];
+      this.status = chrome.cast.SessionStatus.CONNECTED;
+      this.transportId = sessionId || "";
+      this._updateListeners = [];
+      this._messageListeners = {};
+    };
+    chrome.cast.Session.prototype.addUpdateListener = function (listener) {
+      this._updateListeners.push(listener);
+    };
+    chrome.cast.Session.prototype.removeUpdateListener = function (listener) {
+      var idx = this._updateListeners.indexOf(listener);
+      if (idx >= 0) this._updateListeners.splice(idx, 1);
+    };
+    chrome.cast.Session.prototype.addMessageListener = function (namespace, listener) {
+      if (!this._messageListeners[namespace]) {
+        this._messageListeners[namespace] = [];
+      }
+      this._messageListeners[namespace].push(listener);
+      window.postMessage({ __castBridge: true, action: "addMessageListener", namespace: namespace }, "*");
+    };
+    chrome.cast.Session.prototype.removeMessageListener = function (namespace, listener) {
+      if (this._messageListeners[namespace]) {
+        var idx = this._messageListeners[namespace].indexOf(listener);
+        if (idx >= 0) this._messageListeners[namespace].splice(idx, 1);
+      }
+    };
+    chrome.cast.Session.prototype.sendMessage = function (namespace, message, onSuccess, onError) {
+      var msgStr = typeof message === "string" ? message : JSON.stringify(message);
+      window.postMessage({
+        __castBridge: true,
+        action: "sendMessage",
+        namespace: namespace,
+        message: msgStr
+      }, "*");
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.Session.prototype.stop = function (onSuccess, onError) {
+      window.postMessage({ __castBridge: true, action: "stopSession" }, "*");
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.Session.prototype.leave = function (onSuccess, onError) {
+      this.stop(onSuccess, onError);
+    };
+    chrome.cast.Session.prototype.loadMedia = function (loadRequest, onSuccess, onError) {
+      var mediaInfo = loadRequest.media;
+      window.postMessage({
+        __castBridge: true,
+        action: "loadMedia",
+        contentId: mediaInfo.contentId,
+        contentType: mediaInfo.contentType || "video/mp4",
+        autoplay: loadRequest.autoplay !== false,
+        currentTime: loadRequest.currentTime || 0
+      }, "*");
+      var media = new chrome.cast.media.Media(this.sessionId, 1);
+      media.media = mediaInfo;
+      this.media = [media];
+      if (onSuccess) setTimeout(function () { onSuccess(media); }, 0);
+    };
+    chrome.cast.Session.prototype.addMediaListener = function () {};
+    chrome.cast.Session.prototype.removeMediaListener = function () {};
+    chrome.cast.Session.prototype.setReceiverVolumeLevel = function (level, onSuccess) {
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+    chrome.cast.Session.prototype.setReceiverMuted = function (muted, onSuccess) {
+      if (onSuccess) setTimeout(onSuccess, 0);
+    };
+
+    // 内部状態
+    var apiConfig = null;
+    var currentSession = null;
+    var requestSessionPending = false;
+
+    // メインAPI
+    chrome.cast.initialize = function (config, onSuccess, onError) {
+      apiConfig = config;
+      chrome.cast.isAvailable = true;
+      if (onSuccess) setTimeout(onSuccess, 0);
+      // receiverListener に AVAILABLE を通知してキャストボタンを表示させる
+      if (config && config.receiverListener) {
+        setTimeout(function () {
+          config.receiverListener(chrome.cast.ReceiverAvailability.AVAILABLE);
+        }, 100);
+      }
+    };
+
+    chrome.cast.requestSession = function (onSuccess, onError, sessionRequest) {
+      if (requestSessionPending) {
+        if (onError) onError(new chrome.cast.Error(chrome.cast.ErrorCode.CANCEL));
+        return;
+      }
+      requestSessionPending = true;
+      var appId = (sessionRequest && sessionRequest.appId) ||
+        (apiConfig && apiConfig.sessionRequest && apiConfig.sessionRequest.appId) || "";
+      window.postMessage({
+        __castBridge: true,
+        action: "requestSession",
+        appId: appId
+      }, "*");
+
+      // ネイティブからの結果を待つ
+      var handler = function (event) {
+        var data = event.data;
+        if (!data || !data.__castBridge || data.action !== "sessionResult") return;
+        window.removeEventListener("message", handler);
+        requestSessionPending = false;
+        if (data.success) {
+          var receiver = new chrome.cast.Receiver(
+            data.deviceName || "", data.deviceName || "",
+            [chrome.cast.Capability.VIDEO_OUT]
+          );
+          var session = new chrome.cast.Session(
+            data.sessionId || "", appId, data.deviceName || "", [], receiver
+          );
+          currentSession = session;
+          if (onSuccess) onSuccess(session);
+          if (apiConfig && apiConfig.sessionListener) {
+            apiConfig.sessionListener(session);
+          }
+        } else {
+          if (onError) onError(new chrome.cast.Error(
+            data.errorCode || chrome.cast.ErrorCode.CANCEL,
+            data.errorMessage || ""
+          ));
+        }
+      };
+      window.addEventListener("message", handler);
+    };
+
+    chrome.cast.setCustomReceivers = function () {};
+    chrome.cast.unescape = function (str) { return str; };
+    chrome.cast.isAvailable = true;
+    chrome.cast.VERSION = [1, 2, 0, 0];
+
+    // ネイティブからのメッセージ受信（セッション状態変更等）
+    window.addEventListener("message", function (event) {
+      var data = event.data;
+      if (!data || !data.__castBridge) return;
+      if (data.action === "messageReceived" && currentSession) {
+        var listeners = currentSession._messageListeners[data.namespace];
+        if (listeners) {
+          listeners.forEach(function (listener) {
+            try { listener(data.namespace, data.message); } catch (e) {}
+          });
+        }
+      } else if (data.action === "sessionEnded") {
+        if (currentSession) {
+          currentSession.status = chrome.cast.SessionStatus.STOPPED;
+          currentSession._updateListeners.forEach(function (listener) {
+            try { listener(false); } catch (e) {}
+          });
+          currentSession = null;
+        }
+        requestSessionPending = false;
+      }
+    });
+
+    // __onGCastApiAvailable のインターセプト
+    // cast_sender.js がロードされた場合に false で呼ばれる可能性があるため、
+    // 常に true で呼ぶようにインターセプトする
+    var existingCallback = window.__onGCastApiAvailable;
+    var storedCallbacks = [];
+    if (typeof existingCallback === "function") {
+      storedCallbacks.push(existingCallback);
+    }
+
+    Object.defineProperty(window, "__onGCastApiAvailable", {
+      get: function () {
+        // cast_sender.js がこの関数を呼ぶ時、常に true を渡すラッパーを返す
+        return function () {
+          storedCallbacks.forEach(function (cb) {
+            try { cb(true); } catch (e) {}
+          });
+        };
+      },
+      set: function (fn) {
+        if (typeof fn === "function") {
+          storedCallbacks.push(fn);
+          // 設定直後に true で呼び出す
+          setTimeout(function () { fn(true); }, 0);
+        }
+      },
+      configurable: true,
+      enumerable: true
+    });
+  } + ")();";
+
+  // ページコンテキストにスクリプトを注入
+  var script = document.createElement("script");
+  script.textContent = shimCode;
+  (document.head || document.documentElement).appendChild(script);
+  script.remove();
+
+  // ネイティブ通信用のポート接続
+  var port = browser.runtime.connectNative("castBridge");
+
+  // ページからの postMessage アクションをネイティブポートに転送
+  window.addEventListener("message", function (event) {
+    if (event.source !== window) return;
+    var data = event.data;
+    if (!data || !data.__castBridge) return;
+    // ブリッジマーカーを除去してネイティブに送信
+    var msg = {};
+    for (var key in data) {
+      if (key !== "__castBridge") msg[key] = data[key];
+    }
+    port.postMessage(msg);
+  });
+
+  // ネイティブポートからの応答をページに転送
+  port.onMessage.addListener(function (msg) {
+    msg.__castBridge = true;
+    window.postMessage(msg, "*");
+  });
+})();

--- a/app/src/main/assets/web_extensions/cast_bridge/manifest.json
+++ b/app/src/main/assets/web_extensions/cast_bridge/manifest.json
@@ -1,0 +1,29 @@
+{
+  "manifest_version": 2,
+  "name": "Cast Bridge",
+  "version": "1.0",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "cast-bridge@browsem"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "exclude_matches": [
+        "about:*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_start"
+    }
+  ],
+  "permissions": [
+    "geckoViewAddons",
+    "nativeMessaging",
+    "nativeMessagingFromContent"
+  ]
+}

--- a/app/src/main/assets/web_extensions/media_bridge/content.js
+++ b/app/src/main/assets/web_extensions/media_bridge/content.js
@@ -159,6 +159,7 @@
       debugMediaPaused: !!media && media.paused,
       debugMediaEnded: !!media && media.ended,
       debugMediaReadyState: media ? media.readyState : -1,
+      currentSrc: media ? media.currentSrc || media.src || "" : "",
       debugCurrentSrc: media ? media.currentSrc || media.src || "" : "",
       debugTimingCacheHit: shouldReuseLastKnownTiming,
     };

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -93,6 +93,9 @@ internal fun BrowserToolBar(
     toolbarColor: Color?,
     onHorizontalDrag: (Float) -> Unit = {},
     onHorizontalDragEnd: () -> Unit = {},
+    isCastAvailable: Boolean = false,
+    isCastConnected: Boolean = false,
+    onCastClick: () -> Unit = {},
 ) {
     var visibleMenu by remember { mutableStateOf(false) }
     BrowserToolbar(
@@ -112,6 +115,9 @@ internal fun BrowserToolBar(
         onOpenTabs = onOpenTabs,
         tabCount = tabCount,
         showTabButton = showTabActions,
+        isCastAvailable = isCastAvailable,
+        isCastConnected = isCastConnected,
+        onCastClick = onCastClick,
         urlInputState = UrlInputState(
             value = value,
             onValueChange = onValueChange,
@@ -149,6 +155,9 @@ internal fun BrowserToolBar(
                 onPageZoomIn = onPageZoomIn,
                 onPageZoomOut = onPageZoomOut,
                 onResetPageZoom = onResetPageZoom,
+                isCastAvailable = isCastAvailable,
+                isCastConnected = isCastConnected,
+                onCastClick = onCastClick,
             )
         }
     )
@@ -207,6 +216,9 @@ internal fun BrowserToolbar(
     showTabButton: Boolean = true,
     toolbarMenu: @Composable () -> Unit,
     modifier: Modifier = Modifier,
+    isCastAvailable: Boolean = false,
+    isCastConnected: Boolean = false,
+    onCastClick: () -> Unit = {},
 ) {
     var heightCache by remember { mutableIntStateOf(0) }
 
@@ -294,6 +306,21 @@ internal fun BrowserToolbar(
             }
 
             if (!isFocused) {
+                if (isCastAvailable) {
+                    // キャストデバイスが利用可能な場合にCastボタンを表示
+                    IconButton(onClick = onCastClick) {
+                        Icon(
+                            painter = painterResource(
+                                if (isCastConnected) {
+                                    ResourcesR.drawable.ic_cast_connected_24dp
+                                } else {
+                                    ResourcesR.drawable.ic_cast_24dp
+                                },
+                            ),
+                            contentDescription = if (isCastConnected) "キャストを停止" else "キャスト",
+                        )
+                    }
+                }
                 if (showTabButton) {
                     IconButton(
                         onClick = onOpenTabs,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
@@ -59,6 +59,9 @@ internal fun ToolbarMenu(
     onPageZoomIn: () -> Unit,
     onPageZoomOut: () -> Unit,
     onResetPageZoom: () -> Unit,
+    isCastAvailable: Boolean = false,
+    isCastConnected: Boolean = false,
+    onCastClick: () -> Unit = {},
 ) {
     DropdownMenu(
         expanded = visibleMenu,
@@ -315,6 +318,29 @@ internal fun ToolbarMenu(
                 onTranslatePage()
             },
         )
+        if (isCastAvailable) {
+            DropdownMenuItem(
+                text = {
+                    Text(text = if (isCastConnected) "キャストを停止" else "キャスト")
+                },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(
+                            id = if (isCastConnected) {
+                                ResourcesR.drawable.ic_cast_connected_24dp
+                            } else {
+                                ResourcesR.drawable.ic_cast_24dp
+                            },
+                        ),
+                        contentDescription = null,
+                    )
+                },
+                onClick = {
+                    onDismissRequest()
+                    onCastClick()
+                },
+            )
+        }
         DropdownMenuItem(
             text = {
                 Text(text = "共有")

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,6 +54,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.flow.collectLatest
+import net.matsudamper.browser.cast.CastManager
 import net.matsudamper.browser.data.TranslationProvider
 import net.matsudamper.browser.media.GeckoMediaSessionDelegate
 import net.matsudamper.browser.media.MediaWebExtension
@@ -102,6 +104,8 @@ internal fun GeckoBrowserTab(
     val context = LocalContext.current
     val readabilityWebExtension: ReadabilityWebExtension = koinInject()
     val findInPageWebExtension: FindInPageWebExtension = koinInject()
+    val castManager: CastManager = koinInject()
+    val castState by castManager.castState.collectAsState()
     // URLバーフォーカス時にクリップボードから読み取ったURL
     var clipboardUrl by remember { mutableStateOf<String?>(null) }
     // タブ履歴BottomSheetの表示状態
@@ -488,6 +492,15 @@ internal fun GeckoBrowserTab(
                         addToHomeTitle = state.currentPageTitle
                         addToHomeFavicon = browserTab.faviconBitmap
                         showAddToHomeScreenDialog = true
+                    },
+                    isCastAvailable = castState.isAvailable,
+                    isCastConnected = castState.isConnected,
+                    onCastClick = {
+                        if (castState.isConnected) {
+                            castManager.stopCasting()
+                        } else {
+                            castManager.showChooserDialog(context)
+                        }
                     },
                 )
             }

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -55,6 +55,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.flow.collectLatest
 import net.matsudamper.browser.cast.CastManager
+import net.matsudamper.browser.CastWebExtension
 import net.matsudamper.browser.data.TranslationProvider
 import net.matsudamper.browser.media.GeckoMediaSessionDelegate
 import net.matsudamper.browser.media.MediaWebExtension
@@ -104,6 +105,7 @@ internal fun GeckoBrowserTab(
     val context = LocalContext.current
     val readabilityWebExtension: ReadabilityWebExtension = koinInject()
     val findInPageWebExtension: FindInPageWebExtension = koinInject()
+    val castWebExtension: CastWebExtension = koinInject()
     val castManager: CastManager = koinInject()
     val castState by castManager.castState.collectAsState()
     // URLバーフォーカス時にクリップボードから読み取ったURL
@@ -242,6 +244,19 @@ internal fun GeckoBrowserTab(
         }
         onDispose {
             readabilityWebExtension.unregisterSession(session)
+        }
+    }
+
+    // CastWebExtension のセッション登録
+    DisposableEffect(session, castWebExtension, castManager) {
+        val handler = castManager.createBridgeHandler(context)
+        castWebExtension.registerSession(session, handler)
+        // セッション終了をウェブページに通知する
+        val sessionEndedListener = { castWebExtension.notifySessionEnded(session) }
+        castManager.addSessionEndedListener(sessionEndedListener)
+        onDispose {
+            castManager.removeSessionEndedListener(sessionEndedListener)
+            castWebExtension.unregisterSession(session)
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -53,7 +53,11 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import net.matsudamper.browser.cast.CastManager
 import net.matsudamper.browser.CastWebExtension
 import net.matsudamper.browser.data.TranslationProvider
@@ -248,14 +252,21 @@ internal fun GeckoBrowserTab(
     }
 
     // CastWebExtension のセッション登録
-    DisposableEffect(session, castWebExtension, castManager) {
-        val handler = castManager.createBridgeHandler(context)
+    DisposableEffect(session, castWebExtension, castManager, context) {
+        val handler = castManager.createBridgeHandler(context) {
+            // キャスト開始元のこのセッションのみにセッション終了を通知する
+            castWebExtension.notifySessionEnded(session)
+        }
         castWebExtension.registerSession(session, handler)
-        // セッション終了をウェブページに通知する
-        val sessionEndedListener = { castWebExtension.notifySessionEnded(session) }
-        castManager.addSessionEndedListener(sessionEndedListener)
+        // Cast可用性の変更をこのセッションに通知する
+        val castScope = CoroutineScope(Dispatchers.Main)
+        castScope.launch {
+            castManager.castState.collectLatest { state ->
+                castWebExtension.notifyAvailability(session, state.isAvailable)
+            }
+        }
         onDispose {
-            castManager.removeSessionEndedListener(sessionEndedListener)
+            castScope.cancel()
             castWebExtension.unregisterSession(session)
         }
     }

--- a/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
@@ -1,0 +1,256 @@
+package net.matsudamper.browser.cast
+
+import android.content.Context
+import android.util.Log
+import androidx.mediarouter.app.MediaRouteChooserDialog
+import androidx.mediarouter.media.MediaRouteSelector
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaLoadRequestData
+import com.google.android.gms.cast.MediaMetadata
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.SessionManager
+import com.google.android.gms.cast.framework.SessionManagerListener
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import net.matsudamper.browser.media.MediaSessionBridge
+import java.util.concurrent.Executors
+
+/**
+ * Chromecastへのキャストセッションを管理するクラス。
+ * Cast SDKのCastContext/SessionManagerをラップし、
+ * MediaSessionBridgeと連携してローカル/リモート再生を切り替える。
+ * Google Play Services未対応端末では機能を無効化する。
+ */
+class CastManager(
+    private val context: Context,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    private val _castState = MutableStateFlow(CastUiState())
+    val castState: StateFlow<CastUiState> = _castState.asStateFlow()
+
+    private var castContext: CastContext? = null
+    private var sessionManager: SessionManager? = null
+
+    private val sessionManagerListener = object : SessionManagerListener<CastSession> {
+        override fun onSessionStarting(session: CastSession) {
+            Log.d(TAG, "onSessionStarting")
+        }
+
+        override fun onSessionStarted(session: CastSession, sessionId: String) {
+            Log.d(TAG, "onSessionStarted: sessionId=$sessionId device=${session.castDevice?.friendlyName}")
+            val deviceName = session.castDevice?.friendlyName ?: ""
+            _castState.value = _castState.value.copy(isConnected = true, deviceName = deviceName)
+            // ローカル再生を一時停止してキャストに切り替え
+            val state = MediaSessionBridge.playbackState.value
+            MediaSessionBridge.pause()
+            MediaSessionBridge.updateCasting(true)
+            // メディアURLが有効であればChromecastにロード
+            val url = state.mediaSourceUrl
+            if (isCastableUrl(url)) {
+                loadMediaOnCast(session, url, state.title, state.positionMs)
+            } else {
+                Log.w(TAG, "メディアURLがキャスト不可: url=${url.take(100)}")
+            }
+        }
+
+        override fun onSessionStartFailed(session: CastSession, error: Int) {
+            Log.e(TAG, "onSessionStartFailed: error=$error")
+            _castState.value = _castState.value.copy(isConnected = false, deviceName = "")
+            MediaSessionBridge.updateCasting(false)
+        }
+
+        override fun onSessionEnding(session: CastSession) {
+            Log.d(TAG, "onSessionEnding")
+        }
+
+        override fun onSessionEnded(session: CastSession, error: Int) {
+            Log.d(TAG, "onSessionEnded: error=$error")
+            _castState.value = _castState.value.copy(isConnected = false, deviceName = "")
+            // キャスト終了時にローカル再生を再開
+            val remoteClient = session.remoteMediaClient
+            val positionMs = remoteClient?.approximateStreamPosition ?: 0L
+            MediaSessionBridge.updateCasting(false)
+            if (positionMs > 0) {
+                MediaSessionBridge.seekTo(positionMs / 1000.0)
+            }
+            MediaSessionBridge.play()
+        }
+
+        override fun onSessionResuming(session: CastSession, sessionId: String) {
+            Log.d(TAG, "onSessionResuming")
+        }
+
+        override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+            Log.d(TAG, "onSessionResumed: wasSuspended=$wasSuspended")
+            val deviceName = session.castDevice?.friendlyName ?: ""
+            _castState.value = _castState.value.copy(isConnected = true, deviceName = deviceName)
+            MediaSessionBridge.updateCasting(true)
+        }
+
+        override fun onSessionResumeFailed(session: CastSession, error: Int) {
+            Log.e(TAG, "onSessionResumeFailed: error=$error")
+            _castState.value = _castState.value.copy(isConnected = false, deviceName = "")
+            MediaSessionBridge.updateCasting(false)
+        }
+
+        override fun onSessionSuspended(session: CastSession, reason: Int) {
+            Log.d(TAG, "onSessionSuspended: reason=$reason")
+        }
+    }
+
+    init {
+        initializeCastContext()
+        // MediaSessionBridgeの状態変化を監視し、キャスト可能URLの有無をUI状態に反映
+        MediaSessionBridge.playbackState
+            .onEach { state ->
+                val hasCastableUrl = isCastableUrl(state.mediaSourceUrl)
+                if (_castState.value.hasMediaSourceUrl != hasCastableUrl) {
+                    _castState.value = _castState.value.copy(hasMediaSourceUrl = hasCastableUrl)
+                }
+            }
+            .launchIn(scope)
+    }
+
+    private fun initializeCastContext() {
+        val availability = GoogleApiAvailability.getInstance()
+            .isGooglePlayServicesAvailable(context)
+        if (availability != ConnectionResult.SUCCESS) {
+            Log.w(TAG, "Google Play Services が利用不可のためCast機能を無効化: availability=$availability")
+            return
+        }
+        try {
+            val executor = Executors.newSingleThreadExecutor()
+            CastContext.getSharedInstance(context, executor).addOnSuccessListener { ctx ->
+                castContext = ctx
+                sessionManager = ctx.sessionManager
+                sessionManager?.addSessionManagerListener(sessionManagerListener, CastSession::class.java)
+                // CastStateListenerを登録してデバイス検出状態を監視
+                ctx.addCastStateListener { castState ->
+                    val isAvailable = castState != com.google.android.gms.cast.framework.CastState.NO_DEVICES_AVAILABLE
+                    Log.d(TAG, "CastState changed: castState=$castState isAvailable=$isAvailable")
+                    _castState.value = _castState.value.copy(isAvailable = isAvailable)
+                }
+                Log.d(TAG, "CastContext初期化完了")
+            }.addOnFailureListener { e ->
+                Log.e(TAG, "CastContext初期化失敗", e)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "CastContext初期化例外", e)
+        }
+    }
+
+    /**
+     * キャストセッションを停止する。
+     */
+    fun stopCasting() {
+        Log.d(TAG, "stopCasting")
+        sessionManager?.endCurrentSession(true)
+    }
+
+    /**
+     * キャストデバイス選択ダイアログを表示する。
+     * FragmentManagerが不要なDialogを直接インスタンス化する。
+     */
+    fun showChooserDialog(context: Context) {
+        Log.d(TAG, "showChooserDialog")
+        val selector = MediaRouteSelector.Builder()
+            .addControlCategory(
+                CastMediaControlIntent.categoryForCast(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID),
+            )
+            .build()
+        val dialog = MediaRouteChooserDialog(context)
+        dialog.routeSelector = selector
+        dialog.show()
+    }
+
+    /**
+     * キャスト中の再生を操作する。
+     */
+    fun playOnCast() {
+        currentRemoteMediaClient()?.play()
+    }
+
+    fun pauseOnCast() {
+        currentRemoteMediaClient()?.pause()
+    }
+
+    /**
+     * リソースを解放する。ActivityのonDestroy等で呼ぶ。
+     */
+    fun cleanup() {
+        sessionManager?.removeSessionManagerListener(sessionManagerListener, CastSession::class.java)
+        scope.cancel()
+    }
+
+    private fun currentRemoteMediaClient() =
+        sessionManager?.currentCastSession?.remoteMediaClient
+
+    private fun loadMediaOnCast(
+        session: CastSession,
+        url: String,
+        title: String,
+        positionMs: Long,
+    ) {
+        val contentType = guessContentType(url)
+        val metadata = MediaMetadata(MediaMetadata.MEDIA_TYPE_GENERIC).apply {
+            putString(MediaMetadata.KEY_TITLE, title.ifEmpty { "Media" })
+        }
+        val mediaInfo = MediaInfo.Builder(url)
+            .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+            .setContentType(contentType)
+            .setMetadata(metadata)
+            .build()
+        val loadRequest = MediaLoadRequestData.Builder()
+            .setMediaInfo(mediaInfo)
+            .setCurrentTime(positionMs)
+            .setAutoplay(true)
+            .build()
+        session.remoteMediaClient?.load(loadRequest)?.setResultCallback { result ->
+            if (!result.status.isSuccess) {
+                Log.e(TAG, "メディアのロード失敗: ${result.status.statusMessage}")
+            } else {
+                Log.d(TAG, "メディアのロード成功")
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "CastManager"
+
+        /**
+         * キャスト可能なURLかどうかを判定する。
+         * blob:URLやdata:URIはChromecastでは再生できない。
+         */
+        fun isCastableUrl(url: String): Boolean {
+            if (url.isBlank()) return false
+            if (url.startsWith("blob:")) return false
+            if (url.startsWith("data:")) return false
+            if (!url.startsWith("http://") && !url.startsWith("https://")) return false
+            return true
+        }
+
+        private fun guessContentType(url: String): String {
+            return when {
+                url.contains(".mp4", ignoreCase = true) -> "video/mp4"
+                url.contains(".webm", ignoreCase = true) -> "video/webm"
+                url.contains(".mp3", ignoreCase = true) -> "audio/mpeg"
+                url.contains(".m3u8", ignoreCase = true) -> "application/x-mpegurl"
+                url.contains(".mpd", ignoreCase = true) -> "application/dash+xml"
+                url.contains(".ogg", ignoreCase = true) -> "video/ogg"
+                else -> "video/mp4"
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
@@ -50,6 +50,8 @@ class CastManager(
     private var webSessionCallback: ((Boolean, String, String) -> Unit)? = null
     // ウェブページ経由でセッションが開始されたかどうか
     private var isWebInitiatedSession = false
+    // ウェブ経由セッション終了時に呼ぶコールバック（キャスト開始元のセッションのみに通知）
+    private var webSessionEndedCallback: (() -> Unit)? = null
 
     private val sessionManagerListener = object : SessionManagerListener<CastSession> {
         override fun onSessionStarting(session: CastSession) {
@@ -104,8 +106,9 @@ class CastManager(
             val wasWebInitiated = isWebInitiatedSession
             isWebInitiatedSession = false
 
-            // セッション終了リスナーに通知
-            sessionEndedListeners.toList().forEach { it() }
+            // キャスト開始元セッションのみに終了を通知
+            webSessionEndedCallback?.invoke()
+            webSessionEndedCallback = null
 
             if (wasWebInitiated) {
                 // ウェブ経由のセッションはページ側で再生制御するため、ここではキャスト状態のみ解除
@@ -225,30 +228,64 @@ class CastManager(
         currentRemoteMediaClient()?.pause()
     }
 
-    // セッション終了リスナー
-    private val sessionEndedListeners = mutableListOf<() -> Unit>()
-
-    /**
-     * セッション終了時のリスナーを追加する。
-     */
-    fun addSessionEndedListener(listener: () -> Unit) {
-        sessionEndedListeners.add(listener)
+    @Suppress("DEPRECATION")
+    fun seekOnCast(positionMs: Long) {
+        currentRemoteMediaClient()?.seek(positionMs)
     }
 
-    fun removeSessionEndedListener(listener: () -> Unit) {
-        sessionEndedListeners.remove(listener)
+    fun stopMediaOnCast() {
+        currentRemoteMediaClient()?.stop()
+    }
+
+    /**
+     * Cast デバイスにメディアをロードする（ウェブページからのリクエスト用）。
+     */
+    fun loadMediaOnCastFromWeb(contentId: String, contentType: String, autoplay: Boolean, currentTimeMs: Long) {
+        val session = sessionManager?.currentCastSession ?: run {
+            Log.w(TAG, "loadMediaOnCastFromWeb: セッションなし")
+            return
+        }
+        val metadata = MediaMetadata(MediaMetadata.MEDIA_TYPE_GENERIC).apply {
+            putString(MediaMetadata.KEY_TITLE, "Media")
+        }
+        val mediaInfo = MediaInfo.Builder(contentId)
+            .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+            .setContentType(contentType)
+            .setMetadata(metadata)
+            .build()
+        val loadRequest = MediaLoadRequestData.Builder()
+            .setMediaInfo(mediaInfo)
+            .setCurrentTime(currentTimeMs)
+            .setAutoplay(autoplay)
+            .build()
+        session.remoteMediaClient?.load(loadRequest)?.setResultCallback { result ->
+            if (!result.status.isSuccess) {
+                Log.e(TAG, "ウェブ経由メディアロード失敗: ${result.status.statusMessage}")
+            } else {
+                Log.d(TAG, "ウェブ経由メディアロード成功")
+            }
+        }
     }
 
     /**
      * ウェブページからのセッションリクエストを処理する。
      * デバイス選択ダイアログを表示し、結果をコールバックで返す。
+     * 既にリクエスト中の場合は新しいリクエストを拒否する。
      */
     fun requestSessionFromWeb(
         context: Context,
+        onSessionEnded: () -> Unit,
         callback: (success: Boolean, sessionId: String, deviceName: String) -> Unit,
     ) {
+        // 重複リクエストを拒否する
+        if (webSessionCallback != null) {
+            Log.w(TAG, "requestSessionFromWeb: 既にリクエスト処理中のため拒否")
+            callback(false, "", "")
+            return
+        }
         Log.d(TAG, "requestSessionFromWeb")
         webSessionCallback = callback
+        webSessionEndedCallback = onSessionEnded
         showChooserDialog(context)
     }
 
@@ -288,10 +325,10 @@ class CastManager(
     /**
      * CastWebExtension 用のブリッジハンドラを作成する。
      */
-    fun createBridgeHandler(activityContext: Context): CastWebExtension.CastBridgeHandler {
+    fun createBridgeHandler(activityContext: Context, onSessionEnded: () -> Unit): CastWebExtension.CastBridgeHandler {
         return object : CastWebExtension.CastBridgeHandler {
             override fun requestSession(callback: (Boolean, String, String) -> Unit) {
-                requestSessionFromWeb(activityContext, callback)
+                requestSessionFromWeb(activityContext, onSessionEnded, callback)
             }
 
             override fun sendMessage(namespace: String, message: String) {
@@ -305,6 +342,30 @@ class CastManager(
             override fun stopSession() {
                 stopCasting()
             }
+
+            override fun loadMedia(contentId: String, contentType: String, autoplay: Boolean, currentTimeMs: Long) {
+                loadMediaOnCastFromWeb(contentId, contentType, autoplay, currentTimeMs)
+            }
+
+            override fun playMedia() {
+                playOnCast()
+            }
+
+            override fun pauseMedia() {
+                pauseOnCast()
+            }
+
+            override fun seekMedia(positionMs: Long) {
+                seekOnCast(positionMs)
+            }
+
+            override fun stopMedia() {
+                stopMediaOnCast()
+            }
+
+            override fun getAvailability(): Boolean {
+                return _castState.value.isAvailable
+            }
         }
     }
 
@@ -315,7 +376,7 @@ class CastManager(
         sessionManager?.removeSessionManagerListener(sessionManagerListener, CastSession::class.java)
         castExecutor?.shutdown()
         castExecutor = null
-        sessionEndedListeners.clear()
+        webSessionEndedCallback = null
         scope.cancel()
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.mediarouter.app.MediaRouteChooserDialog
 import androidx.mediarouter.media.MediaRouteSelector
+import com.google.android.gms.cast.Cast
 import com.google.android.gms.cast.CastMediaControlIntent
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaLoadRequestData
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import net.matsudamper.browser.CastWebExtension
 import net.matsudamper.browser.media.MediaSessionBridge
 import java.util.concurrent.Executors
 
@@ -44,6 +46,11 @@ class CastManager(
     private var sessionManager: SessionManager? = null
     private var castExecutor: java.util.concurrent.ExecutorService? = null
 
+    // ウェブページからのセッションリクエスト用コールバック
+    private var webSessionCallback: ((Boolean, String, String) -> Unit)? = null
+    // ウェブページ経由でセッションが開始されたかどうか
+    private var isWebInitiatedSession = false
+
     private val sessionManagerListener = object : SessionManagerListener<CastSession> {
         override fun onSessionStarting(session: CastSession) {
             Log.d(TAG, "onSessionStarting")
@@ -53,7 +60,19 @@ class CastManager(
             Log.d(TAG, "onSessionStarted: sessionId=$sessionId device=${session.castDevice?.friendlyName}")
             val deviceName = session.castDevice?.friendlyName ?: ""
             _castState.value = _castState.value.copy(isConnected = true, deviceName = deviceName)
-            // ローカル再生を一時停止してキャストに切り替え
+
+            // ウェブページからのリクエストの場合はコールバックで通知
+            val webCallback = webSessionCallback
+            if (webCallback != null) {
+                webSessionCallback = null
+                isWebInitiatedSession = true
+                MediaSessionBridge.pause()
+                MediaSessionBridge.updateCasting(true)
+                webCallback(true, sessionId, deviceName)
+                return
+            }
+
+            // ツールバーからのキャスト: ローカル再生を一時停止してキャストに切り替え
             val state = MediaSessionBridge.playbackState.value
             MediaSessionBridge.pause()
             MediaSessionBridge.updateCasting(true)
@@ -70,6 +89,9 @@ class CastManager(
             Log.e(TAG, "onSessionStartFailed: error=$error")
             _castState.value = _castState.value.copy(isConnected = false, deviceName = "")
             MediaSessionBridge.updateCasting(false)
+            // ウェブページからのリクエスト失敗を通知
+            webSessionCallback?.invoke(false, "", "")
+            webSessionCallback = null
         }
 
         override fun onSessionEnding(session: CastSession) {
@@ -79,7 +101,19 @@ class CastManager(
         override fun onSessionEnded(session: CastSession, error: Int) {
             Log.d(TAG, "onSessionEnded: error=$error")
             _castState.value = _castState.value.copy(isConnected = false, deviceName = "")
-            // キャスト終了時、リモート側が再生中だった場合のみローカル再生を再開
+            val wasWebInitiated = isWebInitiatedSession
+            isWebInitiatedSession = false
+
+            // セッション終了リスナーに通知
+            sessionEndedListeners.toList().forEach { it() }
+
+            if (wasWebInitiated) {
+                // ウェブ経由のセッションはページ側で再生制御するため、ここではキャスト状態のみ解除
+                MediaSessionBridge.updateCasting(false)
+                return
+            }
+
+            // ツールバーからのキャスト終了時、リモート側が再生中だった場合のみローカル再生を再開
             val remoteClient = session.remoteMediaClient
             val wasPlaying = remoteClient?.isPlaying ?: false
             val positionMs = remoteClient?.approximateStreamPosition ?: 0L
@@ -191,6 +225,89 @@ class CastManager(
         currentRemoteMediaClient()?.pause()
     }
 
+    // セッション終了リスナー
+    private val sessionEndedListeners = mutableListOf<() -> Unit>()
+
+    /**
+     * セッション終了時のリスナーを追加する。
+     */
+    fun addSessionEndedListener(listener: () -> Unit) {
+        sessionEndedListeners.add(listener)
+    }
+
+    fun removeSessionEndedListener(listener: () -> Unit) {
+        sessionEndedListeners.remove(listener)
+    }
+
+    /**
+     * ウェブページからのセッションリクエストを処理する。
+     * デバイス選択ダイアログを表示し、結果をコールバックで返す。
+     */
+    fun requestSessionFromWeb(
+        context: Context,
+        callback: (success: Boolean, sessionId: String, deviceName: String) -> Unit,
+    ) {
+        Log.d(TAG, "requestSessionFromWeb")
+        webSessionCallback = callback
+        showChooserDialog(context)
+    }
+
+    /**
+     * Cast デバイスにメッセージを送信する。
+     */
+    fun sendMessageOnCast(namespace: String, message: String) {
+        val session = sessionManager?.currentCastSession ?: run {
+            Log.w(TAG, "sendMessageOnCast: セッションなし")
+            return
+        }
+        try {
+            session.sendMessage(namespace, message)
+        } catch (e: Exception) {
+            Log.e(TAG, "sendMessageOnCast失敗: namespace=$namespace", e)
+        }
+    }
+
+    /**
+     * Cast デバイスからのメッセージリスナーを登録する。
+     */
+    fun addMessageListenerOnCast(namespace: String, callback: (namespace: String, message: String) -> Unit) {
+        val session = sessionManager?.currentCastSession ?: run {
+            Log.w(TAG, "addMessageListenerOnCast: セッションなし")
+            return
+        }
+        try {
+            session.setMessageReceivedCallbacks(namespace, Cast.MessageReceivedCallback { _, ns, msg ->
+                Log.d(TAG, "messageReceived: namespace=$ns")
+                callback(ns, msg)
+            })
+        } catch (e: Exception) {
+            Log.e(TAG, "addMessageListenerOnCast失敗: namespace=$namespace", e)
+        }
+    }
+
+    /**
+     * CastWebExtension 用のブリッジハンドラを作成する。
+     */
+    fun createBridgeHandler(activityContext: Context): CastWebExtension.CastBridgeHandler {
+        return object : CastWebExtension.CastBridgeHandler {
+            override fun requestSession(callback: (Boolean, String, String) -> Unit) {
+                requestSessionFromWeb(activityContext, callback)
+            }
+
+            override fun sendMessage(namespace: String, message: String) {
+                sendMessageOnCast(namespace, message)
+            }
+
+            override fun addMessageListener(namespace: String, callback: (String, String) -> Unit) {
+                addMessageListenerOnCast(namespace, callback)
+            }
+
+            override fun stopSession() {
+                stopCasting()
+            }
+        }
+    }
+
     /**
      * リソースを解放する。ActivityのonDestroy等で呼ぶ。
      */
@@ -198,6 +315,7 @@ class CastManager(
         sessionManager?.removeSessionManagerListener(sessionManagerListener, CastSession::class.java)
         castExecutor?.shutdown()
         castExecutor = null
+        sessionEndedListeners.clear()
         scope.cancel()
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/cast/CastManager.kt
@@ -42,6 +42,7 @@ class CastManager(
 
     private var castContext: CastContext? = null
     private var sessionManager: SessionManager? = null
+    private var castExecutor: java.util.concurrent.ExecutorService? = null
 
     private val sessionManagerListener = object : SessionManagerListener<CastSession> {
         override fun onSessionStarting(session: CastSession) {
@@ -78,14 +79,17 @@ class CastManager(
         override fun onSessionEnded(session: CastSession, error: Int) {
             Log.d(TAG, "onSessionEnded: error=$error")
             _castState.value = _castState.value.copy(isConnected = false, deviceName = "")
-            // キャスト終了時にローカル再生を再開
+            // キャスト終了時、リモート側が再生中だった場合のみローカル再生を再開
             val remoteClient = session.remoteMediaClient
+            val wasPlaying = remoteClient?.isPlaying ?: false
             val positionMs = remoteClient?.approximateStreamPosition ?: 0L
             MediaSessionBridge.updateCasting(false)
             if (positionMs > 0) {
                 MediaSessionBridge.seekTo(positionMs / 1000.0)
             }
-            MediaSessionBridge.play()
+            if (wasPlaying) {
+                MediaSessionBridge.play()
+            }
         }
 
         override fun onSessionResuming(session: CastSession, sessionId: String) {
@@ -132,6 +136,7 @@ class CastManager(
         }
         try {
             val executor = Executors.newSingleThreadExecutor()
+            castExecutor = executor
             CastContext.getSharedInstance(context, executor).addOnSuccessListener { ctx ->
                 castContext = ctx
                 sessionManager = ctx.sessionManager
@@ -191,6 +196,8 @@ class CastManager(
      */
     fun cleanup() {
         sessionManager?.removeSessionManagerListener(sessionManagerListener, CastSession::class.java)
+        castExecutor?.shutdown()
+        castExecutor = null
         scope.cancel()
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/cast/CastOptionsProvider.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/cast/CastOptionsProvider.kt
@@ -1,0 +1,38 @@
+package net.matsudamper.browser.cast
+
+import android.content.Context
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.framework.CastOptions
+import com.google.android.gms.cast.framework.OptionsProvider
+import com.google.android.gms.cast.framework.SessionProvider
+import com.google.android.gms.cast.framework.media.CastMediaOptions
+import com.google.android.gms.cast.framework.media.MediaIntentReceiver
+import com.google.android.gms.cast.framework.media.NotificationOptions
+
+/**
+ * Cast SDKが要求するOptionsProvider。
+ * AndroidManifest.xmlのmeta-dataで参照される。
+ * Default Media Receiverを使用するためカスタムレシーバーは不要。
+ */
+class CastOptionsProvider : OptionsProvider {
+    override fun getCastOptions(context: Context): CastOptions {
+        val notificationOptions = NotificationOptions.Builder()
+            .setActions(
+                listOf(
+                    MediaIntentReceiver.ACTION_TOGGLE_PLAYBACK,
+                    MediaIntentReceiver.ACTION_STOP_CASTING,
+                ),
+                intArrayOf(0, 1),
+            )
+            .build()
+        val mediaOptions = CastMediaOptions.Builder()
+            .setNotificationOptions(notificationOptions)
+            .build()
+        return CastOptions.Builder()
+            .setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
+            .setCastMediaOptions(mediaOptions)
+            .build()
+    }
+
+    override fun getAdditionalSessionProviders(context: Context): List<SessionProvider>? = null
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/cast/CastUiState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/cast/CastUiState.kt
@@ -1,0 +1,19 @@
+package net.matsudamper.browser.cast
+
+import androidx.compose.runtime.Stable
+
+/**
+ * キャスト機能のUI状態を保持するデータクラス。
+ * Composableがこの状態を観測してCastボタンの表示/非表示を切り替える。
+ */
+@Stable
+data class CastUiState(
+    // Chromecastデバイスが検出されているか（Google Play Services未対応端末ではfalse固定）
+    val isAvailable: Boolean = false,
+    // キャストセッションがアクティブか
+    val isConnected: Boolean = false,
+    // 接続中のデバイス名
+    val deviceName: String = "",
+    // キャスト可能なメディアURLが存在するか（blob:やdata:は不可）
+    val hasMediaSourceUrl: Boolean = false,
+)

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -14,6 +14,7 @@ import net.matsudamper.browser.data.download.DownloadRepository
 import net.matsudamper.browser.data.history.HistoryRepository
 import net.matsudamper.browser.data.websuggestion.HttpWebSuggestionRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
+import net.matsudamper.browser.cast.CastManager
 import net.matsudamper.browser.media.MediaWebExtension
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.workmanager.dsl.worker
@@ -45,6 +46,7 @@ val appModule = module {
     single { MediaWebExtension(androidContext()).also { it.install(get()) } }
     single { ReadabilityWebExtension().also { it.install(get()) } }
     single { FindInPageWebExtension().also { it.install(get()) } }
+    single { CastManager(androidContext()) }
     factory { GeckoDownloadManager(androidContext(), get()) }
     viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get()) }
     worker { DownloadWorker(get(), get(), get()) }

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -1,6 +1,7 @@
 package net.matsudamper.browser.di
 
 import net.matsudamper.browser.BrowserViewModel
+import net.matsudamper.browser.CastWebExtension
 import net.matsudamper.browser.DownloadWorker
 import net.matsudamper.browser.FindInPageWebExtension
 import net.matsudamper.browser.GeckoDownloadManager
@@ -46,6 +47,7 @@ val appModule = module {
     single { MediaWebExtension(androidContext()).also { it.install(get()) } }
     single { ReadabilityWebExtension().also { it.install(get()) } }
     single { FindInPageWebExtension().also { it.install(get()) } }
+    single { CastWebExtension().also { it.install(get()) } }
     single { CastManager(androidContext()) }
     factory { GeckoDownloadManager(androidContext(), get()) }
     viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get()) }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/CastWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/CastWebExtension.kt
@@ -30,6 +30,18 @@ class CastWebExtension {
         fun addMessageListener(namespace: String, callback: (namespace: String, message: String) -> Unit)
         /** キャストセッションを停止する */
         fun stopSession()
+        /** Cast デバイスにメディアをロードする */
+        fun loadMedia(contentId: String, contentType: String, autoplay: Boolean, currentTimeMs: Long)
+        /** キャスト中のメディアを再生する */
+        fun playMedia()
+        /** キャスト中のメディアを一時停止する */
+        fun pauseMedia()
+        /** キャスト中のメディアをシークする */
+        fun seekMedia(positionMs: Long)
+        /** キャスト中のメディアを停止する */
+        fun stopMedia()
+        /** 現在の Cast デバイス検出状態を取得する */
+        fun getAvailability(): Boolean
     }
 
     private var extension: WebExtension? = null
@@ -94,6 +106,19 @@ class CastWebExtension {
     }
 
     /**
+     * Cast デバイスの可用性変更をコンテンツスクリプトに通知する。
+     */
+    fun notifyAvailability(session: GeckoSession, isAvailable: Boolean) {
+        val port = sessionPorts[session] ?: return
+        mainHandler.post {
+            port.postMessage(JSONObject().apply {
+                put("action", "availability")
+                put("isAvailable", isAvailable)
+            })
+        }
+    }
+
+    /**
      * Cast デバイスから受信したメッセージをコンテンツスクリプトに転送する。
      */
     fun notifyMessageReceived(session: GeckoSession, namespace: String, message: String) {
@@ -140,6 +165,17 @@ class CastWebExtension {
                             sessionPorts.remove(session)
                         }
                     })
+                    // ポート接続時にネイティブの可用性を即時通知する
+                    val handler = sessionHandlers[session]
+                    if (handler != null) {
+                        mainHandler.post {
+                            val isAvailable = handler.getAvailability()
+                            port.postMessage(JSONObject().apply {
+                                put("action", "availability")
+                                put("isAvailable", isAvailable)
+                            })
+                        }
+                    }
                 }
             },
             NATIVE_APP_ID,
@@ -184,9 +220,24 @@ class CastWebExtension {
                 handler.stopSession()
             }
             "loadMedia" -> {
-                // メディアロードはsendMessageのurn:x-cast:com.google.cast.media経由で
-                // 処理されるため、ここでは追加処理不要
-                Log.d(TAG, "loadMedia: contentId=${json.optString("contentId")}")
+                val contentId = json.optString("contentId", "")
+                val contentType = json.optString("contentType", "video/mp4")
+                val autoplay = json.optBoolean("autoplay", true)
+                val currentTimeMs = json.optLong("currentTime", 0L)
+                handler.loadMedia(contentId, contentType, autoplay, currentTimeMs)
+            }
+            "mediaPlay" -> {
+                handler.playMedia()
+            }
+            "mediaPause" -> {
+                handler.pauseMedia()
+            }
+            "mediaSeek" -> {
+                val currentTime = json.optDouble("currentTime", 0.0)
+                handler.seekMedia((currentTime * 1000).toLong())
+            }
+            "mediaStop" -> {
+                handler.stopMedia()
             }
             else -> {
                 Log.d(TAG, "未知のアクション: $action")

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/CastWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/CastWebExtension.kt
@@ -1,0 +1,203 @@
+package net.matsudamper.browser
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import org.json.JSONObject
+import org.mozilla.geckoview.GeckoResult
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.WebExtension
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * chrome.cast API シムとネイティブ Cast SDK を橋渡しするビルトイン WebExtension。
+ * コンテンツスクリプトがポートを確立し、ページ内の chrome.cast 呼び出しを
+ * ネイティブ側の CastBridgeHandler に転送する。
+ */
+class CastWebExtension {
+    /**
+     * ウェブページからの Cast 操作を処理するハンドラインターフェース。
+     * app モジュールの CastManager がこれを実装する。
+     */
+    interface CastBridgeHandler {
+        /** デバイス選択ダイアログを表示してセッションを開始する */
+        fun requestSession(callback: (success: Boolean, sessionId: String, deviceName: String) -> Unit)
+        /** Cast デバイスにメッセージを送信する */
+        fun sendMessage(namespace: String, message: String)
+        /** メッセージリスナーを登録する */
+        fun addMessageListener(namespace: String, callback: (namespace: String, message: String) -> Unit)
+        /** キャストセッションを停止する */
+        fun stopSession()
+    }
+
+    private var extension: WebExtension? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // セッションごとの接続ポート
+    private val sessionPorts = ConcurrentHashMap<GeckoSession, WebExtension.Port>()
+    // セッションごとのハンドラ
+    private val sessionHandlers = ConcurrentHashMap<GeckoSession, CastBridgeHandler>()
+    // デリゲート設定済みセッション
+    private val attachedSessions: MutableSet<GeckoSession> =
+        Collections.newSetFromMap(ConcurrentHashMap())
+
+    fun install(runtime: GeckoRuntime) {
+        Log.d(TAG, "install() 開始: uri=$EXTENSION_URI")
+        runtime.webExtensionController
+            .installBuiltIn(EXTENSION_URI)
+            .accept(
+                { ext ->
+                    Log.d(TAG, "インストール完了: id=${ext?.id}")
+                    if (ext == null) return@accept
+                    extension = ext
+                    sessionHandlers.keys.forEach { session ->
+                        attachSessionDelegate(session, ext)
+                    }
+                },
+                { error ->
+                    Log.e(TAG, "インストール失敗", error)
+                },
+            )
+    }
+
+    /**
+     * セッションを登録し、Cast 操作のハンドラを設定する。
+     */
+    fun registerSession(session: GeckoSession, handler: CastBridgeHandler) {
+        sessionHandlers[session] = handler
+        extension?.also { ext ->
+            attachSessionDelegate(session, ext)
+        }
+    }
+
+    fun unregisterSession(session: GeckoSession) {
+        sessionHandlers.remove(session)
+        sessionPorts.remove(session)
+        attachedSessions.remove(session)
+        extension?.let { ext ->
+            session.webExtensionController.setMessageDelegate(ext, null, NATIVE_APP_ID)
+        }
+    }
+
+    /**
+     * セッション終了をコンテンツスクリプトに通知する。
+     */
+    fun notifySessionEnded(session: GeckoSession) {
+        val port = sessionPorts[session] ?: return
+        mainHandler.post {
+            port.postMessage(JSONObject().apply {
+                put("action", "sessionEnded")
+            })
+        }
+    }
+
+    /**
+     * Cast デバイスから受信したメッセージをコンテンツスクリプトに転送する。
+     */
+    fun notifyMessageReceived(session: GeckoSession, namespace: String, message: String) {
+        val port = sessionPorts[session] ?: return
+        mainHandler.post {
+            port.postMessage(JSONObject().apply {
+                put("action", "messageReceived")
+                put("namespace", namespace)
+                put("message", message)
+            })
+        }
+    }
+
+    private fun attachSessionDelegate(session: GeckoSession, ext: WebExtension) {
+        if (!attachedSessions.add(session)) return
+        session.webExtensionController.setMessageDelegate(
+            ext,
+            object : WebExtension.MessageDelegate {
+                override fun onMessage(
+                    nativeApp: String,
+                    message: Any,
+                    sender: WebExtension.MessageSender,
+                ): GeckoResult<Any>? = null
+
+                override fun onConnect(port: WebExtension.Port) {
+                    Log.d(TAG, "onConnect: ポート接続")
+                    sessionPorts[session] = port
+                    port.setDelegate(object : WebExtension.PortDelegate {
+                        override fun onPortMessage(
+                            message: Any,
+                            port: WebExtension.Port,
+                        ) {
+                            val json = message as? JSONObject ?: return
+                            val action = json.optString("action", "")
+                            Log.d(TAG, "onPortMessage: action=$action")
+                            val handler = sessionHandlers[session] ?: return
+                            mainHandler.post {
+                                handleAction(session, handler, action, json, port)
+                            }
+                        }
+
+                        override fun onDisconnect(port: WebExtension.Port) {
+                            Log.d(TAG, "onDisconnect: ポート切断")
+                            sessionPorts.remove(session)
+                        }
+                    })
+                }
+            },
+            NATIVE_APP_ID,
+        )
+    }
+
+    private fun handleAction(
+        session: GeckoSession,
+        handler: CastBridgeHandler,
+        action: String,
+        json: JSONObject,
+        port: WebExtension.Port,
+    ) {
+        when (action) {
+            "requestSession" -> {
+                handler.requestSession { success, sessionId, deviceName ->
+                    mainHandler.post {
+                        port.postMessage(JSONObject().apply {
+                            put("action", "sessionResult")
+                            put("success", success)
+                            put("sessionId", sessionId)
+                            put("deviceName", deviceName)
+                            if (!success) {
+                                put("errorCode", "cancel")
+                            }
+                        })
+                    }
+                }
+            }
+            "sendMessage" -> {
+                val namespace = json.optString("namespace", "")
+                val message = json.optString("message", "")
+                handler.sendMessage(namespace, message)
+            }
+            "addMessageListener" -> {
+                val namespace = json.optString("namespace", "")
+                handler.addMessageListener(namespace) { ns, msg ->
+                    notifyMessageReceived(session, ns, msg)
+                }
+            }
+            "stopSession" -> {
+                handler.stopSession()
+            }
+            "loadMedia" -> {
+                // メディアロードはsendMessageのurn:x-cast:com.google.cast.media経由で
+                // 処理されるため、ここでは追加処理不要
+                Log.d(TAG, "loadMedia: contentId=${json.optString("contentId")}")
+            }
+            else -> {
+                Log.d(TAG, "未知のアクション: $action")
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "CastWebExtension"
+        private const val NATIVE_APP_ID = "castBridge"
+        private const val EXTENSION_URI =
+            "resource://android/assets/web_extensions/cast_bridge/"
+    }
+}

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaPlaybackService.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaPlaybackService.kt
@@ -238,7 +238,8 @@ private class GeckoMediaPlayer : SimpleBasePlayer(Looper.getMainLooper()) {
                 PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
             )
             .setPlaybackState(
-                if (currentState.isActive) STATE_READY else STATE_IDLE,
+                // キャスト中はローカル通知を抑制するためSTATE_IDLEを返す
+                if (currentState.isActive && !currentState.isCasting) STATE_READY else STATE_IDLE,
             )
             .setContentPositionMs(currentState.positionMs)
             .setPlaylist(

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaSessionBridge.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaSessionBridge.kt
@@ -73,6 +73,16 @@ object MediaSessionBridge {
         _playbackState.value = _playbackState.value.copy(features = features)
     }
 
+    fun updateMediaSourceUrl(url: String) {
+        Log.d(TAG, "updateMediaSourceUrl: url=${url.take(100)}")
+        _playbackState.value = _playbackState.value.copy(mediaSourceUrl = url)
+    }
+
+    fun updateCasting(isCasting: Boolean) {
+        Log.d(TAG, "updateCasting: isCasting=$isCasting")
+        _playbackState.value = _playbackState.value.copy(isCasting = isCasting)
+    }
+
     // サービスからGeckoViewへの制御メソッド
     fun play() {
         Log.d(TAG, "play: hasMediaSession=${activeGeckoMediaSession != null}")
@@ -116,4 +126,6 @@ data class MediaPlaybackState(
     val durationMs: Long = 0L,
     val positionMs: Long = 0L,
     val features: Long = 0L,
+    val mediaSourceUrl: String = "",
+    val isCasting: Boolean = false,
 )

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/media/MediaWebExtension.kt
@@ -263,6 +263,7 @@ class MediaWebExtension(
                         durationMs = if (shouldKeepPreviousTiming) previousSnapshot.durationMs else incomingDurationMs,
                         positionMs = if (shouldKeepPreviousTiming) previousSnapshot.positionMs else incomingPositionMs,
                         features = previousSnapshot?.features ?: 0L,
+                        mediaSourceUrl = json.optString("currentSrc", json.optString("debugCurrentSrc", "")),
                     )
                     mainHandler.post {
                         Log.d(TAG, "raw snapshot: session=${session.logKey()} payload=$json")
@@ -373,6 +374,7 @@ class MediaWebExtension(
         )
         MediaSessionBridge.updateFeatures(snapshot.features)
         MediaSessionBridge.updatePlaying(snapshot.isPlaying)
+        MediaSessionBridge.updateMediaSourceUrl(snapshot.mediaSourceUrl)
         if (snapshot.isActive) {
             MediaPlaybackServiceController.start(context)
         }
@@ -492,4 +494,5 @@ internal data class SessionPlaybackSnapshot(
     val durationMs: Long = 0L,
     val positionMs: Long = 0L,
     val features: Long = 0L,
+    val mediaSourceUrl: String = "",
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ ksp = "2.3.6"
 koin = "4.2.0"
 androidxBrowser = "1.10.0"
 uiautomator = "2.3.0"
+playServicesCast = "22.0.0"
 
 [libraries]
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
@@ -68,6 +69,7 @@ koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", versi
 koinAndroidWorkManager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidxBrowser" }
 androidx-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
+play-services-cast-framework = { module = "com.google.android.gms:play-services-cast-framework", version.ref = "playServicesCast" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/resources/src/main/res/drawable/ic_cast_24dp.xml
+++ b/resources/src/main/res/drawable/ic_cast_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M840,120H120C76,120 40,156 40,200v120h80V200h720v560h-280v80h280c44,0 80,-36 80,-80V200C960,156 924,120 840,120zM40,720v120h120C160,772 108,720 40,720zM40,560v80c112,0 200,88 200,200h80C320,684 196,560 40,560zM40,400v80c200,0 360,160 360,360h80C480,596 280,400 40,400z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/resources/src/main/res/drawable/ic_cast_connected_24dp.xml
+++ b/resources/src/main/res/drawable/ic_cast_connected_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M840,120H120C76,120 40,156 40,200v120h80V200h720v560h-280v80h280c44,0 80,-36 80,-80V200C960,156 924,120 840,120zM40,720v120h120C160,772 108,720 40,720zM40,560v80c112,0 200,88 200,200h80C320,684 196,560 40,560zM40,400v80c200,0 360,160 360,360h80C480,596 280,400 40,400zM340,480c-30,0 -60,12 -82,34L200,572l-56,-56 58,-58c36,-36 85,-58 138,-58c108,0 196,88 196,196h-80C456,530 404,480 340,480z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
## Summary
This PR adds Chromecast casting functionality to the browser, allowing users to cast media playback to Chromecast devices. The implementation integrates Google Cast SDK with the existing media playback system and provides UI controls for device selection and casting management.

## Key Changes

- **New CastManager class**: Core manager for handling Chromecast sessions, device discovery, and media loading. Wraps Cast SDK's CastContext and SessionManager, with graceful degradation for devices without Google Play Services.

- **CastUiState data class**: Reactive state holder tracking cast availability, connection status, device name, and castable media presence.

- **CastOptionsProvider**: Required Cast SDK configuration provider that sets up Default Media Receiver and notification options.

- **UI Integration**: 
  - Added Cast button to toolbar (visible when devices available)
  - Cast button shows connected/disconnected state with different icons
  - Added Cast option to toolbar menu
  - Integrated cast state observation in GeckoBrowserTab

- **MediaSessionBridge enhancements**:
  - Added `updateMediaSourceUrl()` to track current media URL
  - Added `updateCasting()` to manage local/remote playback state
  - Extended MediaPlaybackState with `mediaSourceUrl` and `isCasting` fields

- **Media URL validation**: Implemented `isCastableUrl()` to filter out non-castable URLs (blob:, data:, etc.) and `guessContentType()` for content type detection.

- **Lifecycle management**: 
  - Automatic pause of local playback when casting starts
  - Resume local playback with position sync when casting ends
  - Proper resource cleanup on activity destruction

- **Manifest & Build Configuration**:
  - Added Cast SDK OptionsProvider meta-data declaration
  - Added ProGuard rules to preserve CastOptionsProvider
  - Added Play Services Cast dependency (v22.0.0)

- **Assets**: Added Cast icon drawables for connected/disconnected states

## Notable Implementation Details

- Cast SDK initialization is asynchronous with failure handling for unavailable Google Play Services
- Media loading respects current playback position when transitioning to Chromecast
- UI state is reactive via Kotlin Flow, enabling seamless state synchronization
- Device selection uses MediaRouteChooserDialog without requiring FragmentManager

https://claude.ai/code/session_01XqJ9w1gBLrBGoAyxe692Td

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chromecast support: toolbar cast button, menu item to start/stop casting, device name/status display
  * In-page Cast API shim so sites can request and control Cast sessions
  * Remote media controls (play/pause/seek/stop), media chooser dialog, and background media notifications
  * Improved media URL reporting to the web bridge for more reliable casting

* **Behavior**
  * Local playback pauses/resumes and syncs position when casting; local playback UI suppressed while casting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->