### PR TITLE
拡張機能の設定画面をカスタムタブで開く

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -415,10 +415,12 @@ private fun BrowserAppContent(
                                 it(object : ExtensionsScreenViewModel.Event {
                                     override fun navigateToExtensionSettings(url: String) {
                                         context.startActivity(
-                                            Intent(context, CustomTabActivity::class.java).apply {
-                                                action = Intent.ACTION_VIEW
-                                                data = Uri.parse(url)
-                                            }
+                                            Intent(
+                                                Intent.ACTION_VIEW,
+                                                Uri.parse(url),
+                                                context,
+                                                CustomTabActivity::class.java,
+                                            )
                                         )
                                     }
                                 })

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -1,5 +1,7 @@
 package net.matsudamper.browser
 
+import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
@@ -412,16 +414,12 @@ private fun BrowserAppContent(
                             extensionsViewModel.eventHandler.receiveAsFlow().collect {
                                 it(object : ExtensionsScreenViewModel.Event {
                                     override fun navigateToExtensionSettings(url: String) {
-                                        scope.launch {
-                                            val tabId = UUID.randomUUID().toString()
-                                            withContext(Dispatchers.Main) {
-                                                browserTabController.createAndAppendTab(
-                                                    tabId = tabId,
-                                                    initialUrl = url,
-                                                )
-                                                selectTab(tabId, null)
+                                        context.startActivity(
+                                            Intent(context, CustomTabActivity::class.java).apply {
+                                                action = Intent.ACTION_VIEW
+                                                data = Uri.parse(url)
                                             }
-                                        }
+                                        )
                                     }
                                 })
                             }


### PR DESCRIPTION
## 概要

Closes #324

拡張機能の設定ページを開く際、従来はメインブラウザに新規タブを作成して遷移していたが、`CustomTabActivity` を使って開くよう変更する。

## 変更内容

- `BrowserApp.kt` の `navigateToExtensionSettings` イベントハンドラを修正
  - `browserTabController.createAndAppendTab()` + `selectTab()` → `CustomTabActivity` を Intent で起動

## 動作の変化

| 変更前 | 変更後 |
|--------|--------|
| 拡張機能設定URLをメインブラウザの新規タブとして開く | `CustomTabActivity`（カスタムタブ）で開く |
| 設定確認後、タブ一覧に不要なタブが残る | 設定確認後、戻るボタンで拡張機能一覧に戻れる |

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsceJsDgkFXV144VLc1AFr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated extension settings navigation to open links using external browser tabs or Chrome Custom Tabs instead of creating internal browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->