### PR TITLE
fix: ダウンロード管理画面の読み込み中に空メッセージが瞬間表示される問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -36,7 +36,7 @@ internal class DownloadManagementScreenViewModel(
 
     val uiState: StateFlow<DownloadManagementScreenUiState> = MutableStateFlow(
         DownloadManagementScreenUiState(
-            downloads = emptyList(),
+            loadingState = DownloadManagementScreenUiState.LoadingState.Loading,
             callbacks = callbacks,
         ),
     ).also { uiStateFlow ->
@@ -46,7 +46,7 @@ internal class DownloadManagementScreenViewModel(
                 val items = records.map { record -> record.toDownloadItem() }
                 uiStateFlow.update {
                     DownloadManagementScreenUiState(
-                        downloads = items,
+                        loadingState = DownloadManagementScreenUiState.LoadingState.Loaded(items),
                         callbacks = callbacks,
                     )
                 }

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -64,32 +65,47 @@ fun DownloadManagementScreen(
             )
         },
     ) { paddingValues ->
-        if (uiState.downloads.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .padding(paddingValues)
-                    .fillMaxSize()
-                    .padding(16.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text("ダウンロード履歴はありません。")
+        when (val loadingState = uiState.loadingState) {
+            is DownloadManagementScreenUiState.LoadingState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .padding(paddingValues)
-                    .fillMaxSize(),
-            ) {
-                items(
-                    items = uiState.downloads,
-                    key = { it.id },
-                ) { item ->
-                    DownloadItemRow(
-                        item = item,
-                        onCancel = { uiState.callbacks.onCancel(item.id) },
-                        onOpenFile = { fileUri -> uiState.callbacks.onOpenFile(fileUri) },
-                        onResume = { uiState.callbacks.onResume(item.id) },
-                    )
+
+            is DownloadManagementScreenUiState.LoadingState.Loaded -> {
+                if (loadingState.downloads.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .fillMaxSize()
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text("ダウンロード履歴はありません。")
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .fillMaxSize(),
+                    ) {
+                        items(
+                            items = loadingState.downloads,
+                            key = { it.id },
+                        ) { item ->
+                            DownloadItemRow(
+                                item = item,
+                                onCancel = { uiState.callbacks.onCancel(item.id) },
+                                onOpenFile = { fileUri -> uiState.callbacks.onOpenFile(fileUri) },
+                                onResume = { uiState.callbacks.onResume(item.id) },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -5,9 +5,19 @@ import java.util.UUID
 
 @Stable
 data class DownloadManagementScreenUiState(
-    val downloads: List<DownloadItem>,
+    val loadingState: LoadingState,
     val callbacks: Callbacks,
 ) {
+    @Stable
+    sealed interface LoadingState {
+        data object Loading : LoadingState
+
+        @Stable
+        data class Loaded(
+            val downloads: List<DownloadItem>,
+        ) : LoadingState
+    }
+
     @Stable
     sealed interface DownloadStatus {
         data class InProgress(


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

Closes #351

ダウンロード管理画面でデータ読み込み中に「ダウンロード履歴はありません。」が瞬間表示されるバグを修正。

## 変更内容

`DownloadManagementScreenUiState` に `ExtensionsScreenUiState` と同様の `LoadingState` sealed interface を追加。

```kotlin
sealed interface LoadingState {
    data object Loading : LoadingState
    data class Loaded(val downloads: List<DownloadItem>) : LoadingState
}
```

- ViewModel の初期値を `LoadingState.Loading` に変更
- データ取得後に `LoadingState.Loaded(items)` へ遷移
- UI は `when` 式で `Loading` → `CircularProgressIndicator`、`Loaded` → 既存のリスト表示（空なら「履歴なし」メッセージ）

## テスト

- `./gradlew :app:assembleDebug` ✅
- `./gradlew detekt` ✅
- `./gradlew :app:testDebugUnitTest :ui:downloads:testDebugUnitTest` ✅
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011XAFn2Eze5pgcBwoz27YmF)_