### PR TITLE
PRビルド配布APKをarm64-v8aのみに制限

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build debug APK
         env:
           DEBUG_KEYSTORE_PATH: ${{ runner.temp }}/debug.keystore
-        run: ./gradlew :app:assembleDebug
+        run: ./gradlew :app:assembleDebug -Pandroid.injected.build.abi=arm64-v8a
 
       - name: Rename APK with branch and short hash
         env:
@@ -48,8 +48,12 @@ jobs:
           SAFE_REPO="${REPOSITORY##*/}"
           SAFE_BRANCH="${BRANCH_NAME//\//-}"
           APK_NAME="app-${SAFE_REPO}-${SAFE_BRANCH}-${SHORT_SHA}.apk"
-          mv app/build/outputs/apk/debug/app-debug.apk \
-             "app/build/outputs/apk/debug/${APK_NAME}"
+          APK_SOURCE_PATH="$(find app/build/outputs/apk/debug -maxdepth 1 -name '*arm64-v8a*debug.apk' | head -n 1)"
+          if [ -z "${APK_SOURCE_PATH}" ]; then
+            echo "arm64-v8a向けAPKが見つかりませんでした。"
+            exit 1
+          fi
+          mv "${APK_SOURCE_PATH}" "app/build/outputs/apk/debug/${APK_NAME}"
           echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"
           echo "APK_PATH=app/build/outputs/apk/debug/${APK_NAME}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
### Motivation
- PR向けCIで配布するDebug APKを`arm64-v8a`の成果物に限定して不要なABIのアーティファクト配布を防ぐため。

### Description
- `.github/workflows/pr-build.yml`の`assembleDebug`呼び出しに`-Pandroid.injected.build.abi=arm64-v8a`を追加してビルドABIを指定しました。 
- APKリネーム処理を固定パス前提から、`find`で`*arm64-v8a*debug.apk`を探索して該当ファイルをリネームする実装に変更しました。 
- `arm64-v8a`向けAPKが見つからない場合にCIを失敗させるガード（エラーメッセージと`exit 1`）を追加しました。 
- 環境変数`APK_NAME`/`APK_PATH`の設定は従来通り行いますが、参照するファイルは探索結果に基づきます。 

### Testing
- ローカルで変更差分を確認するために`git diff -- .github/workflows/pr-build.yml`を実行し、変更が反映されていることを確認しました（成功）。
- 行番号付きで該当箇所を表示するために`nl -ba .github/workflows/pr-build.yml | sed -n '30,80p'`を実行し、挿入した`-Pandroid.injected.build.abi=arm64-v8a`と`find`ロジックが正しく追加されていることを確認しました（成功）。
- 実際のワークフロー実行（GitHub Actions上でのビルド／アーティファクト生成）はこの変更後のCIで検証される予定です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f87246f8832596edae561e176a08)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced CI/CD build process with improved Android APK handling, including more robust detection and validation mechanisms.
* Strengthened error reporting during builds to provide explicit feedback when issues occur, enabling faster problem identification and resolution.
* Optimized build configuration to ensure consistent and reliable artifact generation across different build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->