### PR TITLE
fix: PullToRefresh の丸がワープして意図せずリロードされる問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import net.matsudamper.browser.ui.browser.UrlBarSuggestionsUiState
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
@@ -68,7 +67,7 @@ internal fun BrowserContentHost(
                 .fillMaxSize()
                 .clipToBounds(),
             factory = { context ->
-                SwipeRefreshLayout(context).also { swipeRefreshLayout ->
+                GeckoSwipeRefreshLayout(context).also { swipeRefreshLayout ->
                     var swipeRefreshScrollEnabled = false
                     val gecko = GeckoView(context).also { geckoView ->
                         geckoView.id = id

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoSwipeRefreshLayout.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoSwipeRefreshLayout.kt
@@ -1,0 +1,32 @@
+package net.matsudamper.browser
+
+import android.content.Context
+import android.view.MotionEvent
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+
+// SwipeRefreshLayout は ACTION_DOWN 時点で canChildScrollUp() が true だと
+// onInterceptTouchEvent が fail-fast し mInitialDownY を更新しない仕様。
+// その状態で非同期に判定が反転すると、直後の ACTION_MOVE で古い
+// mInitialDownY を基準に差分計算が走り、ロード丸が一気に下へワープして
+// しまう。これを防ぐため ACTION_DOWN dispatch 中だけ canChildScrollUp()
+// を強制的に false にして DOWN を必ず親に拾わせ、最新の Y を記録させる。
+internal class GeckoSwipeRefreshLayout(context: Context) : SwipeRefreshLayout(context) {
+
+    private var currentDispatchAction: Int = MotionEvent.ACTION_CANCEL
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        currentDispatchAction = ev.actionMasked
+        return try {
+            super.dispatchTouchEvent(ev)
+        } finally {
+            currentDispatchAction = MotionEvent.ACTION_CANCEL
+        }
+    }
+
+    override fun canChildScrollUp(): Boolean {
+        // ACTION_DOWN 中は fail-fast を回避して mInitialDownY を必ず最新値で
+        // 記録させる。MOVE 以降は setOnChildScrollUpCallback の判定に委ねる。
+        if (currentDispatchAction == MotionEvent.ACTION_DOWN) return false
+        return super.canChildScrollUp()
+    }
+}


### PR DESCRIPTION
## 概要

GeckoView を操作した後にスクロール不可な部分を下に少しなぞるだけで、PullToRefresh のロード丸が一気に下にワープし、意図せずリロードが走ってしまう問題を根本対処します。

## 原因

`BrowserTabSurface.kt` の `BrowserContentHost` における `SwipeRefreshLayout`+`GeckoView` 実装で、タッチ判定とインジケーター位置記録のタイミングが噛み合っていませんでした。

1. `OnTouchListener` が `ACTION_DOWN` で `swipeRefreshScrollEnabled = false` を**同期**セットし、`onTouchEventForDetailResult(event).then { ... }` で**非同期**に最終値を確定する設計。
2. `setOnChildScrollUpCallback` は `!swipeRefreshScrollEnabled || state.scrollY > 0` を返すため、DOWN 直後は `true`（=「子がスクロール可能」）を返してしまう。
3. `SwipeRefreshLayout.onInterceptTouchEvent` は ACTION_DOWN 時点で `canChildScrollUp() == true` だと **fail-fast し `mInitialDownY` を更新しない**仕様（前回ジェスチャの古い座標が残る）。
4. 直後の ACTION_MOVE では非同期完了で `swipeRefreshScrollEnabled = true` になり、`state.scrollY == 0` の条件で callback が false を返して MOVE が処理される。このとき**古い `mInitialDownY` との差分が巨大**になり、丸が一気にワープし refresh 閾値も即超過する。

`onTouchEventForDetailResult` 採用は `INPUT_RESULT_CONTENT_HANDLED`（JS が touch を捕まえるケース）と `HANDLED`/`UNHANDLED` を区別する必要があるため維持し、`SwipeRefreshLayout` 側の DOWN 取りこぼしをピンポイントで解消します。

## 変更内容

### 新規: `GeckoSwipeRefreshLayout.kt`

`SwipeRefreshLayout` を継承したサブクラスを追加し、ACTION_DOWN dispatch 中のみ `canChildScrollUp()` を強制 false にすることで `super.onInterceptTouchEvent` が DOWN を必ず処理し、`mInitialDownY` を最新値で記録させます。MOVE 以降は従来通り `setOnChildScrollUpCallback` の判定に委ねます。

```kotlin
internal class GeckoSwipeRefreshLayout(context: Context) : SwipeRefreshLayout(context) {
    private var currentDispatchAction: Int = MotionEvent.ACTION_CANCEL

    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
        currentDispatchAction = ev.actionMasked
        return try {
            super.dispatchTouchEvent(ev)
        } finally {
            currentDispatchAction = MotionEvent.ACTION_CANCEL
        }
    }

    override fun canChildScrollUp(): Boolean {
        if (currentDispatchAction == MotionEvent.ACTION_DOWN) return false
        return super.canChildScrollUp()
    }
}
```

### 変更: `BrowserTabSurface.kt`

- `SwipeRefreshLayout(context)` → `GeckoSwipeRefreshLayout(context)` に置換
- 未使用となった `SwipeRefreshLayout` の import を削除

`OnTouchListener`、`onTouchEventForDetailResult` 判定、`setOnChildScrollUpCallback`、`setOnRefreshListener` などの周辺ロジックは保持しています。

## 期待される挙動

| ケース | callback 結果 | refresh |
|---|---|---|
| ACTION_DOWN | サブクラスにより常に false（`mInitialDownY` を最新値で記録） | 起動しない（DOWN 段階） |
| 非同期確定後 (UNHANDLED/HANDLED) かつ `scrollY == 0` | false | 最新の `mInitialDownY` を起点に正常動作 |
| 非同期確定後 (UNHANDLED/HANDLED) かつ `scrollY > 0` | true | 起動しない |
| CONTENT_HANDLED（JS が touch を奪う） | true（`swipeRefreshScrollEnabled` が false のまま） | 起動しない |

## 副作用・注意点

- `mIsBeingDragged` は `super.onInterceptTouchEvent` の DOWN 分岐で false にリセットされるため、前回ジェスチャの drag 状態が漏れる懸念は解消。
- `setTargetOffsetTopAndBottom` の DOWN 段階呼び出しはインジケーターを初期位置に戻すだけで、表示状態を変えない。
- タッチイベントは UI スレッドで一貫処理されるため `currentDispatchAction` のスレッド競合なし。
- Paparazzi: `BrowserContentHost` は `AndroidView` + `GeckoView` 実体に依存し `@Preview` 対象外のため影響なし。

## Test plan

- [x] `./gradlew :app:assembleDebug` — 成功
- [x] `./gradlew :app:detekt` — findings 0
- [ ] `./gradlew test` — `:feature-browser:compileDebugUnitTestKotlin` で `InvalidPathException: Malformed input or input contains unmappable characters` が発生。テストクラス名の日本語をファイルシステムが扱えない CI 環境固有の問題で、本変更とは無関係（`:app` モジュール以外）。
- [ ] 手動: スクロール不可な短いページで GeckoView 操作後に下方向へ少しドラッグ → 丸がワープせず、touchSlop 以上引かない限り refresh が起動しないこと
- [ ] 手動: スクロール後にトップ復帰した直後の下方向ちょいドラッグ → 同様にワープなし
- [ ] 手動: JS が touch を奪うページ（地図系など）でドラッグ → refresh が起動しないこと
- [ ] 手動: 通常の上端からのプル → 従来通り refresh が動くこと

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrWrseF2iczTGbskTbXtKM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll position jumping that occurred when using the pull-to-refresh gesture on web pages. The refresh functionality now operates smoothly without unexpected scroll displacement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/380)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->