### PR TITLE
拡張機能の設定ボタンを設定ページがある場合のみ表示

### DIFF
--- a/ui/extensions/src/main/kotlin/net/matsudamper/browser/ui/extensions/ExtensionsScreen.kt
+++ b/ui/extensions/src/main/kotlin/net/matsudamper/browser/ui/extensions/ExtensionsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -137,10 +136,6 @@ private fun ExtensionRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .selectable(
-                selected = false,
-                onClick = onOpenSettings,
-            )
             .padding(horizontal = 16.dp, vertical = 12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -170,11 +165,23 @@ private fun ExtensionRow(
             )
         }
         Spacer(modifier = Modifier.width(8.dp))
-        TextButton(
-            onClick = onUninstall,
-            enabled = uninstallEnabled,
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Text(if (isUninstalling) "削除中..." else "アンインストール")
+            if (extension.hasSettingsPage) {
+                TextButton(
+                    onClick = onOpenSettings,
+                    enabled = uninstallEnabled,
+                ) {
+                    Text("設定")
+                }
+            }
+            TextButton(
+                onClick = onUninstall,
+                enabled = uninstallEnabled,
+            ) {
+                Text(if (isUninstalling) "削除中..." else "アンインストール")
+            }
         }
     }
 }

--- a/ui/extensions/src/main/kotlin/net/matsudamper/browser/ui/extensions/ExtensionsScreen.kt
+++ b/ui/extensions/src/main/kotlin/net/matsudamper/browser/ui/extensions/ExtensionsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -184,4 +185,80 @@ private fun ExtensionRow(
             }
         }
     }
+}
+
+private val previewCallbacks = object : ExtensionsScreenUiState.Callbacks {
+    override fun refreshExtensions() = Unit
+    override fun uninstallExtension(extensionId: String) = Unit
+    override fun openExtensionSettings(extensionId: String) = Unit
+    override fun dismissError() = Unit
+}
+
+/** 設定ページあり・なしの両方の拡張機能が列挙される状態 */
+@Preview(showBackground = true)
+@Composable
+private fun PreviewExtensionsScreenLoaded() {
+    ExtensionsScreen(
+        uiState = ExtensionsScreenUiState(
+            callbacks = previewCallbacks,
+            loadingState = ExtensionsScreenUiState.LoadingState.Loaded(
+                extensions = listOf(
+                    ExtensionsScreenUiState.ExtensionUiState(
+                        id = "ublock@example.com",
+                        displayName = "uBlock Origin",
+                        version = "1.54.0",
+                        hasSettingsPage = true,
+                    ),
+                    ExtensionsScreenUiState.ExtensionUiState(
+                        id = "no-settings@example.com",
+                        displayName = "設定ページなしの拡張機能",
+                        version = "0.1.0",
+                        hasSettingsPage = false,
+                    ),
+                ),
+            ),
+            errorMessage = null,
+            uninstallingId = null,
+        ),
+        onBack = {},
+    )
+}
+
+/** アンインストール中の拡張機能がある状態 */
+@Preview(showBackground = true)
+@Composable
+private fun PreviewExtensionsScreenUninstalling() {
+    ExtensionsScreen(
+        uiState = ExtensionsScreenUiState(
+            callbacks = previewCallbacks,
+            loadingState = ExtensionsScreenUiState.LoadingState.Loaded(
+                extensions = listOf(
+                    ExtensionsScreenUiState.ExtensionUiState(
+                        id = "ublock@example.com",
+                        displayName = "uBlock Origin",
+                        version = "1.54.0",
+                        hasSettingsPage = true,
+                    ),
+                ),
+            ),
+            errorMessage = null,
+            uninstallingId = "ublock@example.com",
+        ),
+        onBack = {},
+    )
+}
+
+/** ロード中の状態 */
+@Preview(showBackground = true)
+@Composable
+private fun PreviewExtensionsScreenLoading() {
+    ExtensionsScreen(
+        uiState = ExtensionsScreenUiState(
+            callbacks = previewCallbacks,
+            loadingState = ExtensionsScreenUiState.LoadingState.Loading,
+            errorMessage = null,
+            uninstallingId = null,
+        ),
+        onBack = {},
+    )
 }


### PR DESCRIPTION
## 概要

Closes #324

拡張機能の設定をカスタムタブで開く機能は `ExtensionsScreenViewModel` と `BrowserApp.kt` にて実装済みでした。ただし `ExtensionsScreenUiState.ExtensionUiState` に `hasSettingsPage` フィールドが存在するにもかかわらず、UI側でそれを活用していませんでした。

本PRでは UI の未完成部分を修正します。

## 変更内容

### `ExtensionsScreen.kt`

- **Before**: 拡張機能の行全体をタップすると設定を開こうとする（設定ページのない拡張機能でもタップ可能でエラーダイアログが表示されていた）
- **After**: `extension.hasSettingsPage` が `true` の場合のみ「設定」ボタンを表示し、そのボタン経由で `CustomTabActivity` を開く

## 動作

- 設定ページあり → 「設定」ボタンが表示され、タップするとカスタムタブで設定ページを開く
- 設定ページなし → 「設定」ボタンは非表示。ユーザーが誤ってタップしてエラーになる状況を防ぐ

---

### Issue #322 について

Issue #322「タブリストのメニュー編集」は `TabsScreen.kt` の `TabGroupMenu` コンポーザブルにて既に実装済み（デフォルトスイッチの右側に3点メニュー＋名前変更・削除のDropdownMenu）のため、本PRには含めていません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCLe5bWUrrkAHLQq2Xgap6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Interface**
  * Extension management actions now display as dedicated buttons. Settings button appears only when supported by the extension. Interactions are more explicit for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->