### PR TITLE
dialog等でstatus barが消えた場合にURLバーのレイアウトが崩れる問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -8,18 +8,23 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
@@ -209,6 +214,7 @@ data class UrlInputState(
 )
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 internal fun BrowserToolbar(
     isFocused: Boolean,
     gestureState: BrowserToolBarGestureState?,
@@ -245,12 +251,13 @@ internal fun BrowserToolbar(
             ),
     ) {
         Row(
-            // ステータスバー領域の高さ分だけコンテンツを下に押し出す。
+            // ステータスバーが一時的に非表示扱いになっても通常時の領域分だけコンテンツを下に押し出す。
             // Surface の背景色はステータスバー領域まで延びて塗りつぶされる。
-            // 親が safeDrawingPadding を適用済みの場合はインセットが消費されているため 0 になる。
             // IntrinsicSize.Min で Row 高さを子の最小 intrinsic 高さに合わせる（URL バーの自然高さ）。
             modifier = Modifier
-                .statusBarsPadding()
+                .windowInsetsPadding(
+                    WindowInsets.statusBarsIgnoringVisibility.only(WindowInsetsSides.Top)
+                )
                 .height(IntrinsicSize.Min),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabToolbar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabToolbar.kt
@@ -2,10 +2,15 @@ package net.matsudamper.browser
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -36,6 +41,7 @@ internal sealed interface CustomTabToolbarTestTags {
 }
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 internal fun CustomTabToolbar(
     title: String,
     url: String,
@@ -66,7 +72,9 @@ internal fun CustomTabToolbar(
             modifier = Modifier
                 .fillMaxWidth()
                 // ステータスバー領域はSurfaceの背景色で塗りつぶし、コンテンツをその下に押し出す
-                .statusBarsPadding()
+                .windowInsetsPadding(
+                    WindowInsets.statusBarsIgnoringVisibility.only(WindowInsetsSides.Top)
+                )
                 .padding(horizontal = 4.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app/src/main/kotlin/net/matsudamper/browser/FindInPageBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/FindInPageBar.kt
@@ -4,16 +4,21 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -42,6 +47,7 @@ import androidx.compose.ui.unit.sp
 import net.matsudamper.browser.resources.R as ResourcesR
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 internal fun FindInPageBar(
     query: String,
     matchCurrent: Int,
@@ -65,7 +71,9 @@ internal fun FindInPageBar(
                 // ステータスバー領域の高さ分だけコンテンツを下に押し出す。
                 // Surface の背景色はステータスバー領域まで延びて塗りつぶされる。
                 modifier = Modifier
-                    .statusBarsPadding()
+                    .windowInsetsPadding(
+                        WindowInsets.statusBarsIgnoringVisibility.only(WindowInsetsSides.Top)
+                    )
                     .padding(horizontal = 8.dp, vertical = 4.dp),
             ) {
                 Box(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed status bar spacing for multiple toolbar components (main toolbar, tab toolbar, and find-in-page bar) to ensure proper alignment and prevent overlapping with system UI.
* Improved content offset handling to maintain consistent spacing relative to the system status bar, including when visibility state temporarily changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->