### PR TITLE
Fix Compose UI test import path

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/WebAppActivityLaunchTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/WebAppActivityLaunchTest.kt
@@ -2,7 +2,7 @@ package net.matsudamper.browser
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4


### PR DESCRIPTION
## Summary
Updated the import statement for `createEmptyComposeRule` to use the correct API path from the Compose UI testing library.

## Changes
- Changed import from `androidx.compose.ui.test.junit4.v2.createEmptyComposeRule` to `androidx.compose.ui.test.junit4.createEmptyComposeRule`

## Details
The `v2` subpackage path was removed from the import, aligning with the current stable API of the Compose UI testing library. This ensures compatibility with the correct version of the testing utilities.

https://claude.ai/code/session_01WDvmV5ZjoPAA3hU8fxuR8j