### PR TITLE
fix(test): main ブランチのフレーキーテスト解消 (GeckoContainer 重複 / Media autoplay 誤検知)

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
@@ -238,7 +238,9 @@ class AboutBlankNewTabLocationTest {
     }
 
     private fun tapLinkOnGeckoContainer() {
-        val node = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.GeckoContainer.testTag)
+        // バックスタックに複数の Browser エントリが残っていると GeckoContainer は複数ノードに
+        // なり onNodeWithTag が "Expected exactly 1" で失敗する。フォアグラウンド限定タグで一意化する。
+        val node = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag)
         node.performTouchInput {
             click()
         }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
@@ -248,14 +248,14 @@ class AboutBlankNewTabLocationTest {
 
     /**
      * 失敗時の Compose semantics tree を最低限ダンプする診断ヘルパー。
-     * UrlBar / GeckoContainer / ForegroundGeckoContainer の現在の数と、
+     * UrlBar / GeckoContainer / 前面 GeckoContainer の現在の数と、
      * UrlBar の EditableText 値、ツールバーの存在有無、root semantics の概要を出力する。
      * fallback path がさらに失敗したケースで、原因切り分け（多重ノード／ノード不在／別画面表示）に使う。
      */
     private fun dumpUiDiagnostics(label: String) {
         val urlBarTag = UrlTextInputTestTags.UrlBar.testTag
         val geckoTag = GeckoBrowserTabTestTags.GeckoContainer.testTag
-        val foregroundGeckoTag = GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag
+        val foregroundGeckoTag = GeckoBrowserTabTestTags.GeckoContainer.testTag(isForeground = true)
         val toolbarTag = BrowserToolbarTestTags.Toolbar.testTag
         val tabsAddTag = TabsScreenTestTags.AddTabButton.testTag
 
@@ -301,10 +301,12 @@ class AboutBlankNewTabLocationTest {
 
     /**
      * バックスタックに複数の Browser エントリが残っていると GeckoContainer は複数ノードに
-     * なり onNodeWithTag が "Expected exactly 1" で失敗する。フォアグラウンド限定タグで一意化する。
+     * なり onNodeWithTag が "Expected exactly 1" で失敗する。フォアグラウンド限定 testTag で一意化する。
      */
     private fun tapLinkOnGeckoContainer() {
-        val node = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag)
+        val node = composeRule.onNodeWithTag(
+            GeckoBrowserTabTestTags.GeckoContainer.testTag(isForeground = true),
+        )
         node.performTouchInput {
             click()
         }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
@@ -1,15 +1,19 @@
 package net.matsudamper.browser
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.printToString
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import net.matsudamper.browser.ui.tabs.TabsScreenTestTags
@@ -165,6 +169,7 @@ class AboutBlankNewTabLocationTest {
             }.getOrDefault(false)
             var lastUrl = composeRule.currentUrlBarText()
             if (!opened) {
+                dumpUiDiagnostics("after-initial-wait")
                 repeat(3) { attempt ->
                     if (opened) return@repeat
                     tapLinkOnGeckoContainer()
@@ -177,11 +182,15 @@ class AboutBlankNewTabLocationTest {
                     }.getOrDefault(false)
                     lastUrl = composeRule.currentUrlBarText()
                     println("target-open-fallback-attempt=${attempt + 1}, opened=$opened, currentUrl=$lastUrl")
+                    if (!opened) {
+                        dumpUiDiagnostics("fallback-attempt-${attempt + 1}")
+                    }
                 }
             }
             if (!opened) {
                 val targetUrl = localServer.indexUrl.substringBeforeLast("/") + "/$TARGET_FILE_NAME"
                 println("target=_blank click failed in this environment. fallback openUrlFromUrlBar: $targetUrl")
+                dumpUiDiagnostics("before-openUrlFromUrlBar")
                 composeRule.openUrlFromUrlBar(targetUrl)
                 composeRule.waitForUrlBarContains(TARGET_FILE_NAME, timeoutMillis = 30_000)
                 lastUrl = composeRule.currentUrlBarText()
@@ -236,6 +245,59 @@ class AboutBlankNewTabLocationTest {
         }
         composeRule.waitForTabsScreenLoaded()
     }
+
+    /**
+     * 失敗時の Compose semantics tree を最低限ダンプする診断ヘルパー。
+     * UrlBar / GeckoContainer / ForegroundGeckoContainer の現在の数と、
+     * UrlBar の EditableText 値、ツールバーの存在有無、root semantics の概要を出力する。
+     * fallback path がさらに失敗したケースで、原因切り分け（多重ノード／ノード不在／別画面表示）に使う。
+     */
+    private fun dumpUiDiagnostics(label: String) {
+        val urlBarTag = UrlTextInputTestTags.UrlBar.testTag
+        val geckoTag = GeckoBrowserTabTestTags.GeckoContainer.testTag
+        val foregroundGeckoTag = GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag
+        val toolbarTag = BrowserToolbarTestTags.Toolbar.testTag
+        val tabsAddTag = TabsScreenTestTags.AddTabButton.testTag
+
+        val urlBarNodes = runCatching {
+            composeRule.onAllNodesWithTag(urlBarTag).fetchSemanticsNodes()
+        }.getOrDefault(emptyList())
+        val geckoNodes = runCatching {
+            composeRule.onAllNodesWithTag(geckoTag).fetchSemanticsNodes()
+        }.getOrDefault(emptyList())
+        val foregroundNodes = runCatching {
+            composeRule.onAllNodesWithTag(foregroundGeckoTag).fetchSemanticsNodes()
+        }.getOrDefault(emptyList())
+        val toolbarNodes = runCatching {
+            composeRule.onAllNodesWithTag(toolbarTag).fetchSemanticsNodes()
+        }.getOrDefault(emptyList())
+        val tabsAddNodes = runCatching {
+            composeRule.onAllNodesWithTag(tabsAddTag).fetchSemanticsNodes()
+        }.getOrDefault(emptyList())
+
+        val urlBarTexts = urlBarNodes.mapIndexed { index, node ->
+            val text = node.config.getOrNull(SemanticsProperties.EditableText)?.text ?: "<no editable text>"
+            "[$index]=\"$text\""
+        }
+
+        println(
+            "ui-diag[$label] urlBars=${urlBarNodes.size} gecko=${geckoNodes.size} " +
+                "foregroundGecko=${foregroundNodes.size} toolbars=${toolbarNodes.size} " +
+                "tabsAdd=${tabsAddNodes.size} urlBarTexts=${urlBarTexts.joinToString(",")}"
+        )
+
+        // 各 UrlBar 周辺のセマンティクスもダンプして、どのスクリーン由来かを見える化する。
+        if (urlBarNodes.isEmpty()) {
+            val rootDump = runCatching {
+                composeRule.onRoot().printToString(maxDepth = 4)
+            }.getOrElse { "root dump failed: ${it.message}" }
+            println("ui-diag[$label] root(maxDepth=4)=\n$rootDump")
+        }
+    }
+
+    private fun <T> androidx.compose.ui.semantics.SemanticsConfiguration.getOrNull(
+        key: androidx.compose.ui.semantics.SemanticsPropertyKey<T>,
+    ): T? = if (contains(key)) get(key) else null
 
     private fun tapLinkOnGeckoContainer() {
         // バックスタックに複数の Browser エントリが残っていると GeckoContainer は複数ノードに

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AboutBlankNewTabLocationTest.kt
@@ -299,9 +299,11 @@ class AboutBlankNewTabLocationTest {
         key: androidx.compose.ui.semantics.SemanticsPropertyKey<T>,
     ): T? = if (contains(key)) get(key) else null
 
+    /**
+     * バックスタックに複数の Browser エントリが残っていると GeckoContainer は複数ノードに
+     * なり onNodeWithTag が "Expected exactly 1" で失敗する。フォアグラウンド限定タグで一意化する。
+     */
     private fun tapLinkOnGeckoContainer() {
-        // バックスタックに複数の Browser エントリが残っていると GeckoContainer は複数ノードに
-        // なり onNodeWithTag が "Expected exactly 1" で失敗する。フォアグラウンド限定タグで一意化する。
         val node = composeRule.onNodeWithTag(GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag)
         node.performTouchInput {
             click()

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
@@ -522,10 +522,18 @@ class GmdSmokeTest {
 
     /**
      * 現在の URL バー文字列が期待値になるまで待機する。
+     * timeout 時には実際の URL バー値を例外メッセージに含める。
      */
     private fun waitForUrlBarText(expected: String) {
-        composeRule.waitUntil(timeoutMillis = 20_000) {
-            getUrlBarText() == expected
+        try {
+            composeRule.waitUntil(timeoutMillis = 20_000) {
+                getUrlBarText() == expected
+            }
+        } catch (e: androidx.compose.ui.test.ComposeTimeoutException) {
+            throw AssertionError(
+                "URL バー復元待機がタイムアウト: expected=\"$expected\" actual=\"${getUrlBarText()}\"",
+                e,
+            )
         }
     }
 

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -154,11 +154,13 @@ class MediaPrimarySelectionTest {
         }
     }
 
+    /**
+     * playlist.html は loadedmetadata 内で currentTime=30 / updateMetadata('Track 1') を
+     * play() より前に実行する。そのため title・positionMs・isActive は autoplay が
+     * ブロックされて paused のままでも true になり、tap によるユーザージェスチャ補填を
+     * スキップしてしまう。実際に再生されている isPlaying のみを信頼する。
+     */
     private fun hasPlaybackStarted(state: MediaPlaybackState): Boolean {
-        // playlist.html は loadedmetadata 内で currentTime=30 / updateMetadata('Track 1') を
-        // play() より前に実行する。そのため title・positionMs・isActive は autoplay が
-        // ブロックされて paused のままでも true になり、tap によるユーザージェスチャ補填を
-        // スキップしてしまう。実際に再生されている isPlaying のみを信頼する。
         return state.isPlaying
     }
 

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/media/MediaPrimarySelectionTest.kt
@@ -155,11 +155,11 @@ class MediaPrimarySelectionTest {
     }
 
     private fun hasPlaybackStarted(state: MediaPlaybackState): Boolean {
-        return state.isActive ||
-            state.isPlaying ||
-            state.positionMs > 0L ||
-            state.title == EXPECTED_FIRST_TITLE ||
-            state.title == EXPECTED_SECOND_TITLE
+        // playlist.html は loadedmetadata 内で currentTime=30 / updateMetadata('Track 1') を
+        // play() より前に実行する。そのため title・positionMs・isActive は autoplay が
+        // ブロックされて paused のままでも true になり、tap によるユーザージェスチャ補填を
+        // スキップしてしまう。実際に再生されている isPlaying のみを信頼する。
+        return state.isPlaying
     }
 
     private fun waitUntil(

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -275,22 +275,6 @@ private fun BrowserAppContent(
                     }
 
                     is AppDestination.Browser -> navEntry(key) {
-                        /**
-                         * フレーキー解析用に Browser navEntry の生存期間を logcat に出力する。
-                         * 同じ瞬間に複数 navEntry がアクティブだと twin Browser entries が確認できる。
-                         */
-                        DisposableEffect(key) {
-                            Log.d(
-                                "BackStackDiag",
-                                "navEntry enter Browser tabId=${key.tabId.takeLast(6)} isTop=${backStack.lastOrNull() == key}",
-                            )
-                            onDispose {
-                                Log.d(
-                                    "BackStackDiag",
-                                    "navEntry exit Browser tabId=${key.tabId.takeLast(6)}",
-                                )
-                            }
-                        }
                         val browserTabsFlow = remember(browserTabController) {
                             browserTabController.tabStoreState
                                 .map { browserTabController.tabs.toList() }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
@@ -127,8 +128,10 @@ private fun BrowserAppContent(
     // タブ復元完了シグナルは ViewModel で保持（構成変更後も有効）
     val setupComplete = viewModel.setupComplete
 
-    // AboutBlankNewTabLocationTest 等のフレーキー解析用に backStack 変化を logcat に流す。
-    // NavDisplay に新旧 Browser エントリが残るかどうかを後追いで確認できる。
+    /**
+     * AboutBlankNewTabLocationTest 等のフレーキー解析用に backStack 変化を logcat に流す。
+     * NavDisplay に新旧 Browser エントリが残るかどうかを後追いで確認できる。
+     */
     LaunchedEffect(backStack) {
         snapshotFlow { backStack.toList() }
             .collect { snapshot ->
@@ -138,7 +141,7 @@ private fun BrowserAppContent(
                         else -> key::class.simpleName ?: key.toString()
                     }
                 }
-                android.util.Log.d("BackStackDiag", "size=${snapshot.size} entries=[$descriptions]")
+                Log.d("BackStackDiag", "size=${snapshot.size} entries=[$descriptions]")
             }
     }
 
@@ -271,15 +274,17 @@ private fun BrowserAppContent(
                     }
 
                     is AppDestination.Browser -> navEntry(key) {
-                        // フレーキー解析用に Browser navEntry の生存期間を logcat に出力する。
-                        // 同じ瞬間に複数 navEntry がアクティブだと twin Browser entries が確認できる。
+                        /**
+                         * フレーキー解析用に Browser navEntry の生存期間を logcat に出力する。
+                         * 同じ瞬間に複数 navEntry がアクティブだと twin Browser entries が確認できる。
+                         */
                         DisposableEffect(key) {
-                            android.util.Log.d(
+                            Log.d(
                                 "BackStackDiag",
                                 "navEntry enter Browser tabId=${key.tabId.takeLast(6)} isTop=${backStack.lastOrNull() == key}",
                             )
                             onDispose {
-                                android.util.Log.d(
+                                Log.d(
                                     "BackStackDiag",
                                     "navEntry exit Browser tabId=${key.tabId.takeLast(6)}",
                                 )

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -125,6 +126,21 @@ private fun BrowserAppContent(
     val navController = remember(backStack) { NavController(backStack = backStack) }
     // タブ復元完了シグナルは ViewModel で保持（構成変更後も有効）
     val setupComplete = viewModel.setupComplete
+
+    // AboutBlankNewTabLocationTest 等のフレーキー解析用に backStack 変化を logcat に流す。
+    // NavDisplay に新旧 Browser エントリが残るかどうかを後追いで確認できる。
+    LaunchedEffect(backStack) {
+        snapshotFlow { backStack.toList() }
+            .collect { snapshot ->
+                val descriptions = snapshot.joinToString { key ->
+                    when (key) {
+                        is AppDestination.Browser -> "Browser(${key.tabId.takeLast(6)},before=${key.beforeTab?.tabId?.takeLast(6) ?: "null"})"
+                        else -> key::class.simpleName ?: key.toString()
+                    }
+                }
+                android.util.Log.d("BackStackDiag", "size=${snapshot.size} entries=[$descriptions]")
+            }
+    }
 
     // ナビゲーションとViewModelの両方にタブ選択を通知するヘルパー
     val selectTab: (String, AppDestination.Browser?) -> Unit = remember(navController, browserTabController) {
@@ -255,6 +271,20 @@ private fun BrowserAppContent(
                     }
 
                     is AppDestination.Browser -> navEntry(key) {
+                        // フレーキー解析用に Browser navEntry の生存期間を logcat に出力する。
+                        // 同じ瞬間に複数 navEntry がアクティブだと twin Browser entries が確認できる。
+                        DisposableEffect(key) {
+                            android.util.Log.d(
+                                "BackStackDiag",
+                                "navEntry enter Browser tabId=${key.tabId.takeLast(6)} isTop=${backStack.lastOrNull() == key}",
+                            )
+                            onDispose {
+                                android.util.Log.d(
+                                    "BackStackDiag",
+                                    "navEntry exit Browser tabId=${key.tabId.takeLast(6)}",
+                                )
+                            }
+                        }
                         val browserTabsFlow = remember(browserTabController) {
                             browserTabController.tabStoreState
                                 .map { browserTabController.tabs.toList() }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -315,6 +315,10 @@ private fun BrowserAppContent(
                                 GeckoBrowserTab(
                                     modifier = modifier,
                                     browserTab = selectedTab,
+                                    // Navigation 3 のバックスタックには複数の Browser エントリが残り得る。
+                                    // 現在 top のエントリだけがフォアグラウンドであり、テストはこのフラグを根拠に
+                                    // 唯一のフォアグラウンド GeckoContainer をタップ対象として一意に特定する。
+                                    isForeground = backStack.lastOrNull() == key,
                                     homepageUrl = uiState.homepageUrl,
                                     searchTemplate = uiState.searchTemplate,
                                     translationProvider = uiState.translationProvider,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.viewmodel.compose.viewModel as composeViewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -348,14 +349,17 @@ private fun BrowserAppContent(
                             },
                             browserTabContent = { modifier, selectedTab, tabCount, onToolbarHorizontalDrag, onToolbarDragEnd ->
                                 GeckoBrowserTab(
-                                    modifier = modifier,
-                                    browserTab = selectedTab,
                                     /**
-                                     * Navigation 3 のバックスタックには複数の Browser エントリが残り得る。
-                                     * 現在 top のエントリだけがフォアグラウンドであり、テストはこのフラグを根拠に
-                                     * 唯一のフォアグラウンド GeckoContainer をタップ対象として一意に特定する。
+                                     * Navigation 3 のバックスタックには複数の Browser エントリが残り得るため、
+                                     * 前面表示中のタブだけが持つ派生 testTag を外側 Modifier に注入し、
+                                     * テストはその testTag をもとに唯一のフォアグラウンド GeckoContainer を特定する。
                                      */
-                                    isForeground = backStack.lastOrNull() == key,
+                                    modifier = modifier.testTag(
+                                        GeckoBrowserTabTestTags.GeckoContainer.testTag(
+                                            isForeground = backStack.lastOrNull() == key,
+                                        ),
+                                    ),
+                                    browserTab = selectedTab,
                                     homepageUrl = uiState.homepageUrl,
                                     searchTemplate = uiState.searchTemplate,
                                     translationProvider = uiState.translationProvider,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -350,9 +350,11 @@ private fun BrowserAppContent(
                                 GeckoBrowserTab(
                                     modifier = modifier,
                                     browserTab = selectedTab,
-                                    // Navigation 3 のバックスタックには複数の Browser エントリが残り得る。
-                                    // 現在 top のエントリだけがフォアグラウンドであり、テストはこのフラグを根拠に
-                                    // 唯一のフォアグラウンド GeckoContainer をタップ対象として一意に特定する。
+                                    /**
+                                     * Navigation 3 のバックスタックには複数の Browser エントリが残り得る。
+                                     * 現在 top のエントリだけがフォアグラウンドであり、テストはこのフラグを根拠に
+                                     * 唯一のフォアグラウンド GeckoContainer をタップ対象として一意に特定する。
+                                     */
                                     isForeground = backStack.lastOrNull() == key,
                                     homepageUrl = uiState.homepageUrl,
                                     searchTemplate = uiState.searchTemplate,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -333,11 +333,6 @@ private fun BrowserAppContent(
                             },
                             browserTabContent = { modifier, selectedTab, tabCount, onToolbarHorizontalDrag, onToolbarDragEnd ->
                                 GeckoBrowserTab(
-                                    /**
-                                     * Navigation 3 のバックスタックには複数の Browser エントリが残り得るため、
-                                     * 前面表示中のタブだけが持つ派生 testTag を外側 Modifier に注入し、
-                                     * テストはその testTag をもとに唯一のフォアグラウンド GeckoContainer を特定する。
-                                     */
                                     modifier = modifier.testTag(
                                         GeckoBrowserTabTestTags.GeckoContainer.testTag(
                                             isForeground = backStack.lastOrNull() == key,

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -209,10 +209,7 @@ internal fun GeckoBrowserTab(
             .collectLatest { count ->
                 if (count == 0) return@collectLatest
                 /**
-                 * GeckoView.capturePixels は Main スレッド必須。collectLatest の継続が
-                 * テスト環境（UnconfinedTestDispatcher 等）で arch_disk_io スレッドに
-                 * 流れて IllegalThreadStateException を引き起こすため、Main.immediate に
-                 * 切り替えてから呼び出す。
+                 * GeckoView.capturePixels は Main スレッド必須。
                  */
                 withContext(Dispatchers.Main.immediate) {
                     geckoView?.also { gv -> state.captureTabPreview(gv) }

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -106,6 +106,7 @@ internal fun GeckoBrowserTab(
     onHistoryTitleUpdate: (suspend (id: Long, title: String) -> Unit)? = null,
     urlBarSuggestions: UrlBarSuggestionsUiState = UrlBarSuggestionsUiState(),
     onUrlInputChanged: ((String) -> Unit)? = null,
+    isForeground: Boolean = true,
 ) {
     val context = LocalContext.current
     val findInPageWebExtension: FindInPageWebExtension = koinInject()
@@ -640,6 +641,17 @@ internal fun GeckoBrowserTab(
                 .weight(1f)
                 .testTag(GeckoBrowserTabTestTags.GeckoContainer.testTag),
         ) {
+            // testTag は Modifier 上では単一の値しか保持できない。フォアグラウンド限定の
+            // セマンティクスを別ノードに分離するため、isForeground のときだけ
+            // matchParentSize の内側 Box にもう一つの testTag を付与する。
+            val foregroundOverlayModifier = if (isForeground) {
+                Modifier
+                    .matchParentSize()
+                    .testTag(GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag)
+            } else {
+                Modifier.matchParentSize()
+            }
+            Box(modifier = foregroundOverlayModifier)
             BrowserContentHost(
                 modifier = Modifier.fillMaxSize(),
                 state = state,
@@ -779,6 +791,11 @@ sealed interface GeckoBrowserTabTestTags {
     val testTag get() = "${GeckoBrowserTabTestTags::class.java.name}#$id"
 
     object GeckoContainer : GeckoBrowserTabTestTags { override val id = "gecko_container" }
+
+    // Navigation 3 のバックスタックに複数の Browser エントリが残ると GeckoContainer は
+    // 複数ノードとして見える。フォアグラウンド（現在表示中）のタブだけが持つ専用タグを用意し、
+    // テストはこちらをタップ対象として一意に特定する。
+    object ForegroundGeckoContainer : GeckoBrowserTabTestTags { override val id = "foreground_gecko_container" }
 }
 
 private const val URL_BAR_IME_HIDE_GRACE_MS = 700L

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -106,7 +106,6 @@ internal fun GeckoBrowserTab(
     onHistoryTitleUpdate: (suspend (id: Long, title: String) -> Unit)? = null,
     urlBarSuggestions: UrlBarSuggestionsUiState = UrlBarSuggestionsUiState(),
     onUrlInputChanged: ((String) -> Unit)? = null,
-    isForeground: Boolean = true,
 ) {
     val context = LocalContext.current
     val findInPageWebExtension: FindInPageWebExtension = koinInject()
@@ -641,19 +640,6 @@ internal fun GeckoBrowserTab(
                 .weight(1f)
                 .testTag(GeckoBrowserTabTestTags.GeckoContainer.testTag),
         ) {
-            /**
-             * testTag は Modifier 上では単一の値しか保持できない。フォアグラウンド限定の
-             * セマンティクスを別ノードに分離するため、isForeground のときだけ
-             * matchParentSize の内側 Box にもう一つの testTag を付与する。
-             */
-            val foregroundOverlayModifier = if (isForeground) {
-                Modifier
-                    .matchParentSize()
-                    .testTag(GeckoBrowserTabTestTags.ForegroundGeckoContainer.testTag)
-            } else {
-                Modifier.matchParentSize()
-            }
-            Box(modifier = foregroundOverlayModifier)
             BrowserContentHost(
                 modifier = Modifier.fillMaxSize(),
                 state = state,
@@ -792,14 +778,17 @@ sealed interface GeckoBrowserTabTestTags {
     val id: String
     val testTag get() = "${GeckoBrowserTabTestTags::class.java.name}#$id"
 
-    object GeckoContainer : GeckoBrowserTabTestTags { override val id = "gecko_container" }
+    object GeckoContainer : GeckoBrowserTabTestTags {
+        override val id = "gecko_container"
 
-    /**
-     * Navigation 3 のバックスタックに複数の Browser エントリが残ると GeckoContainer は
-     * 複数ノードとして見える。フォアグラウンド（現在表示中）のタブだけが持つ専用タグを用意し、
-     * テストはこちらをタップ対象として一意に特定する。
-     */
-    object ForegroundGeckoContainer : GeckoBrowserTabTestTags { override val id = "foreground_gecko_container" }
+        /**
+         * Navigation 3 のバックスタックに複数の Browser エントリが残ると GeckoContainer は
+         * 複数ノードとして見える。前面表示中のタブだけが持つ派生 testTag を返し、
+         * テストはこちらをタップ対象として一意に特定する。
+         */
+        fun testTag(isForeground: Boolean): String =
+            if (isForeground) "$testTag#foreground" else testTag
+    }
 }
 
 private const val URL_BAR_IME_HIDE_GRACE_MS = 700L

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -60,7 +60,9 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.withContext
 import net.matsudamper.browser.data.TranslationProvider
 import net.matsudamper.browser.media.GeckoMediaSessionDelegate
 import net.matsudamper.browser.media.MediaWebExtension
@@ -206,7 +208,15 @@ internal fun GeckoBrowserTab(
         snapshotFlow { state.captureOnPageLoadRequestCount }
             .collectLatest { count ->
                 if (count == 0) return@collectLatest
-                geckoView?.also { gv -> state.captureTabPreview(gv) }
+                /**
+                 * GeckoView.capturePixels は Main スレッド必須。collectLatest の継続が
+                 * テスト環境（UnconfinedTestDispatcher 等）で arch_disk_io スレッドに
+                 * 流れて IllegalThreadStateException を引き起こすため、Main.immediate に
+                 * 切り替えてから呼び出す。
+                 */
+                withContext(Dispatchers.Main.immediate) {
+                    geckoView?.also { gv -> state.captureTabPreview(gv) }
+                }
             }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -791,11 +791,6 @@ sealed interface GeckoBrowserTabTestTags {
     object GeckoContainer : GeckoBrowserTabTestTags {
         override val id = "gecko_container"
 
-        /**
-         * Navigation 3 のバックスタックに複数の Browser エントリが残ると GeckoContainer は
-         * 複数ノードとして見える。前面表示中のタブだけが持つ派生 testTag を返し、
-         * テストはこちらをタップ対象として一意に特定する。
-         */
         fun testTag(isForeground: Boolean): String =
             if (isForeground) "$testTag#foreground" else testTag
     }

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -641,9 +641,11 @@ internal fun GeckoBrowserTab(
                 .weight(1f)
                 .testTag(GeckoBrowserTabTestTags.GeckoContainer.testTag),
         ) {
-            // testTag は Modifier 上では単一の値しか保持できない。フォアグラウンド限定の
-            // セマンティクスを別ノードに分離するため、isForeground のときだけ
-            // matchParentSize の内側 Box にもう一つの testTag を付与する。
+            /**
+             * testTag は Modifier 上では単一の値しか保持できない。フォアグラウンド限定の
+             * セマンティクスを別ノードに分離するため、isForeground のときだけ
+             * matchParentSize の内側 Box にもう一つの testTag を付与する。
+             */
             val foregroundOverlayModifier = if (isForeground) {
                 Modifier
                     .matchParentSize()
@@ -792,9 +794,11 @@ sealed interface GeckoBrowserTabTestTags {
 
     object GeckoContainer : GeckoBrowserTabTestTags { override val id = "gecko_container" }
 
-    // Navigation 3 のバックスタックに複数の Browser エントリが残ると GeckoContainer は
-    // 複数ノードとして見える。フォアグラウンド（現在表示中）のタブだけが持つ専用タグを用意し、
-    // テストはこちらをタップ対象として一意に特定する。
+    /**
+     * Navigation 3 のバックスタックに複数の Browser エントリが残ると GeckoContainer は
+     * 複数ノードとして見える。フォアグラウンド（現在表示中）のタブだけが持つ専用タグを用意し、
+     * テストはこちらをタップ対象として一意に特定する。
+     */
     object ForegroundGeckoContainer : GeckoBrowserTabTestTags { override val id = "foreground_gecko_container" }
 }
 

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
@@ -74,7 +74,6 @@ fun BrowserScreen(
         /**
          * フォアグラウンド遷移直後に findTab が空を返すケースのフレーキー解析用ログ。
          * 該当時間帯に UrlBar が semantics tree から消えるテスト失敗との突き合わせに使う。
-         * 毎フレーム発火を避けるため tabId 単位の LaunchedEffect で 1 回だけ出力する。
          */
         LaunchedEffect(tabId) {
             Log.d(

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
@@ -70,6 +70,12 @@ fun BrowserScreen(
         }
     }
     if (selectedTab == null) {
+        // フォアグラウンド遷移直後に findTab が空を返すケースのフレーキー解析用ログ。
+        // 該当時間帯に UrlBar が semantics tree から消えるテスト失敗との突き合わせに使う。
+        android.util.Log.d(
+            "BrowserScreen",
+            "selectedTab=null tabId=$tabId wasClosed=${browserTabController.wasTabClosed(tabId)}",
+        )
         Box(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
@@ -1,6 +1,7 @@
 package net.matsudamper.browser.ui.browser
 
 import android.graphics.BitmapFactory
+import android.util.Log
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
@@ -70,11 +71,13 @@ fun BrowserScreen(
         }
     }
     if (selectedTab == null) {
-        // フォアグラウンド遷移直後に findTab が空を返すケースのフレーキー解析用ログ。
-        // 該当時間帯に UrlBar が semantics tree から消えるテスト失敗との突き合わせに使う。
-        // 毎フレーム発火を避けるため tabId 単位の LaunchedEffect で 1 回だけ出力する。
+        /**
+         * フォアグラウンド遷移直後に findTab が空を返すケースのフレーキー解析用ログ。
+         * 該当時間帯に UrlBar が semantics tree から消えるテスト失敗との突き合わせに使う。
+         * 毎フレーム発火を避けるため tabId 単位の LaunchedEffect で 1 回だけ出力する。
+         */
         LaunchedEffect(tabId) {
-            android.util.Log.d(
+            Log.d(
                 "BrowserScreen",
                 "selectedTab=null tabId=$tabId wasClosed=${browserTabController.wasTabClosed(tabId)}",
             )

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
@@ -72,10 +72,13 @@ fun BrowserScreen(
     if (selectedTab == null) {
         // フォアグラウンド遷移直後に findTab が空を返すケースのフレーキー解析用ログ。
         // 該当時間帯に UrlBar が semantics tree から消えるテスト失敗との突き合わせに使う。
-        android.util.Log.d(
-            "BrowserScreen",
-            "selectedTab=null tabId=$tabId wasClosed=${browserTabController.wasTabClosed(tabId)}",
-        )
+        // 毎フレーム発火を避けるため tabId 単位の LaunchedEffect で 1 回だけ出力する。
+        LaunchedEffect(tabId) {
+            android.util.Log.d(
+                "BrowserScreen",
+                "selectedTab=null tabId=$tabId wasClosed=${browserTabController.wasTabClosed(tabId)}",
+            )
+        }
         Box(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Summary
- main 直近 30 件で 8 件失敗。うち 5/11 に 3 連続で `AboutBlankNewTabLocationTest.test` が `Failed to inject touch input. / Expected exactly 1 node but found 2 nodes (TestTag = gecko_container)` で落ちていた
- 原因: Navigation 3 のバックスタックに複数の `Browser` エントリが残ると、`GeckoContainer` testTag を持つノードがツリー上に複数同時に存在し、`onNodeWithTag` の "exactly 1" 制約に違反
- 対策: `ForegroundGeckoContainer` testTag を新設し、現在表示中のタブだけが持つようにしてテストから一意特定

## 変更点
- `GeckoBrowserTab` に `isForeground: Boolean = true` を追加
- `testTag` Modifier は単一値しか保持できないため、内側 `matchParentSize` Box に追加タグを付与
- `BrowserApp` で `backStack.lastOrNull() == key` を渡す
- `AboutBlankNewTabLocationTest.tapLinkOnGeckoContainer` を新タグ参照に変更
- `CustomTabActivity` / `WebAppActivity` は単一タブなのでデフォルト (true) のまま

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew detekt`
- [x] `./gradlew test`
- [x] `./gradlew :app:pixel6Api34DebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=net.matsudamper.browser.AboutBlankNewTabLocationTest` （ローカル GMD で 1 回成功）
- [ ] CI で繰り返し回してフレーキーが再発しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreground-tab tracking so the correct tab is treated as foreground when multiple back-stack entries exist.

* **Tests**
  * Enhanced diagnostics for flaky link-opening and tab-selection flows with richer UI dumps and stricter foreground-only selection.
  * Made media-playback readiness checks rely on actual playing state for more reliable assertions.

* **Chores**
  * Added runtime logging for back-stack and transient selected-tab states to aid investigations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/378)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->