### PR TITLE
初回起動時にタブ件数表示が空になる問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
@@ -108,6 +108,13 @@ internal class BrowserViewModel(
         // バックスタックの状態に依存せず、復元は必ず実行される。
         viewModelScope.launch {
             val tabId = restoreTabs()
+            // 初回起動時にタブ件数表示が空になるのを防ぐため、タブ一覧画面を開く前に
+            // デフォルトグループを作成し、復元済みタブを割り当てておく。
+            // TabsScreenViewModel でも同様の初期化を行うが、最初に表示されるのは
+            // BrowserScreen であり、グループ割当が無いと groupTabCount が null になる。
+            tabGroupRepository.createDefaultGroupIfEmpty(
+                browserTabController.tabs.map { it.tabId },
+            )
             eventHandler.trySend { it.onTabsRestored(tabId) }
         }
     }


### PR DESCRIPTION
タブグループのデフォルト初期化が TabsScreenViewModel.init でのみ行われていたため、 初回起動直後は BrowserScreen の groupTabCount が null となり件数が描画されなかった。 BrowserViewModel の restoreTabs 完了直後に createDefaultGroupIfEmpty を実行することで、 BrowserScreenViewModel が生成される前にグループ割当が存在する状態を保証する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where default tab groups weren't properly initialized after restoring tabs, causing tab count and other UI elements to display incorrectly on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->