### PR TITLE
test: ランダム失敗診断ログを追加 (MediaNotificationSmokeTest / GeckoSurfaceResumeTest)

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -29,18 +30,27 @@ class GeckoSurfaceResumeTest {
     fun geckoPixelsRemainVisibleAfterActivityReturnsFromBackground() {
         val pageUri = prepareSurfaceResumePageUri()
 
+        Log.d(TAG, "ページを開きます: $pageUri")
         composeRule.openUrlFromUrlBar(pageUri)
         composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
         composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
+        Log.d(TAG, "ページロード完了。GeckoContainerを待機します")
         waitForGeckoContainer()
+        Log.d(TAG, "GeckoContainer確認済み。フォアグラウンドでのピクセル確認を開始します")
         waitForNonBlackGeckoPixels()
+        Log.d(TAG, "フォアグラウンドでのピクセル確認完了。バックグラウンドに移行します")
 
         composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        Log.d(TAG, "バックグラウンド移行完了。フォアグラウンドに復帰します")
         composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        Log.d(TAG, "フォアグラウンド復帰完了。URLバー確認を待機します")
 
         composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
+        Log.d(TAG, "URLバー確認済み。GeckoContainerを待機します")
         waitForGeckoContainer()
+        Log.d(TAG, "GeckoContainer確認済み。復帰後のピクセル確認を開始します")
         waitForNonBlackGeckoPixels()
+        Log.d(TAG, "復帰後のピクセル確認完了。テスト成功")
     }
 
     private fun waitForGeckoContainer() {
@@ -55,19 +65,36 @@ class GeckoSurfaceResumeTest {
         val deadline = System.currentTimeMillis() + timeoutMillis
         var latestBitmap: Bitmap? = null
         var lastError: Throwable? = null
+        var attempts = 0
         while (System.currentTimeMillis() < deadline) {
+            attempts++
             try {
                 latestBitmap = captureGeckoPixels()
-                if (!latestBitmap.isMostlyBlack()) {
+                val ratio = latestBitmap.blackRatio()
+                val isMostlyBlack = ratio >= BLACK_RATIO_THRESHOLD
+                Log.d(
+                    TAG,
+                    "試行 $attempts: キャプチャ成功 (${latestBitmap.width}x${latestBitmap.height}), " +
+                        "blackRatio=${"%,.2f".format(ratio * 100)}%, isMostlyBlack=$isMostlyBlack",
+                )
+                if (!isMostlyBlack) {
+                    Log.d(TAG, "試行 $attempts: 非黒ピクセルを検出。正常")
                     return latestBitmap
                 }
             } catch (e: AssertionError) {
                 // Activity リジューム直後は GeckoView の Compositor がまだ準備できておらず
                 // capturePixels() が失敗することがある。一時的なエラーとしてリトライする。
+                Log.w(TAG, "試行 $attempts: capturePixels 失敗 (一時的エラー、リトライします)", e)
                 lastError = e
             }
             Thread.sleep(250L)
         }
+        val elapsed = timeoutMillis - (deadline - System.currentTimeMillis())
+        Log.e(
+            TAG,
+            "タイムアウト: ${attempts}回試行 (約${elapsed}ms) 後もGeckoViewのピクセルが黒のまま。" +
+                "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}, lastError=$lastError",
+        )
         error(
             "GeckoView pixels stayed mostly black or capture failed. " +
                 "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}, " +
@@ -102,7 +129,7 @@ class GeckoSurfaceResumeTest {
         }
     }
 
-    private fun Bitmap.isMostlyBlack(): Boolean {
+    private fun Bitmap.blackRatio(): Double {
         val stepX = max(1, width / SAMPLE_GRID_SIZE)
         val stepY = max(1, height / SAMPLE_GRID_SIZE)
         var sampled = 0
@@ -126,8 +153,10 @@ class GeckoSurfaceResumeTest {
             }
             y += stepY
         }
-        return sampled > 0 && black.toDouble() / sampled >= BLACK_RATIO_THRESHOLD
+        return if (sampled > 0) black.toDouble() / sampled else 0.0
     }
+
+    private fun Bitmap.isMostlyBlack(): Boolean = blackRatio() >= BLACK_RATIO_THRESHOLD
 
     private fun View.findGeckoView(): GeckoView? {
         if (this is GeckoView) return this
@@ -173,6 +202,7 @@ class GeckoSurfaceResumeTest {
     }
 
     private companion object {
+        private const val TAG = "GeckoSurfaceResumeTest"
         private const val SURFACE_RESUME_DIR_NAME = "surface-resume"
         private const val SURFACE_RESUME_FILE_NAME = "index.html"
         private const val SAMPLE_GRID_SIZE = 20

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -62,7 +62,8 @@ class GeckoSurfaceResumeTest {
     }
 
     private fun waitForNonBlackGeckoPixels(timeoutMillis: Long = 30_000): Bitmap {
-        val deadline = System.currentTimeMillis() + timeoutMillis
+        val startTime = System.currentTimeMillis()
+        val deadline = startTime + timeoutMillis
         var latestBitmap: Bitmap? = null
         var lastError: Throwable? = null
         var attempts = 0
@@ -89,10 +90,10 @@ class GeckoSurfaceResumeTest {
             }
             Thread.sleep(250L)
         }
-        val elapsed = timeoutMillis - (deadline - System.currentTimeMillis())
+        val elapsed = System.currentTimeMillis() - startTime
         Log.e(
             TAG,
-            "タイムアウト: ${attempts}回試行 (約${elapsed}ms) 後もGeckoViewのピクセルが黒のまま。" +
+            "タイムアウト: ${attempts}回試行 (${elapsed}ms) 後もGeckoViewのピクセルが黒のまま。" +
                 "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}, lastError=$lastError",
         )
         error(
@@ -155,8 +156,6 @@ class GeckoSurfaceResumeTest {
         }
         return if (sampled > 0) black.toDouble() / sampled else 0.0
     }
-
-    private fun Bitmap.isMostlyBlack(): Boolean = blackRatio() >= BLACK_RATIO_THRESHOLD
 
     private fun View.findGeckoView(): GeckoView? {
         if (this is GeckoView) return this

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaNotificationSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaNotificationSmokeTest.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser.media
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -67,21 +68,39 @@ class MediaNotificationSmokeTest {
         val mediaPageUri = prepareLocalMediaPageUri()
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
+        Log.d(TAG, "ページを開きます: $mediaPageUri")
         openMediaPage(mediaPageUri)
+        Log.d(TAG, "ページオープン後、${PAGE_READY_DELAY_MS}ms 固定待機します")
         Thread.sleep(PAGE_READY_DELAY_MS)
+        Log.d(
+            TAG,
+            "固定待機完了。currentPackage=${uiDevice.currentPackageName}, " +
+                "displaySize=${uiDevice.displayWidth}x${uiDevice.displayHeight}",
+        )
 
         // ユーザー操作で再生を開始する（自動再生制限の影響を避ける）。
-        repeat(PLAYBACK_TAP_RETRY_COUNT) {
+        repeat(PLAYBACK_TAP_RETRY_COUNT) { attempt ->
+            val cx = uiDevice.displayWidth / 2
+            val cy = uiDevice.displayHeight / 2
+            Log.d(TAG, "タップ試行 ${attempt + 1}/$PLAYBACK_TAP_RETRY_COUNT: ($cx, $cy)")
             tapScreenCenter(uiDevice)
             Thread.sleep(PLAYBACK_TAP_INTERVAL_MS)
+            Log.d(TAG, "タップ ${attempt + 1}回目完了: currentPackage=${uiDevice.currentPackageName}")
         }
 
+        Log.d(TAG, "通知パネルを開きます")
         uiDevice.openNotification()
         try {
-            assertTrue(
-                "通知タイトルが表示されない",
-                uiDevice.wait(Until.hasObject(By.text(EXPECTED_TITLE)), NOTIFICATION_CONTROL_TIMEOUT_MS),
+            val found = uiDevice.wait(Until.hasObject(By.text(EXPECTED_TITLE)), NOTIFICATION_CONTROL_TIMEOUT_MS)
+            Log.d(
+                TAG,
+                "通知タイトル '$EXPECTED_TITLE' 検索結果: found=$found " +
+                    "(timeout=${NOTIFICATION_CONTROL_TIMEOUT_MS}ms)",
             )
+            if (!found) {
+                Log.e(TAG, "期待した通知が見つかりませんでした。EXPECTED_TITLE='$EXPECTED_TITLE'")
+            }
+            assertTrue("通知タイトルが表示されない", found)
         } finally {
             uiDevice.pressBack()
         }
@@ -126,6 +145,7 @@ class MediaNotificationSmokeTest {
     }
 
     companion object {
+        private const val TAG = "MediaNotifSmokeTest"
         private const val TEST_TIMEOUT_MS = 180_000L
         private const val PAGE_READY_DELAY_MS = 3_000L
         private const val PLAYBACK_TAP_RETRY_COUNT = 3


### PR DESCRIPTION
## 概要\n\nmainへのpushでランダムに失敗する可能性があるAndroidインストゥルメンテーションテストの診断ログを追加します。\n\n今日は情報収集のためのログ追加のみ実施します。\n\n## 対象テスト\n\n### MediaNotificationSmokeTest\n\n**フレーキーリスク: HIGH**\n- `Thread.sleep(3_000)` で固定3秒待機後にメディアページを操作している\n- エミュレーターの速度差によって、ページ準備が完了していない状態でタップする可能性がある\n\n**追加したログ:**\n- ページオープン後の固定sleep前後でpackage名・画面サイズを出力\n- 各タップ試行 (1〜3回目) の座標と完了後のpackage名\n- 通知検索の結果 (found=true/false) と使用したタイムアウト値\n- 通知が見つからなかった場合の詳細エラーログ\n\n### GeckoSurfaceResumeTest\n\n**フレーキーリスク: MEDIUM**\n- アクティビティ復帰後にGeckoViewのピクセルが「ほぼ黒」から回復するまで250msポーリング\n- Compositorの準備タイミングによってキャプチャが失敗することがある\n\n**追加したログ:**\n- テストの各主要ステップ（ページロード、バックグラウンド移行、復帰）のログ\n- 各ポーリング試行で黒比率(%)を出力\n- タイムアウト時の試行回数と経過時間\n- capturePixels失敗時の警告ログ\n\n**実装の改善:**\n- `isMostlyBlack()` を `blackRatio()` から算出するよう整理 (比率をログ出力するため)\n\n## 次のステップ\n\nログが蓄積された後、以下を調査する予定:\n- `PAGE_READY_DELAY_MS` (3秒固定) が不足している環境の特定\n- 黒ピクセル比率の推移パターン\n- タップ失敗時のpackage名（アプリがフォアグラウンドにあるか確認）\n\n---\n_Generated by [Claude Code](https://claude.ai/code/session_015oGdyWBE9F7o7hXVM8PFYp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced diagnostic logging and error reporting for rendering and media notification tests to improve troubleshooting.
  * Improved retry mechanisms with detailed attempt tracking and more informative timeout error messages.
  * Refactored pixel classification utilities for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->