### PR TITLE
APKファイルのインストール権限チェックと設定画面への誘導

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser.screen.downloads
 import android.app.Application
 import android.app.DownloadManager
 import android.content.Intent
+import android.provider.MediaStore
 import android.provider.Settings
 import androidx.core.net.toUri
 import androidx.lifecycle.AndroidViewModel
@@ -156,11 +157,18 @@ internal class DownloadManagementScreenViewModel(
         val app = getApplication<Application>()
         val uri = fileUri.toUri()
         val mimeType = app.contentResolver.getType(uri) ?: "*/*"
+        // MediaStore の content:// URI では lastPathSegment が数値IDになるため、
+        // DISPLAY_NAME を取得してファイル名による拡張子チェックも行う
+        val displayName = app.contentResolver.query(
+            uri, arrayOf(MediaStore.MediaColumns.DISPLAY_NAME), null, null, null,
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) cursor.getString(0) else null
+        }
+        val isApk = mimeType.equals("application/vnd.android.package-archive", ignoreCase = true) ||
+            (displayName?.endsWith(".apk", ignoreCase = true) == true)
 
         // APKの場合、提供元不明アプリのインストール権限がなければ設定画面へ誘導する
-        if (mimeType == "application/vnd.android.package-archive" &&
-            !app.packageManager.canRequestPackageInstalls()
-        ) {
+        if (isApk && !app.packageManager.canRequestPackageInstalls()) {
             val settingsIntent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
                 data = "package:${app.packageName}".toUri()
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -169,8 +177,10 @@ internal class DownloadManagementScreenViewModel(
             return
         }
 
+        // 拡張子でAPKと判定された場合は確実にインストーラーが起動するようMIMEタイプを補正する
+        val effectiveMimeType = if (isApk) "application/vnd.android.package-archive" else mimeType
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, mimeType)
+            setDataAndType(uri, effectiveMimeType)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION
         }
         runCatching { app.startActivity(intent) }

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser.screen.downloads
 import android.app.Application
 import android.app.DownloadManager
 import android.content.Intent
+import android.provider.Settings
 import androidx.core.net.toUri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -155,6 +156,19 @@ internal class DownloadManagementScreenViewModel(
         val app = getApplication<Application>()
         val uri = fileUri.toUri()
         val mimeType = app.contentResolver.getType(uri) ?: "*/*"
+
+        // APKの場合、提供元不明アプリのインストール権限がなければ設定画面へ誘導する
+        if (mimeType == "application/vnd.android.package-archive" &&
+            !app.packageManager.canRequestPackageInstalls()
+        ) {
+            val settingsIntent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                data = "package:${app.packageName}".toUri()
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            runCatching { app.startActivity(settingsIntent) }
+            return
+        }
+
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, mimeType)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION


### PR DESCRIPTION
## 概要
ダウンロードしたAPKファイルを開く際に、提供元不明アプリのインストール権限をチェックし、権限がない場合は設定画面へ誘導するようにしました。

## 変更内容
- **DownloadManagementScreenViewModel.kt**
  - APKファイル（`application/vnd.android.package-archive`）を開く前に、`canRequestPackageInstalls()` で権限をチェック
  - 権限がない場合は `Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES` インテントで設定画面へ誘導
  - 権限がある場合は従来通りインテントで開く

- **AndroidManifest.xml**
  - `REQUEST_INSTALL_PACKAGES` パーミッションを追加

## 実装の詳細
- APKファイルの判定はMIMEタイプで行う
- 設定画面へのインテント起動時にエラーが発生した場合は `runCatching` で安全に処理
- インテントには `FLAG_ACTIVITY_NEW_TASK` フラグを設定して新しいタスクで起動

https://claude.ai/code/session_018wJ18itNEqVX5h6ZLnFgr5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of APK file installations by directing users to system settings when required permissions are unavailable.

* **Chores**
  * Added system permission for package installation requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matsudamper/browsem/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->