### PR TITLE
カスタムタブから通常ブラウザへの遷移時に履歴・スクロール位置を引き継ぐ

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -81,7 +81,7 @@ import org.koin.compose.koinInject
 @Composable
 internal fun BrowserApp(
     viewModel: BrowserViewModel,
-    newTabUrlFlow: Flow<String>,
+    newTabUrlFlow: Flow<NewTabRequest>,
     openDownloadsFlow: Flow<Unit>,
     onInstallExtensionRequest: (String) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit,
@@ -111,7 +111,7 @@ internal fun BrowserApp(
 private fun BrowserAppContent(
     uiState: BrowserAppUiState,
     viewModel: BrowserViewModel,
-    newTabUrlFlow: Flow<String>,
+    newTabUrlFlow: Flow<NewTabRequest>,
     openDownloadsFlow: Flow<Unit>,
     onInstallExtensionRequest: (String) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit,
@@ -192,7 +192,7 @@ private fun BrowserAppContent(
     LaunchedEffect(newTabUrlFlow) {
         // タブ復元完了を待ってから外部URLを処理する（レースコンディション防止）
         setupComplete.await()
-        newTabUrlFlow.collect { url ->
+        newTabUrlFlow.collect { request ->
             // デフォルトグループが設定されている場合、createAndAppendTab より先に DB 行を作成して
             // グループを確定させる。こうすることで TabsScreenViewModel のウォッチャーが発火した際に
             // このタブはすでに assignedTabIds に含まれ、アクティブグループへの上書きを防ぐ。
@@ -203,7 +203,12 @@ private fun BrowserAppContent(
             if (defaultGroupId != null) {
                 tabGroupRepository.assignTabToGroup(tabId, defaultGroupId)
             }
-            val newTab = browserTabController.createAndAppendTab(tabId = tabId, initialUrl = url)
+            // カスタムタブからの引き継ぎがある場合は SessionState を復元して履歴ごと開く
+            val newTab = browserTabController.createAndAppendTab(
+                tabId = tabId,
+                initialUrl = request.url,
+                restoredSessionState = request.sessionState,
+            )
             // selectTab より前に呼ぶことで、外部タブ開封前の selectedTabId を記録できる
             viewModel.registerExternalTab(newTab.tabId)
             selectTab(newTab.tabId, null)

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -149,12 +149,20 @@ class CustomTabActivity : ComponentActivity() {
         deferred.await()
     }
 
-    private fun openInMainBrowser(url: String) {
+    private fun openInMainBrowser(url: String, sessionState: String) {
         val targetUri = Uri.parse(url)
         startActivity(
             Intent(this, MainActivity::class.java).apply {
                 action = Intent.ACTION_VIEW
                 data = targetUri
+                // 履歴・スクロール位置などを引き継ぐため、SessionState をプロセス内ストアへ預けて
+                // トークンのみを Intent に載せる（Intent extra へ直接載せると Binder サイズ上限に当たり得る）
+                sessionState.takeIf { it.isNotBlank() }?.let { state ->
+                    putExtra(
+                        CustomTabHandoffStore.EXTRA_HANDOFF_TOKEN,
+                        CustomTabHandoffStore.store(state),
+                    )
+                }
             }
         )
         finish()
@@ -176,7 +184,7 @@ private fun CustomTabScreen(
     themeColorExtension: ThemeColorWebExtension,
     mediaWebExtension: MediaWebExtension,
     onClose: () -> Unit,
-    onOpenInBrowser: (String) -> Unit,
+    onOpenInBrowser: (url: String, sessionState: String) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit,
 ) {
     val viewModel = viewModel(initializer = {
@@ -247,7 +255,7 @@ private fun CustomTabScreen(
         showInstallExtensionItem = false,
         customTabMode = true,
         onCloseCustomTab = onClose,
-        onOpenInBrowser = onOpenInBrowser,
+        onOpenInBrowser = { url -> onOpenInBrowser(url, activeTab.sessionState) },
         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
         onOpenNewSessionRequest = { null },

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -22,12 +22,17 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.data.TabRepository
 import net.matsudamper.browser.data.TranslationProvider
@@ -195,6 +200,7 @@ private fun CustomTabScreen(
         )
     })
     val uiState by viewModel.uiState.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
     val prewarmedSession = remember(customTabsSessionToken, initialUrl) {
         customTabsSessionToken?.let { token ->
             CustomTabsWarmupStore.consumePreparedSession(
@@ -255,7 +261,13 @@ private fun CustomTabScreen(
         showInstallExtensionItem = false,
         customTabMode = true,
         onCloseCustomTab = onClose,
-        onOpenInBrowser = { url -> onOpenInBrowser(url, activeTab.sessionState) },
+        onOpenInBrowser = { url ->
+            // キャッシュ済みの sessionState はスクロール位置などを取りこぼした古いスナップショットの
+            // ことがあるため、flushSessionState() で最新状態の反映を待ってから引き継ぐ。
+            coroutineScope.launch {
+                onOpenInBrowser(url, captureFreshSessionState(activeTab))
+            }
+        },
         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
         onOpenNewSessionRequest = { null },
@@ -269,3 +281,18 @@ private fun CustomTabScreen(
         onUrlInputChanged = uiState.callbacks::onUrlInputChanged,
     )
 }
+
+/**
+ * flushSessionState() で最新の SessionState を onSessionStateChange 経由で反映させ、
+ * 更新後の [BrowserTab.sessionState] を返す。スクロール位置などを取りこぼさないために使う。
+ * 反映が一定時間内に来ない場合（既に最新の場合を含む）は現在のキャッシュ値を返す。
+ */
+private suspend fun captureFreshSessionState(tab: BrowserTab): String {
+    val before = tab.sessionState
+    tab.session.flushSessionState()
+    return withTimeoutOrNull(FLUSH_SESSION_STATE_TIMEOUT_MS) {
+        snapshotFlow { tab.sessionState }.first { it != before }
+    } ?: tab.sessionState
+}
+
+private const val FLUSH_SESSION_STATE_TIMEOUT_MS = 300L

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -22,13 +22,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -154,7 +154,20 @@ class CustomTabActivity : ComponentActivity() {
         deferred.await()
     }
 
-    private fun openInMainBrowser(url: String, sessionState: String) {
+    /**
+     * カスタムタブの内容を通常ブラウザへ引き継いで開く。
+     *
+     * SessionState の flush 待ち（最大数百ミリ秒）と遷移を、composition に紐づくスコープでなく
+     * Activity の lifecycleScope で完遂させる。タップ直後の再コンポーズで Composable が
+     * composition から外れても処理がキャンセルされず、「ブラウザで開く」が無効化されないようにする。
+     */
+    private fun openInMainBrowser(url: String, tab: BrowserTab) {
+        lifecycleScope.launch {
+            startMainBrowser(url, captureFreshSessionState(tab))
+        }
+    }
+
+    private fun startMainBrowser(url: String, sessionState: String) {
         val targetUri = Uri.parse(url)
         startActivity(
             Intent(this, MainActivity::class.java).apply {
@@ -189,7 +202,7 @@ private fun CustomTabScreen(
     themeColorExtension: ThemeColorWebExtension,
     mediaWebExtension: MediaWebExtension,
     onClose: () -> Unit,
-    onOpenInBrowser: (url: String, sessionState: String) -> Unit,
+    onOpenInBrowser: (url: String, tab: BrowserTab) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit,
 ) {
     val viewModel = viewModel(initializer = {
@@ -200,7 +213,6 @@ private fun CustomTabScreen(
         )
     })
     val uiState by viewModel.uiState.collectAsState()
-    val coroutineScope = rememberCoroutineScope()
     val prewarmedSession = remember(customTabsSessionToken, initialUrl) {
         customTabsSessionToken?.let { token ->
             CustomTabsWarmupStore.consumePreparedSession(
@@ -261,13 +273,7 @@ private fun CustomTabScreen(
         showInstallExtensionItem = false,
         customTabMode = true,
         onCloseCustomTab = onClose,
-        onOpenInBrowser = { url ->
-            // キャッシュ済みの sessionState はスクロール位置などを取りこぼした古いスナップショットの
-            // ことがあるため、flushSessionState() で最新状態の反映を待ってから引き継ぐ。
-            coroutineScope.launch {
-                onOpenInBrowser(url, captureFreshSessionState(activeTab))
-            }
-        },
+        onOpenInBrowser = { url -> onOpenInBrowser(url, activeTab) },
         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
         onOpenNewSessionRequest = { null },

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabHandoffStore.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabHandoffStore.kt
@@ -1,0 +1,69 @@
+package net.matsudamper.browser
+
+import androidx.annotation.VisibleForTesting
+import java.util.UUID
+
+/**
+ * カスタムタブから通常ブラウザへ「ブラウザで開く」した際に、GeckoSession の状態
+ * （履歴・スクロール位置など）を引き継ぐためのプロセス内受け渡しストア。
+ *
+ * SessionState 文字列を Intent extra に直接載せると Binder のトランザクションサイズ上限に
+ * 当たり得るため、状態本体はこのストアに保持し、Intent ではトークンのみを渡す。
+ *
+ * 複数のカスタムタブが同時に存在しても衝突しないよう、受け渡しごとに一意のトークンを発行する。
+ */
+object CustomTabHandoffStore {
+    const val EXTRA_HANDOFF_TOKEN = "net.matsudamper.browser.extra.CUSTOM_TAB_HANDOFF_TOKEN"
+
+    // 受け渡しは startActivity 直後に消費される想定だが、コールドスタートや構成変更に備えて余裕を持たせる
+    private const val STALE_ENTRY_MS = 2 * 60 * 1000L
+
+    // 取り出されないまま溜まり続けないよう、保持件数に上限を設ける
+    private const val MAX_ENTRIES = 8
+
+    private val lock = Any()
+    private val entries = linkedMapOf<String, Entry>()
+
+    private data class Entry(
+        val sessionState: String,
+        val createdAt: Long = System.currentTimeMillis(),
+    )
+
+    /** 引き継ぐ SessionState を登録し、Intent に載せるトークンを返す。 */
+    fun store(sessionState: String): String {
+        val token = UUID.randomUUID().toString()
+        synchronized(lock) {
+            cleanupLocked()
+            if (entries.size >= MAX_ENTRIES) {
+                entries.keys.firstOrNull()?.let { entries.remove(it) }
+            }
+            entries[token] = Entry(sessionState = sessionState)
+        }
+        return token
+    }
+
+    /** トークンに対応する SessionState を取り出して削除する。存在しなければ null。 */
+    fun consume(token: String): String? {
+        return synchronized(lock) {
+            cleanupLocked()
+            entries.remove(token)?.sessionState
+        }
+    }
+
+    private fun cleanupLocked() {
+        val now = System.currentTimeMillis()
+        val iterator = entries.values.iterator()
+        while (iterator.hasNext()) {
+            if (now - iterator.next().createdAt > STALE_ENTRY_MS) {
+                iterator.remove()
+            }
+        }
+    }
+
+    @VisibleForTesting
+    fun resetForTesting() {
+        synchronized(lock) {
+            entries.clear()
+        }
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : ComponentActivity() {
     private var webExtensionWarmUpInProgress = false
     private var webExtensionWarmUpRetryCount = 0
     private var lastProcessedDeepLinkUrl: String? = null
-    private val createNewTabChannel = Channel<String>(Channel.UNLIMITED)
+    private val createNewTabChannel = Channel<NewTabRequest>(Channel.UNLIMITED)
     private val openDownloadsChannel = Channel<Unit>(Channel.CONFLATED)
 
     // リコンポーズのたびに新しい Flow が生成されチャネルがキャンセルされるのを防ぐため、
@@ -140,7 +140,9 @@ class MainActivity : ComponentActivity() {
             // 設定変更（画面回転等）後の再起動では直前に処理した URL を復元し、
             // 同じ URL であれば重複タブを作らないようスキップする。
             if (url != null && url != lastProcessedDeepLinkUrl) {
-                val result = createNewTabChannel.trySend(url)
+                val result = createNewTabChannel.trySend(
+                    NewTabRequest(url = url, sessionState = consumeHandoffSessionState(intent)),
+                )
                 if (result.isFailure) {
                     Log.e("MainActivity", "URL の送信に失敗: $url, reason=${result.exceptionOrNull()}")
                 } else {
@@ -200,13 +202,24 @@ class MainActivity : ComponentActivity() {
         }
         val url = intent.dataString
         if (url != null) {
-            val result = createNewTabChannel.trySend(url)
+            val result = createNewTabChannel.trySend(
+                NewTabRequest(url = url, sessionState = consumeHandoffSessionState(intent)),
+            )
             if (result.isFailure) {
                 Log.e("MainActivity", "URL の送信に失敗: $url, reason=${result.exceptionOrNull()}")
             } else {
                 lastProcessedDeepLinkUrl = url
             }
         }
+    }
+
+    /**
+     * カスタムタブからの「ブラウザで開く」遷移であれば、預けられた SessionState を取り出す。
+     * トークンは一度のみ消費され、構成変更後の再 onCreate では null（重複生成は URL 重複判定で防止）。
+     */
+    private fun consumeHandoffSessionState(intent: Intent): String? {
+        val token = intent.getStringExtra(CustomTabHandoffStore.EXTRA_HANDOFF_TOKEN) ?: return null
+        return CustomTabHandoffStore.consume(token)
     }
 
     /**

--- a/app/src/main/kotlin/net/matsudamper/browser/NewTabRequest.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/NewTabRequest.kt
@@ -1,0 +1,12 @@
+package net.matsudamper.browser
+
+/**
+ * 外部 Intent 等から新規タブを開く際の要求。
+ *
+ * [sessionState] が指定されている場合は、カスタムタブからの引き継ぎとして
+ * GeckoSession の状態（履歴・スクロール位置など）を復元する。
+ */
+internal data class NewTabRequest(
+    val url: String,
+    val sessionState: String? = null,
+)

--- a/app/src/test/kotlin/net/matsudamper/browser/CustomTabHandoffStoreTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/CustomTabHandoffStoreTest.kt
@@ -1,0 +1,43 @@
+package net.matsudamper.browser
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CustomTabHandoffStoreTest {
+
+    @After
+    fun tearDown() {
+        CustomTabHandoffStore.resetForTesting()
+    }
+
+    @Test
+    fun `store して consume すると同じ状態が返る`() {
+        val token = CustomTabHandoffStore.store("state-A")
+        assertEquals("state-A", CustomTabHandoffStore.consume(token))
+    }
+
+    @Test
+    fun `consume すると削除され二度目は null`() {
+        val token = CustomTabHandoffStore.store("state-A")
+        CustomTabHandoffStore.consume(token)
+        assertNull(CustomTabHandoffStore.consume(token))
+    }
+
+    @Test
+    fun `複数カスタムタブは独立したトークンを持ち取り出し順に依存しない`() {
+        val tokenA = CustomTabHandoffStore.store("state-A")
+        val tokenB = CustomTabHandoffStore.store("state-B")
+
+        assertNotEquals(tokenA, tokenB)
+        assertEquals("state-B", CustomTabHandoffStore.consume(tokenB))
+        assertEquals("state-A", CustomTabHandoffStore.consume(tokenA))
+    }
+
+    @Test
+    fun `未知のトークンは null`() {
+        assertNull(CustomTabHandoffStore.consume("does-not-exist"))
+    }
+}


### PR DESCRIPTION
## 概要

カスタムタブの「ブラウザで開く」機能から通常ブラウザへ遷移する際に、GeckoSession の履歴・スクロール位置などの状態を引き継ぐ機能を実装しました。

## 主な変更

- **CustomTabHandoffStore の新規作成**
  - SessionState をプロセス内で一時保持するストア
  - Intent extra へ直接載せると Binder トランザクションサイズ上限に当たるため、状態本体はストアに保持し Intent にはトークンのみを渡す
  - 複数のカスタムタブが同時に存在しても衝突しないよう UUID ベースのトークンを発行
  - 古いエントリの自動削除と保持件数の上限管理を実装

- **CustomTabActivity の修正**
  - `openInMainBrowser()` に sessionState パラメータを追加
  - `captureFreshSessionState()` で最新の SessionState を取得（flushSessionState で更新を待機）
  - スクロール位置などを取りこぼさないため、遷移時に最新状態の反映を待つ

- **MainActivity の修正**
  - `createNewTabChannel` の型を `String` から `NewTabRequest` に変更
  - `consumeHandoffSessionState()` で Intent からトークンを取り出し SessionState を復元

- **BrowserApp の修正**
  - `newTabUrlFlow` の型を `Flow<String>` から `Flow<NewTabRequest>` に変更
  - 新規タブ作成時に `restoredSessionState` を指定して履歴を復元

- **NewTabRequest の新規作成**
  - 外部 Intent からの新規タブ要求を表現するデータクラス
  - URL と SessionState（オプション）を保持

## テスト

CustomTabHandoffStoreTest で以下をカバー：
- store/consume の基本動作
- 複数トークンの独立性
- consume による削除確認
- 未知トークンの null 返却

https://claude.ai/code/session_011U4Vs31TboTnr4dsApyhao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom tabs now support complete session state handoff to the main browser, preserving browsing history, scroll position, and other session data. This ensures seamless browsing continuity when opening links from custom tabs in the main application.

* **Tests**
  * Added test coverage for session state storage, transfer, and retrieval in custom tab integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->