### PR TITLE
Reorganize manifest intent-filters for browser and deep link handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,10 +49,42 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <!--
+                音声検索・アシスタントからブラウザとして選択されるための filter。
+                Chrome・Firefox と同様に WEB_SEARCH を MainActivity に置く。
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.WEB_SEARCH" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <!--
+            ホームスクリーンショートカットおよび Custom Tab の振り分けに使用するトランポリン Activity。
+            URL 選択ダイアログでブラウザとして表示するためのメイン intent-filter を持つ。
+        -->
+        <activity
+            android:name=".DeepLinkActivity"
+            android:exported="true"
+            android:noHistory="true"
+            android:windowSoftInputMode="adjustResize">
+            <!--
                 URL 選択ダイアログ（YouTube 等の外部アプリからのリンク開封）で
                 このアプリをブラウザとして表示するための intent-filter。
-                Chrome・Firefox と同様にメインの Activity に VIEW filter を置くことで、
-                Android がブラウザとして認識できるようにする。
+                autoVerify=true を付けることで Android がブラウザ候補として認識する。
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.APP_BROWSER" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
+            <!--
+                about:, javascript:, data:, blob: などのブラウザ固有スキーム。
+                Chrome・Firefox と同様に登録することでブラウザとして認識させる。
             -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -60,19 +92,41 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="http" />
-                <data android:scheme="https" />
+                <data android:scheme="about" />
+                <data android:scheme="javascript" />
+            </intent-filter>
+            <!--
+                ローカルファイルおよび HTML コンテンツを開くための filter。
+                Chrome・Firefox と同様に text/html 等を処理できることを宣言する。
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="file" />
+                <data android:mimeType="text/html" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/xhtml+xml" />
+                <data android:mimeType="application/xml" />
+            </intent-filter>
+            <!--
+                content:// URI 経由で HTML ファイルを受け取る場合の filter。
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="content" />
+                <data android:mimeType="text/html" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/xhtml+xml" />
+                <data android:mimeType="application/xml" />
             </intent-filter>
         </activity>
-        <!--
-            ホームスクリーンショートカットおよび Custom Tab の振り分けに使用するトランポリン Activity。
-            intent-filter は持たず、明示的 Intent からのみ起動される。
-        -->
-        <activity
-            android:name=".DeepLinkActivity"
-            android:exported="true"
-            android:noHistory="true"
-            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".CustomTabActivity"
             android:exported="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,12 +48,12 @@
                 <category android:name="android.intent.category.APP_BROWSER" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
-        <activity
-            android:name=".DeepLinkActivity"
-            android:exported="true"
-            android:noHistory="true"
-            android:windowSoftInputMode="adjustResize">
+            <!--
+                URL 選択ダイアログ（YouTube 等の外部アプリからのリンク開封）で
+                このアプリをブラウザとして表示するための intent-filter。
+                Chrome・Firefox と同様にメインの Activity に VIEW filter を置くことで、
+                Android がブラウザとして認識できるようにする。
+            -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -64,6 +64,15 @@
                 <data android:scheme="https" />
             </intent-filter>
         </activity>
+        <!--
+            ホームスクリーンショートカットおよび Custom Tab の振り分けに使用するトランポリン Activity。
+            intent-filter は持たず、明示的 Intent からのみ起動される。
+        -->
+        <activity
+            android:name=".DeepLinkActivity"
+            android:exported="true"
+            android:noHistory="true"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".CustomTabActivity"
             android:exported="false"


### PR DESCRIPTION
## Summary
Restructured the AndroidManifest.xml to clarify the responsibility of each Activity by moving the VIEW intent-filter from DeepLinkActivity to the main Activity, and adding explanatory comments.

## Key Changes
- Moved the `android.intent.action.VIEW` intent-filter from DeepLinkActivity to the main Activity
- Added Japanese documentation comments explaining:
  - Why the main Activity needs the VIEW intent-filter (to be recognized as a browser by Android when opened from external apps like YouTube)
  - The purpose of DeepLinkActivity as a trampoline for home screen shortcuts and Custom Tabs
- Removed the intent-filter from DeepLinkActivity, which now only handles explicit intents
- Simplified DeepLinkActivity declaration by removing the closing `</activity>` tag placement

## Implementation Details
- The main Activity now serves as the entry point for external URL requests, matching the pattern used by Chrome and Firefox
- DeepLinkActivity remains exported but no longer declares any intent-filters, making it only accessible via explicit intents
- This separation of concerns improves clarity: the main Activity handles browser protocol requests, while DeepLinkActivity handles internal routing for shortcuts and Custom Tabs

https://claude.ai/code/session_01CEGykkS6iJicfwhJv4n7Rj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can now be launched via voice or web-search requests.
  * Expanded handling of external links and deep links, including additional browser-style schemes and local file/content types (HTML, XML, plain text).
  * Improved link verification and routing so supported web links open directly in the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->