### PR TITLE
Wrap ByteArray preview images in TabPreviewImage class

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -54,16 +54,24 @@ class GeckoSurfaceResumeTest {
     private fun waitForNonBlackGeckoPixels(timeoutMillis: Long = 30_000): Bitmap {
         val deadline = System.currentTimeMillis() + timeoutMillis
         var latestBitmap: Bitmap? = null
+        var lastError: Throwable? = null
         while (System.currentTimeMillis() < deadline) {
-            latestBitmap = captureGeckoPixels()
-            if (!latestBitmap.isMostlyBlack()) {
-                return latestBitmap
+            try {
+                latestBitmap = captureGeckoPixels()
+                if (!latestBitmap.isMostlyBlack()) {
+                    return latestBitmap
+                }
+            } catch (e: AssertionError) {
+                // Activity リジューム直後は GeckoView の Compositor がまだ準備できておらず
+                // capturePixels() が失敗することがある。一時的なエラーとしてリトライする。
+                lastError = e
             }
             Thread.sleep(250L)
         }
         error(
-            "GeckoView pixels stayed mostly black. " +
-                "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}",
+            "GeckoView pixels stayed mostly black or capture failed. " +
+                "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}, " +
+                "lastError=$lastError",
         )
     }
 

--- a/feature-tabs/src/main/kotlin/net/matsudamper/browser/screen/tab/TabsScreenViewModel.kt
+++ b/feature-tabs/src/main/kotlin/net/matsudamper/browser/screen/tab/TabsScreenViewModel.kt
@@ -17,6 +17,7 @@ import net.matsudamper.browser.core.TabStoreState
 import net.matsudamper.browser.data.TabGroupData
 import net.matsudamper.browser.data.TabGroupRepository
 import net.matsudamper.browser.data.tab.TabGroupAssignment
+import net.matsudamper.browser.ui.tabs.TabPreviewImage
 import net.matsudamper.browser.ui.tabs.TabsScreenTabData
 import net.matsudamper.browser.ui.tabs.TabsScreenUiState
 
@@ -98,7 +99,7 @@ class TabsScreenViewModel(
                             TabsScreenTabData(
                                 id = tab.id,
                                 title = tab.title,
-                                previewBitmapArray = tab.previewBitmapArray,
+                                previewImage = tab.previewBitmapArray?.let { TabPreviewImage(it) },
                             )
                         }
                 }
@@ -311,7 +312,7 @@ class TabsScreenViewModel(
                     TabsScreenTabData(
                         id = tab.id,
                         title = tab.title,
-                        previewBitmapArray = tab.previewBitmapArray,
+                        previewImage = tab.previewBitmapArray?.let { TabPreviewImage(it) },
                     )
                 }
         }

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
@@ -1,5 +1,7 @@
 package net.matsudamper.browser.ui.tabs
 
+import android.graphics.Bitmap
+import android.util.LruCache
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -77,6 +79,15 @@ internal fun GroupTabGrid(
             gridState = gridState,
             onMove = onReorderTabs,
         )
