### PR TITLE
タブのカウントをそのグループ内だけにする

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -69,7 +69,7 @@ internal fun BrowserToolBar(
     onInstallExtension: () -> Unit,
     onOpenSettings: () -> Unit,
     onShare: () -> Unit,
-    tabCount: Int,
+    tabCount: Int?,
     onOpenTabs: () -> Unit,
     showTabActions: Boolean = true,
     onRefresh: () -> Unit,
@@ -203,7 +203,7 @@ internal fun BrowserToolbar(
     toolbarColor: Color?,
     updateVisibleMenu: (Boolean) -> Unit,
     onOpenTabs: () -> Unit,
-    tabCount: Int,
+    tabCount: Int?,
     showTabButton: Boolean = true,
     toolbarMenu: @Composable () -> Unit,
     modifier: Modifier = Modifier,
@@ -294,7 +294,7 @@ internal fun BrowserToolbar(
             }
 
             if (!isFocused) {
-                if (showTabButton) {
+                if (showTabButton && tabCount != null) {
                     IconButton(
                         onClick = onOpenTabs,
                         modifier = Modifier.testTag(BrowserToolbarTestTags.OpenTabsButton.testTag),

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -79,7 +79,7 @@ internal fun GeckoBrowserTab(
     mediaWebExtension: MediaWebExtension,
     browserSessionLifecycleController: BrowserSessionLifecycleController,
     modifier: Modifier = Modifier,
-    tabCount: Int,
+    tabCount: Int?,
     onInstallExtensionRequest: (String) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit = {},
     onOpenSettings: () -> Unit,

--- a/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
+++ b/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
@@ -61,6 +61,7 @@ class BrowserScreenViewModel(
     val uiState: StateFlow<BrowserScreenUiState> = MutableStateFlow(
         BrowserScreenUiState(
             urlBarSuggestions = UrlBarSuggestionsUiState(),
+            groupTabCount = null,
             callbacks = callbacks,
         ),
     ).also { uiStateFlow ->
@@ -74,6 +75,7 @@ class BrowserScreenViewModel(
                             previousTab = adjacentTabs.previousTab,
                             nextTab = adjacentTabs.nextTab,
                         ),
+                        groupTabCount = state.resolveGroupTabCount(),
                         callbacks = callbacks,
                     )
                 }
@@ -143,6 +145,21 @@ private data class ViewModelState(
 
     private fun findTab(tabId: String): BrowserTab? {
         return orderedBrowserTabs.firstOrNull { it.tabId == tabId }
+    }
+
+    fun resolveGroupTabCount(): Int? {
+        // タブ・グループ情報がまだロードされていない場合は null を返す
+        if (browserTabs.isEmpty()) return null
+        val assignmentMap = tabGroupAssignments.associate { it.tabId to it.groupId }
+        val knownGroupIds = tabGroups.map { it.id.value }.toSet()
+        val currentGroupId = assignmentMap[screenTabId]?.takeIf { it in knownGroupIds }
+        return if (currentGroupId != null) {
+            // 現在のタブが属するグループ内のタブ数
+            browserTabs.count { tab -> assignmentMap[tab.tabId] == currentGroupId }
+        } else {
+            // 未グループのタブ数
+            browserTabs.count { tab -> assignmentMap[tab.tabId]?.let { it in knownGroupIds } != true }
+        }
     }
 
     private fun resolveOrderedBrowserTabs(): List<BrowserTab> {

--- a/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/CustomTabScreenViewModel.kt
+++ b/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/CustomTabScreenViewModel.kt
@@ -30,6 +30,7 @@ class CustomTabScreenViewModel(
     val uiState: StateFlow<BrowserScreenUiState> = MutableStateFlow(
         BrowserScreenUiState(
             urlBarSuggestions = UrlBarSuggestionsUiState(),
+            groupTabCount = null,
             callbacks = callbacks,
         ),
     ).also { uiStateFlow ->
@@ -38,6 +39,7 @@ class CustomTabScreenViewModel(
                 uiStateFlow.update {
                     BrowserScreenUiState(
                         urlBarSuggestions = suggestions,
+                        groupTabCount = null,
                         callbacks = callbacks,
                     )
                 }

--- a/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/WebAppScreenViewModel.kt
+++ b/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/WebAppScreenViewModel.kt
@@ -30,6 +30,7 @@ class WebAppScreenViewModel(
     val uiState: StateFlow<BrowserScreenUiState> = MutableStateFlow(
         BrowserScreenUiState(
             urlBarSuggestions = UrlBarSuggestionsUiState(),
+            groupTabCount = null,
             callbacks = callbacks,
         ),
     ).also { uiStateFlow ->
@@ -38,6 +39,7 @@ class WebAppScreenViewModel(
                 uiStateFlow.update {
                     BrowserScreenUiState(
                         urlBarSuggestions = suggestions,
+                        groupTabCount = null,
                         callbacks = callbacks,
                     )
                 }

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -45,18 +44,16 @@ fun BrowserScreen(
     uiState: BrowserScreenUiState,
     browserTabController: BrowserTabController,
     onSelectTab: (String) -> Unit,
-    previewHeaderContent: @Composable (modifier: Modifier, tab: BrowserTab, tabCount: Int) -> Unit,
+    previewHeaderContent: @Composable (modifier: Modifier, tab: BrowserTab, tabCount: Int?) -> Unit,
     browserTabContent: @Composable (
         modifier: Modifier,
         selectedTab: BrowserTab,
-        tabCount: Int,
+        tabCount: Int?,
         onToolbarHorizontalDrag: (Float) -> Unit,
         onToolbarDragEnd: () -> Unit,
     ) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val tabStoreState by browserTabController.tabStoreState.collectAsState()
-    val tabs = remember(tabStoreState, browserTabController) { browserTabController.tabs }
     val prevTab = uiState.swipePreview.previousTab
     val nextTab = uiState.swipePreview.nextTab
 
@@ -100,7 +97,7 @@ fun BrowserScreen(
         prevTab?.let { tab ->
             TabPreviewPage(
                 tab = tab,
-                tabCount = tabs.size,
+                tabCount = uiState.groupTabCount,
                 previewHeaderContent = previewHeaderContent,
                 modifier = Modifier
                     .fillMaxSize()
@@ -112,7 +109,7 @@ fun BrowserScreen(
         nextTab?.let { tab ->
             TabPreviewPage(
                 tab = tab,
-                tabCount = tabs.size,
+                tabCount = uiState.groupTabCount,
                 previewHeaderContent = previewHeaderContent,
                 modifier = Modifier
                     .fillMaxSize()
@@ -126,7 +123,7 @@ fun BrowserScreen(
                 .fillMaxSize()
                 .offset { IntOffset(swipeOffset.value.roundToInt(), 0) },
             selectedTab,
-            tabs.size,
+            uiState.groupTabCount,
             { delta ->
                 coroutineScope.launch {
                     val maxOffset = if (prevTab != null) pageWidthPx else 0f
@@ -166,8 +163,8 @@ fun BrowserScreen(
 @Composable
 private fun TabPreviewPage(
     tab: BrowserTab,
-    tabCount: Int,
-    previewHeaderContent: @Composable (modifier: Modifier, tab: BrowserTab, tabCount: Int) -> Unit,
+    tabCount: Int?,
+    previewHeaderContent: @Composable (modifier: Modifier, tab: BrowserTab, tabCount: Int?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // 上部（ステータスバー）は BrowserToolBar の背景色で塗りつぶすため除外する

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreenUiState.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreenUiState.kt
@@ -5,6 +5,7 @@ import net.matsudamper.browser.BrowserTab
 data class BrowserScreenUiState(
     val urlBarSuggestions: UrlBarSuggestionsUiState,
     val swipePreview: SwipePreviewUiState = SwipePreviewUiState(),
+    val groupTabCount: Int?,
     val callbacks: Callbacks,
 ) {
     data class SwipePreviewUiState(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab count handling to gracefully display or hide count information when unavailable during certain app states.

* **Features**
  * Enhanced support for group-based tab counting, allowing the app to display tab counts specific to tab groups when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->