### PR TITLE
Prevent overwriting preview bitmap on compression failure

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -694,7 +694,11 @@ internal class BrowserTabScreenState(
                 coroutineScope.launch(Dispatchers.IO) {
                     val stream = ByteArrayOutputStream()
                     previewBitmap.compress(Bitmap.CompressFormat.WEBP_LOSSY, 0, stream)
-                    browserTab.previewBitmap = stream.toByteArray()
+                    // compress失敗時は空バイトになるため、既存プレビューを上書きしない
+                    val bytes = stream.toByteArray()
+                    if (bytes.isNotEmpty()) {
+                        browserTab.previewBitmap = bytes
+                    }
                 }
             },
             { onCaptured?.invoke() },


### PR DESCRIPTION
## Summary
Added a safety check to prevent overwriting the existing preview bitmap when WebP compression fails or produces empty output.

## Key Changes
- Added validation to check if the compressed byte array is non-empty before updating `browserTab.previewBitmap`
- Only updates the preview bitmap if compression succeeds and produces valid output
- Preserves the existing preview bitmap when compression fails, maintaining the last known good state

## Implementation Details
The change wraps the bitmap assignment in a conditional check that verifies the compressed bytes are not empty. This prevents data loss scenarios where a compression failure (which results in an empty byte array) would overwrite a previously valid preview bitmap with empty data.

https://claude.ai/code/session_013H5NNq5vDgXe7yLCmoMxeQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tab preview capture by preventing invalid preview data from being stored, ensuring preview images aren't lost during capture failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->