+        // デコード済み Bitmap を保持してスクロール往復時の再デコードを避ける。
+        // 画面を離れる（GroupTabGrid がコンポジションから抜ける）と破棄される。
+        // キーは TabPreviewImage（contentEquals/contentHashCode 実装済み）なので
+        // プレビュー内容が変わった際は自然にキャッシュミスする。
+        val bitmapCache = remember {
+            object : LruCache<TabPreviewImage, Bitmap>(TAB_BITMAP_CACHE_BYTES) {
+                override fun sizeOf(key: TabPreviewImage, value: Bitmap): Int = value.byteCount
+            }
+        }
 
         // ドラッグ状態を上位コンポーザブルに通知する
         LaunchedEffect(dragDropState.isDragging, dragDropState.dragCenterInRoot) {
@@ -94,7 +105,6 @@ internal fun GroupTabGrid(
         LazyVerticalGrid(
             columns = GridCells.Fixed(columns),
             state = gridState,
-            beyondBoundsItemCount = 4,
             modifier = Modifier
                 .fillMaxSize()
                 .onGloballyPositioned { coordinates ->
@@ -142,6 +152,7 @@ internal fun GroupTabGrid(
                         if (!dragDropState.isDragging) onSelectTab(tabId)
                     },
                     onCloseTab = onCloseTab,
+                    bitmapCache = bitmapCache,
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(TabsLayoutDefaults.cardAspectRatio)
@@ -169,6 +180,7 @@ internal fun GroupTabGrid(
                         selected = overlayTab.id == selectedTabId,
                         onSelectTab = {},
                         onCloseTab = {},
+                        bitmapCache = bitmapCache,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -176,6 +188,11 @@ internal fun GroupTabGrid(
         }
     }
 }
+
+// タブサムネイルキャッシュの上限（バイト）。16MiB。
+// タブカードは inSampleSize=2 でデコードするため、1枚あたり数百KB程度。
+// 典型的なタブ数（〜50）をカバーできる容量。
+private const val TAB_BITMAP_CACHE_BYTES: Int = 16 * 1024 * 1024
 
 
 @Composable

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
@@ -94,6 +94,7 @@ internal fun GroupTabGrid(
         LazyVerticalGrid(
             columns = GridCells.Fixed(columns),
             state = gridState,
+            beyondBoundsItemCount = 4,
             modifier = Modifier
                 .fillMaxSize()
                 .onGloballyPositioned { coordinates ->

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabCard.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabCard.kt
@@ -103,10 +103,11 @@ internal fun TabCard(
                 contentAlignment = Alignment.Center,
             ) {
                 var bitmap: Bitmap? by remember { mutableStateOf(null) }
-                LaunchedEffect(tab.previewBitmapArray) {
-                    val array = tab.previewBitmapArray ?: return@LaunchedEffect
+                LaunchedEffect(tab.previewImage) {
+                    val array = tab.previewImage?.bytes ?: return@LaunchedEffect
                     bitmap = withContext(Dispatchers.Default) {
-                        BitmapFactory.decodeByteArray(array, 0, array.size)
+                        val options = BitmapFactory.Options().apply { inSampleSize = 2 }
+                        BitmapFactory.decodeByteArray(array, 0, array.size, options)
                     }
                 }
 

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabCard.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabCard.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser.ui.tabs
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.LruCache
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
@@ -43,6 +44,7 @@ internal fun TabCard(
     selected: Boolean,
     onSelectTab: (String) -> Unit,
     onCloseTab: (String) -> Unit,
+    bitmapCache: LruCache<TabPreviewImage, Bitmap>,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -102,12 +104,31 @@ internal fun TabCard(
                     .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center,
             ) {
-                var bitmap: Bitmap? by remember { mutableStateOf(null) }
-                LaunchedEffect(tab.previewImage) {
-                    val array = tab.previewImage?.bytes ?: return@LaunchedEffect
-                    bitmap = withContext(Dispatchers.Default) {
+                val image = tab.previewImage
+                // キャッシュにヒットすれば初期値として即表示する。
+                // remember の key を指定しないのは、previewImage が更新されている間も
+                // 古い Bitmap を表示し続けてチラつきを避けるため。
+                var bitmap: Bitmap? by remember {
+                    mutableStateOf(image?.let { bitmapCache.get(it) })
+                }
+                LaunchedEffect(image) {
+                    if (image == null) {
+                        bitmap = null
+                        return@LaunchedEffect
+                    }
+                    val cached = bitmapCache.get(image)
+                    if (cached != null) {
+                        bitmap = cached
+                        return@LaunchedEffect
+                    }
+                    val array = image.bytes
+                    val decoded = withContext(Dispatchers.Default) {
                         val options = BitmapFactory.Options().apply { inSampleSize = 2 }
                         BitmapFactory.decodeByteArray(array, 0, array.size, options)
+                    }
+                    if (decoded != null) {
+                        bitmapCache.put(image, decoded)
+                        bitmap = decoded
                     }
                 }
 

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
@@ -464,11 +464,11 @@ private fun Preview() {
     val groupedTabs = remember {
         listOf(
             listOf(
-                TabsScreenTabData(id = "1", title = "Example Domain", previewBitmapArray = null),
-                TabsScreenTabData(id = "2", title = "Google", previewBitmapArray = null),
+                TabsScreenTabData(id = "1", title = "Example Domain", previewImage = null),
+                TabsScreenTabData(id = "2", title = "Google", previewImage = null),
             ),
             listOf(
-                TabsScreenTabData(id = "3", title = "GitHub", previewBitmapArray = null),
+                TabsScreenTabData(id = "3", title = "GitHub", previewImage = null),
             ),
         )
     }

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreenUiState.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreenUiState.kt
@@ -33,5 +33,18 @@ data class TabsScreenUiState(
 data class TabsScreenTabData(
     val id: String,
     val title: String,
-    val previewBitmapArray: ByteArray?,
+    val previewImage: TabPreviewImage?,
 )
+
+// ByteArray を contentEquals で比較するラッパー。
+// data class の自動生成 equals は配列の参照等値になるため、
+// ラッパー側で正しいコンテンツ等値を実装する。
+class TabPreviewImage(val bytes: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TabPreviewImage) return false
+        return bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int = bytes.contentHashCode()
+}


### PR DESCRIPTION
## Summary
Refactored the tab preview image handling to wrap `ByteArray` in a dedicated `TabPreviewImage` class that properly implements content-based equality and hashing, fixing comparison issues in data classes.

## Key Changes
- Created `TabPreviewImage` wrapper class with proper `contentEquals()` implementation for `ByteArray` comparison
  - Implements `equals()` using `contentEquals()` instead of reference equality
  - Implements `hashCode()` using `contentHashCode()`
- Renamed `previewBitmapArray` property to `previewImage` in `TabsScreenTabData`
- Updated `TabCard` to use the new `TabPreviewImage` class and access bytes via `.bytes` property
- Added bitmap decoding optimization with `inSampleSize = 2` option to reduce memory usage
- Updated `TabsScreenViewModel` to wrap `ByteArray` in `TabPreviewImage` at the mapping layer
- Added `beyondBoundsItemCount = 4` to `GroupTabGrid` LazyVerticalGrid for improved scrolling performance
- Updated preview data in `TabsScreen` to use new property name

## Implementation Details
The `TabPreviewImage` class solves a critical issue where data class auto-generated `equals()` would use reference equality for `ByteArray` fields, causing unnecessary recompositions and comparison failures. By wrapping the array in a class with proper content-based equality, Compose can now correctly detect when preview images actually change.

https://claude.ai/code/session_016juFqm3XnvXZ2PyyPnxW9s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster tab preview loading with an in-memory cache and smaller decoded previews for lower memory use and smoother scrolling/dragging.

* **Bug Fixes**
  * More reliable preview updates by changing how preview data is represented and compared to avoid unnecessary reloads.

* **Tests**
  * Improved stability of a resume/check test by retrying captures and providing clearer failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->