### PR TITLE
SPA 遷移時にプレビュー画像が残る/一瞬見える問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -222,7 +222,9 @@ internal class BrowserTabScreenState(
         if (tabHistoryCurrentIndex < tabHistoryItems.lastIndex) {
             tabHistoryCurrentIndex++
         }
-        markRenderingPending()
+        // 履歴移動先が SPA 同一ドキュメント遷移かフルページロードか不明のため
+        // ここでは markRenderingPending() を呼ばず、フルロードなら onPageStart で
+        // プレースホルダーを出す。SPA では一瞬プレースホルダーが見えるのを防ぐ
         session.goForward()
     }
 
@@ -232,7 +234,6 @@ internal class BrowserTabScreenState(
         if (tabHistoryCurrentIndex > 0) {
             tabHistoryCurrentIndex--
         }
-        markRenderingPending()
         session.goBack()
     }
 
@@ -241,7 +242,6 @@ internal class BrowserTabScreenState(
         if (targetIndex == tabHistoryCurrentIndex) return
         skipHistoryRecordCount++
         tabHistoryCurrentIndex = targetIndex
-        markRenderingPending()
         session.gotoHistoryIndex(targetIndex)
     }
 
@@ -649,6 +649,13 @@ internal class BrowserTabScreenState(
         if (isFullPageLoadPending) {
             maybeResetToolbarColorOnPageStart(url)
             isFullPageLoadPending = false
+        } else {
+            // SPA 遷移（pushState / 同一ドキュメント内 history 移動）では
+            // onPageStart / onPageStop が発火しないため、onGoBack 等で
+            // markRenderingPending() により false になった renderReady が戻らず、
+            // プレースホルダーが被り続ける。GeckoView は既に新しいコンテンツを
+            // 描画しており、遷移前のページは FCP 済みなので両フラグを復帰させる
+            markRenderingDone()
         }
         currentPageUrl = url
         if (!isUrlInputFocused) {
@@ -899,6 +906,11 @@ internal class BrowserTabScreenState(
     private fun markRenderingPending() {
         renderReady = false
         previewCaptureReady = false
+    }
+
+    private fun markRenderingDone() {
+        renderReady = true
+        previewCaptureReady = true
     }
 
     private fun copyUrlToClipboard(url: String) {


### PR DESCRIPTION
- onGoBack / onGoForward / jumpToHistoryEntry の楽観的な markRenderingPending() を削除。フルロードなら onPageStart 側でプレースホルダーが出るため、 SPA 同一ドキュメント遷移時に一瞬プレースホルダーが見える問題を解消
- onLocationChange が SPA 遷移として発火した場合は markRenderingDone() で renderReady / previewCaptureReady を復帰させ、プレースホルダーが 被り続ける問題を解消