### PR TITLE
拡張機能のオプションページ閉じる際に storage.local 書き込み完了を待つ

### DIFF
--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
@@ -98,6 +98,14 @@ class BrowserTab(
         sessionDelegateHost.detachUi()
     }
 
+    /**
+     * session.close() を about:blank へのナビゲーション完了後に遅延実行するよう登録する。
+     * moz-extension:// ページを閉じる際に browser.storage.local の書き込みが完了するまで待つために使用する。
+     */
+    internal fun scheduleCloseOnBlankNavigation(action: () -> Unit) {
+        sessionDelegateHost.scheduleCloseOnBlankNavigation(action)
+    }
+
     fun attachSessionCallbacks(
         callbacks: BrowserSessionStateCallbacks,
         onOpenNewSessionRequest: (String) -> GeckoResult<GeckoSession>,

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
@@ -405,9 +405,20 @@ class BrowserTabController(
     }
 
     private fun disposeTab(tab: BrowserTab, reason: String) {
-        tab.disposeSessionDelegates(CancellationException(reason))
-        if (tab.session.isOpen) {
-            tab.session.close()
+        if (tab.session.isOpen && tab.currentUrl.startsWith("moz-extension://")) {
+            // 拡張機能のオプションページを閉じる際は、about:blank へのナビゲーション完了を待ってから
+            // セッションを閉じる。これにより pagehide イベントが発火し、
+            // browser.storage.local の書き込みが完了する機会を確保する。
+            tab.disposeSessionDelegates(CancellationException(reason))
+            tab.scheduleCloseOnBlankNavigation {
+                tab.session.close()
+            }
+            tab.session.loadUri("about:blank")
+        } else {
+            tab.disposeSessionDelegates(CancellationException(reason))
+            if (tab.session.isOpen) {
+                tab.session.close()
+            }
         }
     }
 

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -215,7 +215,9 @@ internal class BrowserTabSessionDelegateHost(
     private var pendingCloseAction: (() -> Unit)? = null
 
     fun scheduleCloseOnBlankNavigation(action: () -> Unit) {
-        pendingCloseAction = action
+        synchronized(lock) {
+            pendingCloseAction = action
+        }
     }
 
     // タブ切り替え時にUI側コールバックが再生成されるため、最新のナビゲーション状態をキャッシュして
@@ -255,10 +257,10 @@ internal class BrowserTabSessionDelegateHost(
                 // about:blank へのナビゲーション完了時にクローズ処理を実行する
                 // (拡張機能の設定ページを閉じる際に browser.storage.local 書き込みを待つため)
                 if (url == "about:blank") {
-                    pendingCloseAction?.let { action ->
-                        pendingCloseAction = null
-                        action()
+                    val action = synchronized(lock) {
+                        pendingCloseAction.also { pendingCloseAction = null }
                     }
+                    action?.invoke()
                 }
                 currentCallbacks()?.onLocationChange(url)
             }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -210,6 +210,14 @@ internal class BrowserTabSessionDelegateHost(
     private var onCloseRequest: (() -> Unit)? = null
     private val pendingNewSessionRequests = ArrayDeque<PendingNewSessionRequest>()
 
+    // about:blank ナビゲーション完了時に実行するクローズ処理
+    // disposeSessionDelegates 後に session.close() を遅延させるために使用
+    private var pendingCloseAction: (() -> Unit)? = null
+
+    fun scheduleCloseOnBlankNavigation(action: () -> Unit) {
+        pendingCloseAction = action
+    }
+
     // タブ切り替え時にUI側コールバックが再生成されるため、最新のナビゲーション状態をキャッシュして
     // attachUi 時にリプレイする
     private var cachedCanGoBack: Boolean = false
@@ -243,6 +251,14 @@ internal class BrowserTabSessionDelegateHost(
                 }
                 if (url.isNotBlank() && url != "about:blank") {
                     browserTab.pendingInitialUrl = null
+                }
+                // about:blank へのナビゲーション完了時にクローズ処理を実行する
+                // (拡張機能の設定ページを閉じる際に browser.storage.local 書き込みを待つため)
+                if (url == "about:blank") {
+                    pendingCloseAction?.let { action ->
+                        pendingCloseAction = null
+                        action()
+                    }
                 }
                 currentCallbacks()?.onLocationChange(url)
             }


### PR DESCRIPTION
## 概要

拡張機能のオプションページ（`moz-extension://` URL）を閉じる際に、`browser.storage.local` への書き込みが完了するまで待つようにしました。

## 変更内容

- **BrowserTabController.disposeTab()**: 
  - `moz-extension://` で始まるURLのセッション閉じる際、`about:blank` へのナビゲーション完了を待ってからセッションを閉じるように変更
  - `scheduleCloseOnBlankNavigation()` で遅延クローズ処理を登録し、`about:blank` ナビゲーション完了時に実行

- **GeckoSessionDelegateHost**:
  - `pendingCloseAction` フィールドを追加し、`about:blank` ナビゲーション完了時に実行するクローズ処理を保持
  - `scheduleCloseOnBlankNavigation()` メソッドを追加
  - `onLocationChange()` で `about:blank` ナビゲーション完了を検出し、登録されたクローズ処理を実行

- **BrowserTab**:
  - `scheduleCloseOnBlankNavigation()` メソッドを追加し、`sessionDelegateHost` の同メソッドに委譲

## 実装の詳細

拡張機能のオプションページでは、ページを離れる際に `pagehide` イベントが発火し、このイベント内で `browser.storage.local` への書き込みが行われます。セッションを即座に閉じるとこの書き込みが完了しない可能性があるため、`about:blank` へのナビゲーション完了（`pagehide` イベント発火後）を待ってからセッションを閉じるようにしました。

https://claude.ai/code/session_012a4vwce9HzUgQkFFdSBFiw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension option page closure: closing such tabs now waits for a final blank navigation to complete so in-page storage writes finish and resources are cleaned up reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/379)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/379)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->