### PR TITLE
test: ランダム失敗診断ログを追加 (GeckoSurfaceResumeTest / MediaNotificationSmokeTest)

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -29,18 +30,25 @@ class GeckoSurfaceResumeTest {
     fun geckoPixelsRemainVisibleAfterActivityReturnsFromBackground() {
         val pageUri = prepareSurfaceResumePageUri()
 
+        Log.d(TAG, "ページロード開始: $pageUri")
         composeRule.openUrlFromUrlBar(pageUri)
         composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
         composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
         waitForGeckoContainer()
+        Log.d(TAG, "初期レンダリング確認開始")
         waitForNonBlackGeckoPixels()
+        Log.d(TAG, "初期レンダリング確認完了")
 
+        Log.d(TAG, "バックグラウンド移行")
         composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        Log.d(TAG, "フォアグラウンド復帰")
         composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
 
         composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
         waitForGeckoContainer()
+        Log.d(TAG, "復帰後レンダリング確認開始")
         waitForNonBlackGeckoPixels()
+        Log.d(TAG, "復帰後レンダリング確認完了")
     }
 
     private fun waitForGeckoContainer() {
@@ -53,23 +61,32 @@ class GeckoSurfaceResumeTest {
 
     private fun waitForNonBlackGeckoPixels(timeoutMillis: Long = 30_000): Bitmap {
         val deadline = System.currentTimeMillis() + timeoutMillis
+        val startTime = System.currentTimeMillis()
         var latestBitmap: Bitmap? = null
         var lastError: Throwable? = null
+        var attempt = 0
         while (System.currentTimeMillis() < deadline) {
+            attempt++
             try {
                 latestBitmap = captureGeckoPixels()
-                if (!latestBitmap.isMostlyBlack()) {
+                val ratio = latestBitmap.blackRatio()
+                Log.d(TAG, "試行${attempt}: 黒比率=${String.format("%.1f", ratio * 100)}%" +
+                    " (${latestBitmap.width}x${latestBitmap.height})")
+                if (ratio < BLACK_RATIO_THRESHOLD) {
+                    Log.d(TAG, "非黒ピクセル確認完了 (試行${attempt}, 経過${System.currentTimeMillis() - startTime}ms)")
                     return latestBitmap
                 }
             } catch (e: AssertionError) {
                 // Activity リジューム直後は GeckoView の Compositor がまだ準備できておらず
                 // capturePixels() が失敗することがある。一時的なエラーとしてリトライする。
+                Log.w(TAG, "試行${attempt}: capturePixels失敗 - ${e.message}")
                 lastError = e
             }
             Thread.sleep(250L)
         }
+        val elapsed = System.currentTimeMillis() - startTime
         error(
-            "GeckoView pixels stayed mostly black or capture failed. " +
+            "GeckoView pixels stayed mostly black or capture failed after ${attempt} attempts (${elapsed}ms). " +
                 "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}, " +
                 "lastError=$lastError",
         )
@@ -102,7 +119,7 @@ class GeckoSurfaceResumeTest {
         }
     }
 
-    private fun Bitmap.isMostlyBlack(): Boolean {
+    private fun Bitmap.blackRatio(): Double {
         val stepX = max(1, width / SAMPLE_GRID_SIZE)
         val stepY = max(1, height / SAMPLE_GRID_SIZE)
         var sampled = 0
@@ -126,7 +143,7 @@ class GeckoSurfaceResumeTest {
             }
             y += stepY
         }
-        return sampled > 0 && black.toDouble() / sampled >= BLACK_RATIO_THRESHOLD
+        return if (sampled > 0) black.toDouble() / sampled else 0.0
     }
 
     private fun View.findGeckoView(): GeckoView? {
@@ -173,6 +190,7 @@ class GeckoSurfaceResumeTest {
     }
 
     private companion object {
+        private const val TAG = "GeckoSurfaceResumeTest"
         private const val SURFACE_RESUME_DIR_NAME = "surface-resume"
         private const val SURFACE_RESUME_FILE_NAME = "index.html"
         private const val SAMPLE_GRID_SIZE = 20

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaNotificationSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaNotificationSmokeTest.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser.media
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -68,19 +69,31 @@ class MediaNotificationSmokeTest {
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         openMediaPage(mediaPageUri)
+
+        val displayWidth = uiDevice.displayWidth
+        val displayHeight = uiDevice.displayHeight
+        Log.d(TAG, "ページオープン完了: package=${uiDevice.currentPackageName}," +
+            " 画面サイズ=${displayWidth}x${displayHeight}, ${PAGE_READY_DELAY_MS}ms sleep開始")
         Thread.sleep(PAGE_READY_DELAY_MS)
+        Log.d(TAG, "sleep完了: package=${uiDevice.currentPackageName}")
 
         // ユーザー操作で再生を開始する（自動再生制限の影響を避ける）。
-        repeat(PLAYBACK_TAP_RETRY_COUNT) {
-            tapScreenCenter(uiDevice)
+        val tapX = displayWidth / 2
+        val tapY = displayHeight / 2
+        repeat(PLAYBACK_TAP_RETRY_COUNT) { index ->
+            Log.d(TAG, "タップ${index + 1}/${PLAYBACK_TAP_RETRY_COUNT}: ($tapX, $tapY)")
+            uiDevice.click(tapX, tapY)
             Thread.sleep(PLAYBACK_TAP_INTERVAL_MS)
+            Log.d(TAG, "タップ${index + 1}完了: package=${uiDevice.currentPackageName}")
         }
 
         uiDevice.openNotification()
+        val found = uiDevice.wait(Until.hasObject(By.text(EXPECTED_TITLE)), NOTIFICATION_CONTROL_TIMEOUT_MS)
+        Log.d(TAG, "通知検索結果: found=$found, title=\"$EXPECTED_TITLE\", timeout=${NOTIFICATION_CONTROL_TIMEOUT_MS}ms")
         try {
             assertTrue(
-                "通知タイトルが表示されない",
-                uiDevice.wait(Until.hasObject(By.text(EXPECTED_TITLE)), NOTIFICATION_CONTROL_TIMEOUT_MS),
+                "通知タイトル \"$EXPECTED_TITLE\" が ${NOTIFICATION_CONTROL_TIMEOUT_MS}ms 以内に表示されなかった",
+                found,
             )
         } finally {
             uiDevice.pressBack()
@@ -103,12 +116,6 @@ class MediaNotificationSmokeTest {
         }
     }
 
-    private fun tapScreenCenter(uiDevice: UiDevice) {
-        val displayWidth = uiDevice.displayWidth
-        val displayHeight = uiDevice.displayHeight
-        uiDevice.click(displayWidth / 2, displayHeight / 2)
-    }
-
     private fun prepareLocalMediaPageUri(): String {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
@@ -126,6 +133,7 @@ class MediaNotificationSmokeTest {
     }
 
     companion object {
+        private const val TAG = "MediaNotificationSmoke"
         private const val TEST_TIMEOUT_MS = 180_000L
         private const val PAGE_READY_DELAY_MS = 3_000L
         private const val PLAYBACK_TAP_RETRY_COUNT = 3

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaNotificationSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaNotificationSmokeTest.kt
@@ -72,24 +72,24 @@ class MediaNotificationSmokeTest {
 
         val displayWidth = uiDevice.displayWidth
         val displayHeight = uiDevice.displayHeight
-        Log.d(TAG, "ページオープン完了: package=${uiDevice.currentPackageName}," +
-            " 画面サイズ=${displayWidth}x${displayHeight}, ${PAGE_READY_DELAY_MS}ms sleep開始")
+        Log.d(TAG, "ページオープン完了: package=${uiDevice.currentPackageName}, " +
+            "画面サイズ=${displayWidth}x${displayHeight}, ${PAGE_READY_DELAY_MS}ms待機開始")
         Thread.sleep(PAGE_READY_DELAY_MS)
-        Log.d(TAG, "sleep完了: package=${uiDevice.currentPackageName}")
+        Log.d(TAG, "待機完了: package=${uiDevice.currentPackageName}")
 
         // ユーザー操作で再生を開始する（自動再生制限の影響を避ける）。
         val tapX = displayWidth / 2
         val tapY = displayHeight / 2
         repeat(PLAYBACK_TAP_RETRY_COUNT) { index ->
-            Log.d(TAG, "タップ${index + 1}/${PLAYBACK_TAP_RETRY_COUNT}: ($tapX, $tapY)")
+            Log.d(TAG, "タップ試行${index + 1}/${PLAYBACK_TAP_RETRY_COUNT}: 座標=($tapX, $tapY)")
             uiDevice.click(tapX, tapY)
             Thread.sleep(PLAYBACK_TAP_INTERVAL_MS)
-            Log.d(TAG, "タップ${index + 1}完了: package=${uiDevice.currentPackageName}")
+            Log.d(TAG, "タップ試行${index + 1}完了: package=${uiDevice.currentPackageName}")
         }
 
         uiDevice.openNotification()
         val found = uiDevice.wait(Until.hasObject(By.text(EXPECTED_TITLE)), NOTIFICATION_CONTROL_TIMEOUT_MS)
-        Log.d(TAG, "通知検索結果: found=$found, title=\"$EXPECTED_TITLE\", timeout=${NOTIFICATION_CONTROL_TIMEOUT_MS}ms")
+        Log.d(TAG, "通知検索完了: 発見=$found, タイトル=\"$EXPECTED_TITLE\", タイムアウト=${NOTIFICATION_CONTROL_TIMEOUT_MS}ms")
         try {
             assertTrue(
                 "通知タイトル \"$EXPECTED_TITLE\" が ${NOTIFICATION_CONTROL_TIMEOUT_MS}ms 以内に表示されなかった",


### PR DESCRIPTION
## 概要

mainへのpushでランダムに失敗する可能性があるAndroidインストゥルメンテーションテストの診断ログを追加します。

今日は情報収集のためのログ追加のみ実施します。

## 対象テスト

### GeckoSurfaceResumeTest

**フレーキーリスク: MEDIUM**
- アクティビティ復帰後にGeckoViewのピクセルが「ほぼ黒」から回復するまで250msポーリング
- Compositorの準備タイミングによってキャプチャが失敗することがある

**追加したログ:**
- テストの各主要ステップ（ページロード・バックグラウンド移行・復帰）のログ
- 各ポーリング試行で黒比率(%)を出力 (`試行N: 黒比率=XX.X%`)
- タイムアウト時のエラーに試行回数と経過時間(ms)を追加
- `capturePixels()` 失敗時を `Log.w` で警告ログに記録

**実装の改善:**
- `isMostlyBlack()` を `blackRatio()` から算出するよう整理（比率をログ出力するため）

### MediaNotificationSmokeTest

**フレーキーリスク: HIGH**
- `Thread.sleep(3_000)` で固定3秒待機後にメディアページを操作している
- エミュレーターの速度差によって、ページ準備が完了していない状態でタップする可能性がある

**追加したログ:**
- ページオープン後のsleep前後でpackage名・画面サイズを出力
- 各タップ試行（1〜3回目）の座標と完了後のpackage名
- 通知検索の結果（`found=true/false`）と使用したタイムアウト値
- assertionメッセージに期待タイトルとタイムアウト値を追加

## 次のステップ

ログが蓄積された後、以下を調査する予定:
- `PAGE_READY_DELAY_MS` (3秒固定) が不足している環境の特定
- 黒ピクセル比率の推移パターン
- タップ失敗時のpackage名（アプリがフォアグラウンドにあるか確認）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FknVR1qKUx86fuc7uAa9PC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced diagnostic logging for rendering verification tests with detailed URL loading and lifecycle transition tracking.
  * Improved test reliability with enhanced retry logic, timing metrics, and detailed failure messages for notification and rendering verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->