### PR TITLE
ci: Androidインストルメンテーションテストに失敗時診断ログを追加

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -83,8 +83,34 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: テスト前のシステムリソース確認
+        run: |
+          echo "=== メモリ ==="
+          free -h
+          echo "=== ディスク空き容量 ==="
+          df -h
+          echo "=== CPU 数 ==="
+          nproc
+          echo "=== KVM デバイス ==="
+          ls -la /dev/kvm 2>/dev/null || echo "KVM デバイスが存在しません"
+
       - name: Run Android Instrumentation Tests (Managed Device)
         run: ./gradlew :app:pixel6Api34DebugAndroidTest
+
+      - name: テスト失敗時の診断情報収集
+        if: failure()
+        run: |
+          echo "=== テスト失敗時のメモリ ==="
+          free -h
+          echo "=== テスト失敗時のディスク ==="
+          df -h
+          echo "=== Gradle Managed Device ログファイル一覧 ==="
+          find app/build -name "*.log" 2>/dev/null | head -30 || true
+          find ~/.android -name "*.log" 2>/dev/null | head -30 || true
+          echo "=== adb デバイス一覧 ==="
+          adb devices 2>/dev/null || true
+          echo "=== ビルド出力ディレクトリ構造 ==="
+          find app/build/outputs -type f 2>/dev/null | head -50 || true
 
       - name: Upload Android test report
         if: always()
@@ -94,6 +120,16 @@ jobs:
           path: |
             app/build/reports/androidTests/managedDevice/debug/pixel6Api34
             app/build/outputs/androidTest-results/managedDevice/debug/pixel6Api34
+
+      - name: テスト失敗時の追加ログアップロード
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-test-failure-logs
+          path: |
+            app/build/outputs/managed_device_android_test_additional_output/
+            app/build/reports/androidTests/
+          retention-days: 7
 
   detekt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要\n\nmainへのpushで `android-test` ジョブ（`pixel6Api34DebugAndroidTest`）がランダムに失敗した際、原因を特定するための診断情報が不足しています。\n\nGradle Managed Device を使ったエミュレーターテストは、リソース枯渇・KVM初期化失敗・タイミング問題など環境起因で不安定になりやすいですが、現状ではテスト結果レポート以外に何も残りません。\n\n## 変更内容\n\n**テスト前のシステムリソース確認ステップを追加:**\n- メモリ使用量 (`free -h`)\n- ディスク空き容量 (`df -h`)\n- CPU数 (`nproc`)\n- KVMデバイスの存在確認\n\n**テスト失敗時の診断情報収集ステップを追加 (`if: failure()`):**\n- 失敗時点のメモリ・ディスク使用量\n- Gradle Managed Device が出力したログファイル一覧\n- `adb devices` でエミュレーターの接続状態\n- ビルド出力ディレクトリの構造\n\n**テスト失敗時の追加ログアーティファクトアップロード:**\n- `managed_device_android_test_additional_output/`\n- `reports/androidTests/` 全体\n- 7日間保持\n\n## 目的\n\n今後ランダム失敗が発生した際に、次のどれが原因かを特定できるようにする:\n- メモリ不足・ディスク不足によるエミュレーター起動失敗\n- KVM が正常に有効化されていない\n- テストのタイムアウト（どのテストケースまで実行されたか）\n- Gecko エンジン初期化の遅延

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkread8Sadf59XoVpUNoQh)_