### PR TITLE
Add automatic tab preview capture on page load completion

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -949,7 +949,7 @@ internal class BrowserTabScreenState(
         // false のまま戻らず、以降のタブのキャプチャが全て拒否される。
         previewCaptureReady = true
         // プレビュー画像がまだない場合はページロード完了時にキャプチャをリクエストする
-        if (browserTab.previewBitmap.isNullOrEmpty()) {
+        if (browserTab.previewBitmap == null || browserTab.previewBitmap!!.isEmpty()) {
             captureOnPageLoadRequestCount++
         }
         if (success) {

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -197,6 +197,11 @@ internal class BrowserTabScreenState(
 
     var renderReady by mutableStateOf(false)
 
+    // プレビュー画像が未取得の状態でページロードが完了した際にインクリメントされるカウンター。
+    // GeckoBrowserTab がこの値を監視してキャプチャをトリガーする。
+    var captureOnPageLoadRequestCount by mutableIntStateOf(0)
+        private set
+
     // プレビューキャプチャの可否を表すフラグ。
     // false の間は captureTabPreview() が早期 return するため、状態遷移が
     // 想定通りに行われないと「いつまで経ってもプレビューが保存されない」状態に
@@ -943,6 +948,10 @@ internal class BrowserTabScreenState(
         // ページロード完了時点でキャプチャを許可する。これがないと previewCaptureReady が
         // false のまま戻らず、以降のタブのキャプチャが全て拒否される。
         previewCaptureReady = true
+        // プレビュー画像がまだない場合はページロード完了時にキャプチャをリクエストする
+        if (browserTab.previewBitmap.isNullOrEmpty()) {
+            captureOnPageLoadRequestCount++
+        }
         if (success) {
             fetchFavicon(currentPageUrl)
             // ページ遷移後もズームを維持する

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -201,6 +201,15 @@ internal fun GeckoBrowserTab(
         geckoView?.requestFocus()
     }
 
+    // プレビュー画像未取得時にページロードが完了したらキャプチャを実行する
+    LaunchedEffect(state) {
+        snapshotFlow { state.captureOnPageLoadRequestCount }
+            .collectLatest { count ->
+                if (count == 0) return@collectLatest
+                geckoView?.also { gv -> state.captureTabPreview(gv) }
+            }
+    }
+
     // URLバー入力変更時にサジェスト検索を発火
     LaunchedEffect(state, onUrlInputChanged) {
         snapshotFlow { state.urlInput to state.isUrlInputFocused }


### PR DESCRIPTION
## Summary
This PR implements automatic tab preview capture when a page finishes loading without an existing preview image. This ensures that tabs always have preview thumbnails available after navigation completes.

## Key Changes
- **BrowserTabScreenState.kt**
  - Added `captureOnPageLoadRequestCount` state variable to track when preview capture should be triggered
  - Modified `onPageLoadComplete()` to increment this counter when a page finishes loading but no preview bitmap exists yet
  - Ensures `previewCaptureReady` flag is properly reset to allow subsequent captures

- **GeckoBrowserTab.kt**
  - Added `LaunchedEffect` that observes `captureOnPageLoadRequestCount` changes
  - Automatically triggers `captureTabPreview()` when the counter increments and a preview is missing
  - Uses `snapshotFlow` and `collectLatest` to handle reactive updates

## Implementation Details
- The counter-based approach allows the GeckoBrowserTab composable to react to page load completion events
- Early return when count is 0 prevents unnecessary capture attempts
- This solves the issue where tabs could remain without preview images if capture wasn't triggered at the right time during page load

https://claude.ai/code/session_01QDLqrBLJUxk8zZ73yd2bes