### PR TITLE
復元タブのスクロール位置を BrowserTab で保持して PullToRefresh 誤発動を防止

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -242,7 +242,11 @@ internal class BrowserTabScreenState(
 
     // --- Scroll / Refresh state ---
     var isRefreshing by mutableStateOf(false)
-    var scrollY by mutableIntStateOf(0)
+    // BrowserTab.scrollY に委譲することで、タブ切替で State が再生成されても
+    // スクロール位置を保持し、復元タブでの PullToRefresh 誤発動を防ぐ。
+    var scrollY: Int
+        get() = browserTab.scrollY
+        set(value) { browserTab.scrollY = value }
 
     val showInstallExtensionItem: Boolean
         get() = resolveAmoInstallUriFromPage(currentPageUrl) != null

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser
 import android.graphics.Bitmap
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import org.mozilla.geckoview.GeckoResult
@@ -78,6 +79,12 @@ class BrowserTab(
 
     // ページのfavicon（ホーム追加時のアイコンに使用、永続化は不要）
     var faviconBitmap: Bitmap? by mutableStateOf(null)
+
+    // スクロール位置（永続化は不要）。BrowserTabScreenState がタブ切替で再生成されても
+    // GeckoSession と同じ寿命を持つここで保持することで、復元タブのスクロール位置を維持する。
+    // State 側にだけ持つと、復元直後は GeckoSession のスクロール位置が変化せず
+    // onScrollChanged が発火しないため 0 のままとなり、PullToRefresh が誤発動する。
+    var scrollY: Int by mutableIntStateOf(0)
 
     // 未オープンタブのセッション復元情報を保持
     internal var pendingSessionState: String? by mutableStateOf(null)


### PR DESCRIPTION
## 概要

タブ切替時に `BrowserTabScreenState` が再生成されてもスクロール位置を保持するため、スクロール位置の管理を `BrowserTab` に移行しました。これにより、復元タブでの PullToRefresh の誤発動を防ぎます。

## 主な変更

- **BrowserTab.kt**: `scrollY` プロパティを追加
  - `mutableIntStateOf(0)` で初期化
  - GeckoSession と同じ寿命を持つため、タブ切替後も値が保持される
  - コメントで、State 側のみに持つと `onScrollChanged` が発火しないため 0 のままになり PullToRefresh が誤発動する理由を説明

- **BrowserTabScreenState.kt**: `scrollY` を委譲プロパティに変更
  - `get()` で `browserTab.scrollY` を返す
  - `set()` で `browserTab.scrollY` に値を設定
  - タブ切替で State が再生成されても、BrowserTab の scrollY を参照することで値が保持される

## 実装の詳細

スクロール位置を BrowserTab で保持することで、以下の問題を解決します：
- 復元タブでタブ切替直後、GeckoSession のスクロール位置が変化せず `onScrollChanged` が発火しない
- その結果 scrollY が 0 のままになり、PullToRefresh が誤発動する

BrowserTabScreenState の scrollY は BrowserTab の scrollY に委譲することで、State の再生成に影響されず値を保持できます。

https://claude.ai/code/session_01Bn3XiETFZ5qq3oJhbzJzxz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed scroll position preservation when switching between tabs, ensuring the scroll state is maintained when tabs are restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->