### PR TITLE
ホーム画面アイコン取得: manifest基準の相対URL解決と試行上限の改善

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/HomeScreenIconFetcher.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/HomeScreenIconFetcher.kt
@@ -21,6 +21,7 @@ internal object HomeScreenIconFetcher {
     private const val FETCH_TIMEOUT_MS = 8000
     private const val MAX_HTML_BYTES = 256 * 1024
     private const val MAX_SHORTCUT_ICON_SIZE = 192
+    private const val MAX_ICON_FETCH_ATTEMPTS = 20
     private const val USER_AGENT = "Mozilla/5.0 (Android) Browsem"
 
     private val linkTagRegex = Regex("""<link\b[^>]*>""", RegexOption.IGNORE_CASE)
@@ -45,7 +46,7 @@ internal object HomeScreenIconFetcher {
             ?: HtmlIconCandidates()
         val storedManifestIcons = parseManifestIconCandidates(
             manifestJson = webAppManifestJson,
-            baseUri = pageUri,
+            fallbackBaseUri = pageUri,
             source = IconSource.StoredManifest,
         )
         val linkedManifestIcons = pageHtmlIcons.manifestUrls
@@ -54,7 +55,7 @@ internal object HomeScreenIconFetcher {
                 val manifestUri = runCatching { URI(manifestUrl) }.getOrNull() ?: return@flatMap emptyList()
                 parseManifestIconCandidates(
                     manifestJson = fetchText(manifestUrl, MAX_HTML_BYTES),
-                    baseUri = manifestUri,
+                    fallbackBaseUri = manifestUri,
                     source = IconSource.LinkedManifest,
                 )
             }
@@ -70,9 +71,11 @@ internal object HomeScreenIconFetcher {
                 compareByDescending<IconCandidate> { it.source.priority }
                     .thenByDescending { it.size },
             )
-            .take(8)
 
+        var attemptCount = 0
         for (candidate in candidates) {
+            if (attemptCount >= MAX_ICON_FETCH_ATTEMPTS) break
+            attemptCount++
             val bitmap = fetchBitmap(candidate.url) ?: continue
             return bitmap.scaleForShortcut()
         }
@@ -120,11 +123,16 @@ internal object HomeScreenIconFetcher {
 
     private fun parseManifestIconCandidates(
         manifestJson: String?,
-        baseUri: URI,
+        fallbackBaseUri: URI,
         source: IconSource,
     ): List<IconCandidate> {
         if (manifestJson.isNullOrBlank()) return emptyList()
         val manifest = runCatching { JSONObject(manifestJson) }.getOrNull() ?: return emptyList()
+        val manifestBaseUri = manifest.optString("href")
+            .takeIf { it.isNotBlank() }
+            ?.let { runCatching { URI(it) }.getOrNull() }
+            ?.takeIf { it.isHttpUri() }
+            ?: fallbackBaseUri
         val icons = manifest.optJSONArray("icons") ?: return emptyList()
         return buildList {
             for (index in 0 until icons.length()) {
@@ -134,7 +142,7 @@ internal object HomeScreenIconFetcher {
                     continue
                 }
                 val src = icon.optString("src").takeIf { it.isNotBlank() } ?: continue
-                val url = resolveUrl(baseUri, src) ?: continue
+                val url = resolveUrl(manifestBaseUri, src) ?: continue
                 add(
                     IconCandidate(
                         url = url,


### PR DESCRIPTION
### Motivation
- 保存済みの Web App Manifest を使ったアイコン候補生成で `icons[].src` の相対パスがページURL基準で誤解決される問題に対応するため。 
- 候補を事前に `take(8)` で切り詰めることで下位候補（例: `/favicon.ico`）が除外されうる問題を解消するため。

### Description
- `HomeScreenIconFetcher` に `MAX_ICON_FETCH_ATTEMPTS` を追加して実際のダウンロード試行回数で上限管理するように変更した（`20` 回）。
- `parseManifestIconCandidates` の引数を `fallbackBaseUri` にし、manifest JSON に `href` がある場合はそれを `manifestBaseUri` として優先し `icons[].src` を解決するようにした。
- HTML から取得したリンクや外部リンク版 manifest のパース呼び出し側を `fallbackBaseUri` を渡す形式に更新した。 
- 事前の `.take(8)` を廃止し、候補一覧を維持したままループ内でダウンロード試行回数をカウントして上限に達したら抜ける実装に変更した。
- 変更対象ファイル: `app/src/main/kotlin/net/matsudamper/browser/HomeScreenIconFetcher.kt`。

### Testing
- `./gradlew :app:compileDebugKotlin` を実行してコンパイルが成功することを確認済み。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e946b7dfa48325a6eed7e8da396863)