### PR TITLE
fab分paddingを入れる

### DIFF
--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
@@ -58,6 +58,7 @@ internal fun GroupTabGrid(
     onTabDragStateChanged: (isDragging: Boolean, centerInRoot: Offset) -> Unit,
     onTabDropped: (tabId: String) -> Unit,
     onTabLongPressWithoutDrag: (tabId: String) -> Unit,
+    floatingActionButtonBoundsInRoot: Rect?,
     modifier: Modifier = Modifier,
 ) {
     if (tabs.isEmpty()) {
@@ -79,6 +80,21 @@ internal fun GroupTabGrid(
             gridState = gridState,
             onMove = onReorderTabs,
         )
+        var gridBoundsInRoot by remember { mutableStateOf(Rect.Zero) }
+        val density = LocalDensity.current
+        val floatingActionButtonBottomPadding = remember(
+            density,
+            floatingActionButtonBoundsInRoot,
+            gridBoundsInRoot,
+        ) {
+            if (floatingActionButtonBoundsInRoot == null || !floatingActionButtonBoundsInRoot.overlapsHorizontally(gridBoundsInRoot)) {
+                0.dp
+            } else {
+                with(density) {
+                    (gridBoundsInRoot.bottom - floatingActionButtonBoundsInRoot.top).coerceAtLeast(0f).toDp()
+                }
+            }
+        }
         // デコード済み Bitmap を保持してスクロール往復時の再デコードを避ける。
         // 画面を離れる（GroupTabGrid がコンポジションから抜ける）と破棄される。
         // キーは TabPreviewImage（contentEquals/contentHashCode 実装済み）なので
@@ -108,7 +124,9 @@ internal fun GroupTabGrid(
             modifier = Modifier
                 .fillMaxSize()
                 .onGloballyPositioned { coordinates ->
-                    dragDropState.gridBoundsInRoot = coordinates.boundsInRoot()
+                    val boundsInRoot = coordinates.boundsInRoot()
+                    dragDropState.gridBoundsInRoot = boundsInRoot
+                    gridBoundsInRoot = boundsInRoot
                 }
                 .pointerInput(dragDropState) {
                     detectDragGesturesAfterLongPress(
@@ -133,7 +151,12 @@ internal fun GroupTabGrid(
                         onDragCancel = { dragDropState.onDragEnd() },
                     )
                 },
-            contentPadding = PaddingValues(TabsLayoutDefaults.gridPadding),
+            contentPadding = PaddingValues(
+                start = TabsLayoutDefaults.gridPadding,
+                top = TabsLayoutDefaults.gridPadding,
+                end = TabsLayoutDefaults.gridPadding,
+                bottom = TabsLayoutDefaults.gridPadding + floatingActionButtonBottomPadding,
+            ),
             verticalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
             horizontalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
         ) {
@@ -166,7 +189,6 @@ internal fun GroupTabGrid(
         if (dragDropState.isDragging) {
             val overlayTab = tabs.firstOrNull { it.id == dragDropState.draggedItemKey }
             if (overlayTab != null) {
-                val density = LocalDensity.current
                 val widthDp = with(density) { dragDropState.draggedItemSize.width.toDp() }
                 val heightDp = with(density) { dragDropState.draggedItemSize.height.toDp() }
                 Box(
@@ -187,6 +209,10 @@ internal fun GroupTabGrid(
             }
         }
     }
+}
+
+private fun Rect.overlapsHorizontally(other: Rect): Boolean {
+    return left < other.right && right > other.left
 }
 
 // タブサムネイルキャッシュの上限（バイト）。16MiB。

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
@@ -245,6 +247,8 @@ private fun TabsScreenLoadedContent(
     // 削除確認ダイアログの対象グループインデックス
     var deleteDialogGroupIndex by remember { mutableStateOf<Int?>(null) }
 
+    var floatingActionButtonBoundsInRoot by remember { mutableStateOf<Rect?>(null) }
+
     Scaffold(
         modifier = modifier
             .fillMaxSize(),
@@ -254,7 +258,9 @@ private fun TabsScreenLoadedContent(
                 onClick = { onOpenNewTab(groups.getOrNull(activeGroupIndex)?.id) },
                 modifier = Modifier
                     .testTag(TabsScreenTestTags.AddTabButton.testTag)
-                    .padding(16.dp),
+                    .onGloballyPositioned { coordinates ->
+                        floatingActionButtonBoundsInRoot = coordinates.boundsInRoot()
+                    },
             ) {
                 Icon(imageVector = Icons.Default.Add, contentDescription = "新規タブ")
             }
@@ -364,6 +370,7 @@ private fun TabsScreenLoadedContent(
                         onTabLongPressWithoutDrag = { tabId ->
                             moveDialogTabId = tabId
                         },
+                        floatingActionButtonBoundsInRoot = floatingActionButtonBoundsInRoot,
                         modifier = Modifier.weight(1f),
                     )
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Tab grid now dynamically adjusts its bottom padding when a floating action button is present, preventing content overlap and optimizing screen space allocation for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->