### PR TITLE
Fix swipe gesture bug during tab group data loading

### DIFF
--- a/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
+++ b/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
@@ -101,20 +101,14 @@ class BrowserScreenViewModel(
         scope.launch {
             tabGroupRepository.observeGroups().collectLatest { groups ->
                 viewModelStateFlow.update {
-                    it.copy(
-                        tabGroups = groups,
-                        tabGroupsLoaded = true,
-                    ).withResolvedOrderedBrowserTabs()
+                    it.copy(tabGroups = Loadable.Loaded(groups)).withResolvedOrderedBrowserTabs()
                 }
             }
         }
         scope.launch {
             tabGroupRepository.observeTabGroupAssignments().collectLatest { assignments ->
                 viewModelStateFlow.update {
-                    it.copy(
-                        tabGroupAssignments = assignments,
-                        tabGroupAssignmentsLoaded = true,
-                    ).withResolvedOrderedBrowserTabs()
+                    it.copy(tabGroupAssignments = Loadable.Loaded(assignments)).withResolvedOrderedBrowserTabs()
                 }
             }
         }
@@ -123,18 +117,20 @@ class BrowserScreenViewModel(
     interface Event
 }
 
+// ロード状態とデータを 1 つの値で表現する。
+// Flow の初回値発行前は Loading、発行後は Loaded(value) になる。
+private sealed interface Loadable<out T> {
+    data object Loading : Loadable<Nothing>
+    data class Loaded<T>(val value: T) : Loadable<T>
+}
+
 private data class ViewModelState(
     val urlBarSuggestions: UrlBarSuggestionsUiState = UrlBarSuggestionsUiState(),
-    val tabGroups: List<TabGroupData> = emptyList(),
-    val tabGroupAssignments: List<TabGroupAssignment> = emptyList(),
+    val tabGroups: Loadable<List<TabGroupData>> = Loadable.Loading,
+    val tabGroupAssignments: Loadable<List<TabGroupAssignment>> = Loadable.Loading,
     val browserTabs: List<BrowserTab> = emptyList(),
     val orderedBrowserTabs: List<BrowserTab> = emptyList(),
     val screenTabId: String? = null,
-    // tabGroups / tabGroupAssignments の Flow が初回値を発行済みかどうか。
-    // 未ロード時は空リストと「グループが存在しない」状態が区別できず、
-    // 別グループのタブまでスワイプ移動できてしまうため、ロード完了まで待つ判定に使う。
-    val tabGroupsLoaded: Boolean = false,
-    val tabGroupAssignmentsLoaded: Boolean = false,
 ) {
     fun withResolvedOrderedBrowserTabs(): ViewModelState {
         val orderedBrowserTabs = resolveOrderedBrowserTabs()
@@ -143,18 +139,15 @@ private data class ViewModelState(
         )
     }
 
-    private fun isTabGroupStateLoaded(): Boolean {
-        return tabGroupsLoaded && tabGroupAssignmentsLoaded
-    }
-
     fun resolveAdjacentTabs(): AdjacentTabs {
         // タブグループの状態がロード完了するまでは前後タブを解決しない。
         // 未ロード時はすべてのタブが「グループ未割り当て」と見なされてしまい、
         // グループ間でスワイプ移動できてしまう不具合を防ぐ。
-        if (!isTabGroupStateLoaded()) return AdjacentTabs()
+        val groups = (tabGroups as? Loadable.Loaded)?.value ?: return AdjacentTabs()
+        val assignments = (tabGroupAssignments as? Loadable.Loaded)?.value ?: return AdjacentTabs()
         // 同じタブグループ内のタブのみを対象にして前後タブを解決する。
         // グループ間の移動を防ぐため、現在のタブが属するグループのタブだけに絞り込む。
-        val sameGroupTabIds = resolveGroupTabIds()
+        val sameGroupTabIds = resolveGroupTabIds(groups, assignments)
         val adjacentTabIds = resolveAdjacentTabIds(
             orderedTabIds = sameGroupTabIds,
             anchorTabId = screenTabId,
@@ -169,9 +162,12 @@ private data class ViewModelState(
      * 現在のタブと同じグループに属するタブIDのリストを返す。
      * グループ未割り当ての場合は未割り当てタブのみを返す。
      */
-    private fun resolveGroupTabIds(): List<String> {
-        val assignmentMap = tabGroupAssignments.associate { it.tabId to it.groupId }
-        val knownGroupIds = tabGroups.map { it.id.value }.toSet()
+    private fun resolveGroupTabIds(
+        groups: List<TabGroupData>,
+        assignments: List<TabGroupAssignment>,
+    ): List<String> {
+        val assignmentMap = assignments.associate { it.tabId to it.groupId }
+        val knownGroupIds = groups.map { it.id.value }.toSet()
         val currentGroupId = assignmentMap[screenTabId]?.takeIf { it in knownGroupIds }
         return orderedBrowserTabs
             .filter { tab ->
@@ -187,15 +183,19 @@ private data class ViewModelState(
 
     fun resolveGroupTabCount(): Int? {
         if (browserTabs.isEmpty()) return null
-        val assignmentMap = tabGroupAssignments.associate { it.tabId to it.groupId }
-        val knownGroupIds = tabGroups.map { it.id.value }.toSet()
+        val groups = (tabGroups as? Loadable.Loaded)?.value ?: return null
+        val assignments = (tabGroupAssignments as? Loadable.Loaded)?.value ?: return null
+        val assignmentMap = assignments.associate { it.tabId to it.groupId }
+        val knownGroupIds = groups.map { it.id.value }.toSet()
         val currentGroupId = assignmentMap[screenTabId]?.takeIf { it in knownGroupIds } ?: return null
         return browserTabs.count { tab -> assignmentMap[tab.tabId] == currentGroupId }
     }
 
     private fun resolveOrderedBrowserTabs(): List<BrowserTab> {
-        val assignmentMap = tabGroupAssignments.associate { it.tabId to it.groupId }
-        val groupedTabs = tabGroups.flatMap { group ->
+        val groups = (tabGroups as? Loadable.Loaded)?.value ?: return browserTabs
+        val assignments = (tabGroupAssignments as? Loadable.Loaded)?.value ?: return browserTabs
+        val assignmentMap = assignments.associate { it.tabId to it.groupId }
+        val groupedTabs = groups.flatMap { group ->
             browserTabs.filter { tab -> assignmentMap[tab.tabId] == group.id.value }
         }
         val groupedTabIds = groupedTabs.map { it.tabId }.toSet()

--- a/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
+++ b/feature-browser/src/main/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModel.kt
@@ -101,14 +101,20 @@ class BrowserScreenViewModel(
         scope.launch {
             tabGroupRepository.observeGroups().collectLatest { groups ->
                 viewModelStateFlow.update {
-                    it.copy(tabGroups = groups).withResolvedOrderedBrowserTabs()
+                    it.copy(
+                        tabGroups = groups,
+                        tabGroupsLoaded = true,
+                    ).withResolvedOrderedBrowserTabs()
                 }
             }
         }
         scope.launch {
             tabGroupRepository.observeTabGroupAssignments().collectLatest { assignments ->
                 viewModelStateFlow.update {
-                    it.copy(tabGroupAssignments = assignments).withResolvedOrderedBrowserTabs()
+                    it.copy(
+                        tabGroupAssignments = assignments,
+                        tabGroupAssignmentsLoaded = true,
+                    ).withResolvedOrderedBrowserTabs()
                 }
             }
         }
@@ -124,6 +130,11 @@ private data class ViewModelState(
     val browserTabs: List<BrowserTab> = emptyList(),
     val orderedBrowserTabs: List<BrowserTab> = emptyList(),
     val screenTabId: String? = null,
+    // tabGroups / tabGroupAssignments の Flow が初回値を発行済みかどうか。
+    // 未ロード時は空リストと「グループが存在しない」状態が区別できず、
+    // 別グループのタブまでスワイプ移動できてしまうため、ロード完了まで待つ判定に使う。
+    val tabGroupsLoaded: Boolean = false,
+    val tabGroupAssignmentsLoaded: Boolean = false,
 ) {
     fun withResolvedOrderedBrowserTabs(): ViewModelState {
         val orderedBrowserTabs = resolveOrderedBrowserTabs()
@@ -132,7 +143,15 @@ private data class ViewModelState(
         )
     }
 
+    private fun isTabGroupStateLoaded(): Boolean {
+        return tabGroupsLoaded && tabGroupAssignmentsLoaded
+    }
+
     fun resolveAdjacentTabs(): AdjacentTabs {
+        // タブグループの状態がロード完了するまでは前後タブを解決しない。
+        // 未ロード時はすべてのタブが「グループ未割り当て」と見なされてしまい、
+        // グループ間でスワイプ移動できてしまう不具合を防ぐ。
+        if (!isTabGroupStateLoaded()) return AdjacentTabs()
         // 同じタブグループ内のタブのみを対象にして前後タブを解決する。
         // グループ間の移動を防ぐため、現在のタブが属するグループのタブだけに絞り込む。
         val sameGroupTabIds = resolveGroupTabIds()

--- a/feature-browser/src/test/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModelTest.kt
+++ b/feature-browser/src/test/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModelTest.kt
@@ -382,4 +382,60 @@ class BrowserScreenViewModelTest {
         assertNull(viewModel.uiState.value.swipePreview.previousTab)
         assertEquals(1, viewModel.uiState.value.groupTabCount)
     }
+
+    // -----------------------------------------------------------------------
+    // ロード未完了時のスワイプ抑制テスト
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `tabGroupAssignmentsの初回発行前はswipePreviewが空`() = runTest(testDispatcher) {
+        // 実機では Room の Flow が初回値を発行する前に他の Flow が先に走り、
+        // 「グループ未割り当て」と判別不能な状態でスワイプができてしまう不具合があった。
+        // ここでは observeTabGroupAssignments が値を発行しないリポジトリで再現する。
+        val tabA = createTab("a")
+        val tabB = createTab("b")
+        val browserTabsFlow = MutableStateFlow(listOf(tabA, tabB))
+        val repo = object : TabGroupRepository {
+            override fun observeGroups() = MutableStateFlow<List<TabGroupData>>(
+                listOf(TabGroupData(TabGroupId("g1"), "グループ1")),
+            )
+            // 値を発行しない Flow（初回ロード未完了状態）
+            override fun observeTabGroupAssignments() = kotlinx.coroutines.flow.flow<List<TabGroupAssignment>> {
+                kotlinx.coroutines.awaitCancellation()
+            }
+            override suspend fun createDefaultGroupIfEmpty(tabIds: List<String>) = TabGroupId("default")
+            override suspend fun addGroup(name: String, sortOrder: Int) = TabGroupId("new")
+            override suspend fun assignTabToGroup(tabId: String, groupId: TabGroupId) {}
+            override suspend fun assignTabToGroupIfUnassigned(tabId: String, groupId: TabGroupId) {}
+            override suspend fun removeTabFromGroup(tabId: String) {}
+            override suspend fun reorderGroups(orderedGroupIds: List<String>) {}
+            override suspend fun renameGroup(groupId: TabGroupId, name: String) {}
+            override suspend fun deleteGroup(groupId: TabGroupId, fallbackGroupId: TabGroupId?) {}
+            override suspend fun setDefaultGroup(groupId: TabGroupId, isDefault: Boolean) {}
+            override suspend fun getDefaultGroupId(): TabGroupId? = null
+        }
+
+        val historyRepository = mockk<HistoryRepository>(relaxed = true) {
+            every { searchSuggestions(any(), any()) } returns emptyFlow()
+            every { getRecentSuggestions(any()) } returns emptyFlow()
+        }
+        val settingsRepository = mockk<SettingsRepository>(relaxed = true) {
+            every { settings } returns emptyFlow()
+        }
+        val webSuggestionRepository = mockk<WebSuggestionRepository>(relaxed = true)
+
+        val viewModel = BrowserScreenViewModel(
+            historyRepository = historyRepository,
+            settingsRepository = settingsRepository,
+            webSuggestionRepository = webSuggestionRepository,
+            tabGroupRepository = repo,
+            browserTabsFlow = browserTabsFlow,
+            screenTabId = "a",
+        )
+        advanceUntilIdle()
+
+        // assignments が未発行のため前後タブは null。グループ間誤スワイプを防ぐ。
+        assertNull(viewModel.uiState.value.swipePreview.previousTab)
+        assertNull(viewModel.uiState.value.swipePreview.nextTab)
+    }
 }

--- a/feature-browser/src/test/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModelTest.kt
+++ b/feature-browser/src/test/kotlin/net/matsudamper/browser/screen/browser/BrowserScreenViewModelTest.kt
@@ -4,8 +4,10 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -91,7 +93,7 @@ class BrowserScreenViewModelTest {
 
     private fun buildViewModel(
         browserTabsFlow: MutableStateFlow<List<BrowserTab>>,
-        tabGroupRepository: FakeTabGroupRepository,
+        tabGroupRepository: TabGroupRepository,
         screenTabId: String,
     ): BrowserScreenViewModel {
         // HistoryRepository/SettingsRepository は Android SDK に依存しているため relaxed mock で代替
@@ -395,46 +397,46 @@ class BrowserScreenViewModelTest {
         val tabA = createTab("a")
         val tabB = createTab("b")
         val browserTabsFlow = MutableStateFlow(listOf(tabA, tabB))
-        val repo = object : TabGroupRepository {
+        val repo = object : TabGroupRepository by FakeTabGroupRepository() {
             override fun observeGroups() = MutableStateFlow<List<TabGroupData>>(
                 listOf(TabGroupData(TabGroupId("g1"), "グループ1")),
             )
             // 値を発行しない Flow（初回ロード未完了状態）
-            override fun observeTabGroupAssignments() = kotlinx.coroutines.flow.flow<List<TabGroupAssignment>> {
-                kotlinx.coroutines.awaitCancellation()
+            override fun observeTabGroupAssignments() = flow<List<TabGroupAssignment>> {
+                awaitCancellation()
             }
-            override suspend fun createDefaultGroupIfEmpty(tabIds: List<String>) = TabGroupId("default")
-            override suspend fun addGroup(name: String, sortOrder: Int) = TabGroupId("new")
-            override suspend fun assignTabToGroup(tabId: String, groupId: TabGroupId) {}
-            override suspend fun assignTabToGroupIfUnassigned(tabId: String, groupId: TabGroupId) {}
-            override suspend fun removeTabFromGroup(tabId: String) {}
-            override suspend fun reorderGroups(orderedGroupIds: List<String>) {}
-            override suspend fun renameGroup(groupId: TabGroupId, name: String) {}
-            override suspend fun deleteGroup(groupId: TabGroupId, fallbackGroupId: TabGroupId?) {}
-            override suspend fun setDefaultGroup(groupId: TabGroupId, isDefault: Boolean) {}
-            override suspend fun getDefaultGroupId(): TabGroupId? = null
         }
 
-        val historyRepository = mockk<HistoryRepository>(relaxed = true) {
-            every { searchSuggestions(any(), any()) } returns emptyFlow()
-            every { getRecentSuggestions(any()) } returns emptyFlow()
-        }
-        val settingsRepository = mockk<SettingsRepository>(relaxed = true) {
-            every { settings } returns emptyFlow()
-        }
-        val webSuggestionRepository = mockk<WebSuggestionRepository>(relaxed = true)
-
-        val viewModel = BrowserScreenViewModel(
-            historyRepository = historyRepository,
-            settingsRepository = settingsRepository,
-            webSuggestionRepository = webSuggestionRepository,
-            tabGroupRepository = repo,
-            browserTabsFlow = browserTabsFlow,
-            screenTabId = "a",
-        )
+        val viewModel = buildViewModel(browserTabsFlow, repo, "a")
         advanceUntilIdle()
 
         // assignments が未発行のため前後タブは null。グループ間誤スワイプを防ぐ。
+        assertNull(viewModel.uiState.value.swipePreview.previousTab)
+        assertNull(viewModel.uiState.value.swipePreview.nextTab)
+    }
+
+    @Test
+    fun `tabGroupsの初回発行前はswipePreviewが空`() = runTest(testDispatcher) {
+        // observeGroups が未発行の場合も前後タブを解決しないことを検証する。
+        val tabA = createTab("a")
+        val tabB = createTab("b")
+        val browserTabsFlow = MutableStateFlow(listOf(tabA, tabB))
+        val repo = object : TabGroupRepository by FakeTabGroupRepository() {
+            // 値を発行しない Flow（初回ロード未完了状態）
+            override fun observeGroups() = flow<List<TabGroupData>> {
+                awaitCancellation()
+            }
+            override fun observeTabGroupAssignments() = MutableStateFlow(
+                listOf(
+                    TabGroupAssignment("a", "g1"),
+                    TabGroupAssignment("b", "g1"),
+                ),
+            )
+        }
+
+        val viewModel = buildViewModel(browserTabsFlow, repo, "a")
+        advanceUntilIdle()
+
         assertNull(viewModel.uiState.value.swipePreview.previousTab)
         assertNull(viewModel.uiState.value.swipePreview.nextTab)
     }


### PR DESCRIPTION
## Summary
Fixes a bug where swipe gestures between tabs could incorrectly move tabs across different groups during the initial data loading phase. The issue occurred because tab group assignments were treated as empty before the repository's Flow emitted its first value, causing all tabs to be incorrectly classified as unassigned.

## Key Changes
- **Introduced `Loadable` sealed interface**: Distinguishes between loading (`Loading`) and loaded (`Loaded(value)`) states for tab groups and assignments data
- **Updated `ViewModelState`**: Changed `tabGroups` and `tabGroupAssignments` from `List` to `Loadable<List>` with initial state of `Loading`
- **Enhanced `resolveAdjacentTabs()`**: Returns empty `AdjacentTabs` until both tab groups and assignments are fully loaded, preventing swipe operations during the loading phase
- **Updated dependent methods**: Modified `resolveGroupTabIds()`, `resolveGroupTabCount()`, and `resolveOrderedBrowserTabs()` to handle the new `Loadable` state and safely extract loaded values
- **Added comprehensive test**: New test case `tabGroupAssignmentsの初回発行前はswipePreviewが空` verifies that swipe preview remains empty when assignments haven't been emitted yet

## Implementation Details
The fix ensures that swipe gesture calculations only proceed once both data sources have emitted their initial values. This prevents the race condition where one Flow emits before the other, causing incorrect tab grouping logic. The `Loadable` pattern provides a clean way to track loading state alongside the actual data.

https://claude.ai/code/session_017ifjYtpkNRBB3ucHuvUGX5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed an issue where swipe navigation preview controls could appear before the browser finished initializing tab group information. The app now properly waits for all required data to load before displaying these navigation options, preventing potential confusion and ensuring consistent behavior across app launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->