### PR TITLE
fix: ダウンロードが0バイトで完了する不具合を修正（レスポンスボディの直接保存）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,6 +165,7 @@ dependencies {
 
     testImplementation(libs.junit4)
     testImplementation(libs.composable.preview.scanner)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -587,16 +587,14 @@ internal class BrowserTabScreenState(
     fun confirmPendingDownload() {
         val response = pendingDownloadResponse ?: return
         pendingDownloadResponse = null
-        // suspend 前に必要な情報を取り出し、body は即座にクローズする
-        // （許可ダイアログ中にキャンセルされても body がリークしないようにするため）
-        val downloadUrl = response.uri
-        response.body?.close()
+        // body はクローズせず、Worker がボディ（実データ）を直接保存できるよう response ごと引き渡す。
+        // パスワード submit(POST)・ワンタイムURL のダウンロードを 0 バイトにしないため。
         val referrerUrl = currentPageUrl
         coroutineScope.launch {
             // ダウンロード進捗を通知で表示するためにパーミッションを要求し、ユーザーの応答を待つ
             onRequestDownloadNotificationPermission()
-            geckoDownloadManager.enqueueDownload(
-                url = downloadUrl,
+            geckoDownloadManager.enqueueDownloadFromResponse(
+                response = response,
                 referrerUrl = referrerUrl,
                 coroutineScope = coroutineScope,
             )

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -591,13 +591,22 @@ internal class BrowserTabScreenState(
         // パスワード submit(POST)・ワンタイムURL のダウンロードを 0 バイトにしないため。
         val referrerUrl = currentPageUrl
         coroutineScope.launch {
-            // ダウンロード進捗を通知で表示するためにパーミッションを要求し、ユーザーの応答を待つ
-            onRequestDownloadNotificationPermission()
-            geckoDownloadManager.enqueueDownloadFromResponse(
-                response = response,
-                referrerUrl = referrerUrl,
-                coroutineScope = coroutineScope,
-            )
+            var enqueued = false
+            try {
+                // ダウンロード進捗を通知で表示するためにパーミッションを要求し、ユーザーの応答を待つ
+                onRequestDownloadNotificationPermission()
+                geckoDownloadManager.enqueueDownloadFromResponse(
+                    response = response,
+                    referrerUrl = referrerUrl,
+                    coroutineScope = coroutineScope,
+                )
+                enqueued = true
+            } finally {
+                // 権限待ち中などにキャンセルされ、エンキューに到達しなかった場合はボディを閉じてリークを防ぐ
+                if (!enqueued) {
+                    response.body?.close()
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
@@ -16,9 +16,14 @@ import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.CancellationException
 import net.matsudamper.browser.data.download.DownloadRepository
+import net.matsudamper.browser.download.DownloadEngine
+import net.matsudamper.browser.download.DownloadHttpClient
+import net.matsudamper.browser.download.DownloadHttpResponse
+import net.matsudamper.browser.download.DownloadMetadata
+import net.matsudamper.browser.download.GeckoDownloadHttpClient
+import net.matsudamper.browser.download.PendingDownloadBodyStore
+import net.matsudamper.browser.download.WebResponseDownloadResponse
 import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoWebExecutor
-import org.mozilla.geckoview.WebRequest
 import java.io.IOException
 
 /**
@@ -30,9 +35,15 @@ import java.io.IOException
 internal class DownloadWorker(
     private val context: Context,
     params: WorkerParameters,
-    private val geckoRuntime: GeckoRuntime,
+    geckoRuntime: GeckoRuntime,
 ) : CoroutineWorker(context, params) {
     private val repository get() = DownloadRepository(context)
+
+    /** HTTP取得のクライアント。GeckoViewのCookie/セッションを共有する */
+    private val httpClient: DownloadHttpClient = GeckoDownloadHttpClient(geckoRuntime)
+
+    /** ストリームコピー・切断検出を担うコアロジック */
+    private val engine = DownloadEngine()
 
     /** 失敗時に保存した部分ファイルURI（doWork終了後にcatchブロックで参照） */
     private var partialResultUri: Uri? = null
@@ -158,80 +169,83 @@ internal class DownloadWorker(
         notificationId: Int,
         repository: DownloadRepository,
     ): Pair<Uri, String> {
-        val executor = GeckoWebExecutor(geckoRuntime)
-        val request = WebRequest.Builder(urlString)
-            .apply { if (referrerUrl.isNotBlank()) addHeader("Referer", referrerUrl) }
-            .build()
+        // onExternalResponse で保持した元レスポンスがあれば、そのボディを直接保存する。
+        // パスワード submit(POST)・ワンタイムURL・セッション依存のダウンロードは
+        // URL を GET し直すと 0 バイトになるため、元レスポンスのボディを優先する。
+        val pendingResponse = PendingDownloadBodyStore.take(id.toString())
+        val response: DownloadHttpResponse = pendingResponse?.let { WebResponseDownloadResponse(it) }
+            ?: httpClient.fetch(urlString, referrerUrl, 0L)
 
-        val response = fetchResponse(executor, request)
+        try {
+            val statusCode = response.statusCode
+            if (statusCode !in 200 until 300) {
+                throw IOException("HTTP エラー: $statusCode")
+            }
 
-        val statusCode = response.statusCode
-        if (statusCode !in 200 until 300) {
-            response.body?.close()
-            throw IOException("HTTP エラー: $statusCode")
-        }
+            val body = response.body ?: throw IOException("レスポンスボディが空です。")
+            val contentLength = DownloadMetadata.parseContentLength(response.header("Content-Length"))
+            val mimeType = DownloadMetadata.parseMimeType(response.header("Content-Type"))
+            val fileName = URLUtil.guessFileName(urlString, response.header("Content-Disposition"), mimeType)
+                .ifBlank { "download-${System.currentTimeMillis()}" }
 
-        val body = response.body ?: throw IOException("レスポンスボディが空です。")
-        val contentLength = response.headers["Content-Length"]?.toLongOrNull() ?: -1L
-        val mimeType = parseMimeType(response.headers["Content-Type"])
-        val fileName = URLUtil.guessFileName(urlString, response.headers["Content-Disposition"], mimeType)
-            .ifBlank { "download-${System.currentTimeMillis()}" }
+            setForeground(createForegroundInfo(notificationId, 0, contentLength <= 0, fileName, 0L, contentLength))
+            repository.updateProgress(id.toString(), fileName, 0, 0L, contentLength)
 
-        setForeground(createForegroundInfo(notificationId, 0, contentLength <= 0, fileName, 0L, contentLength))
-        repository.updateProgress(id.toString(), fileName, 0, 0L, contentLength)
+            val resolver = context.contentResolver
+            val values = ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+                put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+                put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+                put(MediaStore.Downloads.IS_PENDING, 1)
+            }
+            val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                ?: throw IOException("ダウンロードエントリの作成に失敗しました。")
 
-        val resolver = context.contentResolver
-        val values = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
-            put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
-            put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
-            put(MediaStore.Downloads.IS_PENDING, 1)
-        }
-        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
-            ?: throw IOException("ダウンロードエントリの作成に失敗しました。")
+            // 失敗時に部分ファイルURIを参照できるよう保存する
+            partialResultUri = uri
+            partialResultFileName = fileName
+            partialResultContentLength = contentLength
 
-        // 失敗時に部分ファイルURIを参照できるよう保存する
-        partialResultUri = uri
-        partialResultFileName = fileName
-        partialResultContentLength = contentLength
-
-        resolver.openOutputStream(uri)?.use { outputStream ->
-            body.use { inputStream ->
-                val buffer = ByteArray(8192)
-                var bytesRead: Int
-                var totalRead = 0L
-                // 通知・Room更新のレート制限を避けるため、最後に更新した時刻を記録する
-                var lastUpdateTime = 0L
-                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-                    outputStream.write(buffer, 0, bytesRead)
-                    totalRead += bytesRead
+            var lastUpdateTime = 0L
+            resolver.openOutputStream(uri)?.use { outputStream ->
+                engine.copyTo(
+                    body = body,
+                    sink = outputStream,
+                    expectedTotalLength = contentLength,
+                    startBytes = 0L,
+                ) { totalRead ->
+                    // 失敗時の部分ファイルサイズ把握のため累計バイト数は毎回更新する
                     partialResultTotalRead = totalRead
+                    // 通知・Room更新のみレート制限する
                     val now = System.currentTimeMillis()
-                    if (now - lastUpdateTime >= 1000L) {
+                    if (now - lastUpdateTime >= PROGRESS_UPDATE_INTERVAL_MILLIS) {
                         val progress = if (contentLength > 0) (totalRead * 100 / contentLength).toInt() else 0
                         repository.updateProgress(id.toString(), fileName, progress, totalRead, contentLength)
                         setForeground(createForegroundInfo(notificationId, progress, contentLength <= 0, fileName, totalRead, contentLength))
                         lastUpdateTime = now
                     }
                 }
-            }
-        } ?: throw IOException("出力ストリームを開けませんでした。")
+            } ?: throw IOException("出力ストリームを開けませんでした。")
 
-        val completeValues = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
-        resolver.update(uri, completeValues, null, null)
-        // 完了したので部分ファイル情報をクリアする
-        partialResultUri = null
-        // IS_PENDING=0 更新後にMediaStoreが重複を避けてリネームした場合に備え、実際のファイル名を取得する
-        val actualFileName = resolver.query(
-            uri,
-            arrayOf(MediaStore.MediaColumns.DISPLAY_NAME),
-            null,
-            null,
-            null,
-        )?.use { cursor ->
-            if (cursor.moveToFirst()) cursor.getString(0) else null
+            val completeValues = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
+            resolver.update(uri, completeValues, null, null)
+            // 完了したので部分ファイル情報をクリアする
+            partialResultUri = null
+            // IS_PENDING=0 更新後にMediaStoreが重複を避けてリネームした場合に備え、実際のファイル名を取得する
+            val actualFileName = resolver.query(
+                uri,
+                arrayOf(MediaStore.MediaColumns.DISPLAY_NAME),
+                null,
+                null,
+                null,
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) cursor.getString(0) else null
+            }
+            return Pair(uri, actualFileName ?: fileName)
+        } finally {
+            // ボディを確実にクローズする（pendingResponse 経由・fetch 経由いずれの場合も）
+            response.close()
         }
-        return Pair(uri, actualFileName ?: fileName)
     }
 
     /**
@@ -251,99 +265,71 @@ internal class DownloadWorker(
         val actualFileSize = resolver.openFileDescriptor(partialUri, "r")?.use { it.statSize } ?: 0L
         val rangeStart = actualFileSize
 
-        val executor = GeckoWebExecutor(geckoRuntime)
+        val response = httpClient.fetch(urlString, referrerUrl, rangeStart)
+        try {
+            val statusCode = response.statusCode
 
-        val request = WebRequest.Builder(urlString)
-            .apply {
-                if (referrerUrl.isNotBlank()) addHeader("Referer", referrerUrl)
-                if (rangeStart > 0) addHeader("Range", "bytes=$rangeStart-")
+            // サーバーがRangeリクエストをサポートしていない場合（200 OK）は最初からやり直す
+            if (statusCode == 200) {
+                // 部分ファイルを削除して新規ダウンロードを開始する
+                resolver.delete(partialUri, null, null)
+                partialResultUri = null
+                return downloadFile(urlString, referrerUrl, notificationId, repository)
             }
-            .build()
 
-        val response = fetchResponse(executor, request)
-        val statusCode = response.statusCode
+            if (statusCode != 206) {
+                throw IOException("HTTP エラー: $statusCode")
+            }
 
-        // サーバーがRangeリクエストをサポートしていない場合（200 OK）は最初からやり直す
-        if (statusCode == 200) {
-            response.body?.close()
-            // 部分ファイルを削除して新規ダウンロードを開始する
-            resolver.delete(partialUri, null, null)
-            partialResultUri = null
-            return downloadFile(urlString, referrerUrl, notificationId, repository)
-        }
+            // 206 Partial Content: 既存ファイルへ追記する
+            val body = response.body ?: throw IOException("レスポンスボディが空です。")
+            val contentRangeHeader = response.header("Content-Range")
+            // Content-Range: bytes START-END/TOTAL 形式からトータルサイズを取得する
+            val totalFileSize = DownloadMetadata.parseTotalFromContentRange(contentRangeHeader)
+                ?: (rangeStart + DownloadMetadata.parseContentLength(response.header("Content-Length")))
+            val contentLength = totalFileSize
+            val mimeType = DownloadMetadata.parseMimeType(response.header("Content-Type"))
+            val fileName = URLUtil.guessFileName(urlString, response.header("Content-Disposition"), mimeType)
+                .ifBlank { "download-${System.currentTimeMillis()}" }
 
-        if (statusCode != 206) {
-            response.body?.close()
-            throw IOException("HTTP エラー: $statusCode")
-        }
+            setForeground(createForegroundInfo(notificationId, if (contentLength > 0) (rangeStart * 100 / contentLength).toInt() else 0, contentLength <= 0, fileName, rangeStart, contentLength))
 
-        // 206 Partial Content: 既存ファイルへ追記する
-        val body = response.body ?: throw IOException("レスポンスボディが空です。")
-        val contentRangeHeader = response.headers["Content-Range"]
-        // Content-Range: bytes START-END/TOTAL 形式からトータルサイズを取得する
-        val totalFileSize = contentRangeHeader
-            ?.substringAfter('/')?.toLongOrNull()
-            ?: (rangeStart + (response.headers["Content-Length"]?.toLongOrNull() ?: -1L))
-        val contentLength = totalFileSize
-        val mimeType = parseMimeType(response.headers["Content-Type"])
-        val fileName = URLUtil.guessFileName(urlString, response.headers["Content-Disposition"], mimeType)
-            .ifBlank { "download-${System.currentTimeMillis()}" }
+            // 部分ファイルへの追記用に IS_PENDING を確認・維持する
+            val pendingValues = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 1) }
+            resolver.update(partialUri, pendingValues, null, null)
 
-        setForeground(createForegroundInfo(notificationId, if (contentLength > 0) (rangeStart * 100 / contentLength).toInt() else 0, contentLength <= 0, fileName, rangeStart, contentLength))
+            partialResultUri = partialUri
+            partialResultFileName = fileName
+            partialResultContentLength = contentLength
+            partialResultTotalRead = rangeStart
 
-        // 部分ファイルへの追記用に IS_PENDING を確認・維持する
-        val pendingValues = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 1) }
-        resolver.update(partialUri, pendingValues, null, null)
-
-        partialResultUri = partialUri
-        partialResultFileName = fileName
-        partialResultContentLength = contentLength
-        partialResultTotalRead = rangeStart
-
-        // "wa" モードで追記オープンする
-        resolver.openOutputStream(partialUri, "wa")?.use { outputStream ->
-            body.use { inputStream ->
-                val buffer = ByteArray(8192)
-                var bytesRead: Int
-                var totalRead = rangeStart
-                var lastUpdateTime = 0L
-                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-                    outputStream.write(buffer, 0, bytesRead)
-                    totalRead += bytesRead
+            var lastUpdateTime = 0L
+            // "wa" モードで追記オープンする
+            resolver.openOutputStream(partialUri, "wa")?.use { outputStream ->
+                engine.copyTo(
+                    body = body,
+                    sink = outputStream,
+                    expectedTotalLength = contentLength,
+                    startBytes = rangeStart,
+                ) { totalRead ->
                     partialResultTotalRead = totalRead
                     val now = System.currentTimeMillis()
-                    if (now - lastUpdateTime >= 1000L) {
+                    if (now - lastUpdateTime >= PROGRESS_UPDATE_INTERVAL_MILLIS) {
                         val progress = if (contentLength > 0) (totalRead * 100 / contentLength).toInt() else 0
                         repository.updateProgress(id.toString(), fileName, progress, totalRead, contentLength)
                         setForeground(createForegroundInfo(notificationId, progress, contentLength <= 0, fileName, totalRead, contentLength))
                         lastUpdateTime = now
                     }
                 }
-            }
-        } ?: throw IOException("出力ストリームを開けませんでした。")
+            } ?: throw IOException("出力ストリームを開けませんでした。")
 
-        val completeValues = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
-        resolver.update(partialUri, completeValues, null, null)
-        partialResultUri = null
-        return Pair(partialUri, fileName)
-    }
-
-    /** GeckoWebExecutorでリクエストを送信してレスポンスを取得する */
-    private fun fetchResponse(executor: GeckoWebExecutor, request: WebRequest): org.mozilla.geckoview.WebResponse {
-        return try {
-            executor.fetch(request).poll(60_000)
-                ?: throw IOException("レスポンスがnullです。")
-        } catch (e: IOException) {
-            throw e
-        } catch (e: Throwable) {
-            throw IOException("Geckoリクエスト失敗", e)
+            val completeValues = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
+            resolver.update(partialUri, completeValues, null, null)
+            partialResultUri = null
+            return Pair(partialUri, fileName)
+        } finally {
+            response.close()
         }
-    }
-
-    /** Content-Typeヘッダーからメディアタイプ文字列を取り出す */
-    private fun parseMimeType(contentType: String?): String {
-        return contentType?.substringBefore(';')?.trim()?.takeIf { it.isNotEmpty() }
-            ?: "application/octet-stream"
     }
 
     private fun createForegroundInfo(
@@ -382,6 +368,9 @@ internal class DownloadWorker(
     }
 
     companion object {
+        /** 進捗（通知・Room）の更新間隔。頻繁な更新を避けるためのレート制限 */
+        private const val PROGRESS_UPDATE_INTERVAL_MILLIS = 1000L
+
         const val KEY_URL = "url"
         const val KEY_REFERRER_URL = "referrer_url"
         const val KEY_NOTIFICATION_ID = "notification_id"

--- a/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
@@ -51,6 +51,13 @@ internal class DownloadWorker(
     private var partialResultTotalRead: Long = 0L
     private var partialResultContentLength: Long = -1L
 
+    /**
+     * 元レスポンス（pendingResponse）のボディを直接保存したか。
+     * この場合は URL 再取得での再開が無効データ（ワンタイムURL無効化・ログインページ等）になり得るため、
+     * 失敗時に再開可能として保存しない。
+     */
+    private var usedPendingBody: Boolean = false
+
     override suspend fun doWork(): Result {
         val url = inputData.getString(KEY_URL) ?: return Result.failure()
         val referrerUrl = inputData.getString(KEY_REFERRER_URL).orEmpty()
@@ -93,7 +100,7 @@ internal class DownloadWorker(
         } catch (e: Exception) {
             e.printStackTrace()
             val savedUri = partialResultUri
-            if (savedUri != null && partialResultTotalRead > 0) {
+            if (savedUri != null && partialResultTotalRead > 0 && !usedPendingBody) {
                 // 部分ファイルが存在する場合は再開可能として保存する
                 repository.updatePartialFailed(
                     workerId = id.toString(),
@@ -173,6 +180,8 @@ internal class DownloadWorker(
         // パスワード submit(POST)・ワンタイムURL・セッション依存のダウンロードは
         // URL を GET し直すと 0 バイトになるため、元レスポンスのボディを優先する。
         val pendingResponse = PendingDownloadBodyStore.take(id.toString())
+        // 元レスポンスのボディを使う場合、URL再取得での再開は無効データになり得るため記録する
+        usedPendingBody = pendingResponse != null
         val response: DownloadHttpResponse = pendingResponse?.let { WebResponseDownloadResponse(it) }
             ?: httpClient.fetch(urlString, referrerUrl, 0L)
 

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoDownloadManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoDownloadManager.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import net.matsudamper.browser.data.download.DownloadRepository
+import net.matsudamper.browser.download.PendingDownloadBodyStore
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.WebResponse
 
@@ -23,10 +24,20 @@ internal class GeckoDownloadManager(
      * Workerが起動する前にENQUEUEDレコードをRoomに挿入し、UIに即時反映させる。
      * 進捗は通知で表示される。
      */
-    fun enqueueDownload(url: String, referrerUrl: String, coroutineScope: CoroutineScope) {
+    fun enqueueDownload(
+        url: String,
+        referrerUrl: String,
+        coroutineScope: CoroutineScope,
+        response: WebResponse? = null,
+    ) {
         DownloadWorker.ensureNotificationChannel(context)
         // ダウンロードごとに一意な通知IDを事前に生成し、WorkerとGeckoDownloadManagerで共有する
         val workId = UUID.randomUUID()
+        // 元レスポンス（POST結果・ワンタイムURL等）があれば、Workerがボディを直接保存できるよう保持する。
+        // プロセス再起動などで取り出せなかった場合はWorker側でURL再取得にフォールバックする。
+        if (response != null) {
+            PendingDownloadBodyStore.put(workId.toString(), response)
+        }
         val notificationId = workId.hashCode() and 0x7fffffff
         val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
             .setId(workId)
@@ -61,13 +72,19 @@ internal class GeckoDownloadManager(
     }
 
     /**
-     * GeckoViewがレンダリングできないレスポンス（ダウンロード対象ファイル等）を受け取った際に、
-     * レスポンスボディは破棄し、URLでWorkManagerに再ダウンロードさせる。
-     * WorkManagerで実行するため、アプリが終了してもダウンロードが継続される。
+     * GeckoViewがレンダリングできないレスポンス（ダウンロード対象ファイル等）を受け取った際に呼ばれる。
+     * レスポンスボディ（実データ）を破棄せず保持したままWorkManagerにエンキューし、Workerがそれを直接保存する。
+     * これにより、パスワード submit(POST)・ワンタイムURL・セッション依存のダウンロードでも
+     * URL再取得による 0 バイト化を避けられる。WorkManagerで実行するため、
+     * プロセスが生きている限りバックグラウンドでダウンロードが継続される。
      */
     fun enqueueDownloadFromResponse(response: WebResponse, referrerUrl: String, coroutineScope: CoroutineScope) {
-        response.body?.close()
-        enqueueDownload(url = response.uri, referrerUrl = referrerUrl, coroutineScope = coroutineScope)
+        enqueueDownload(
+            url = response.uri,
+            referrerUrl = referrerUrl,
+            coroutineScope = coroutineScope,
+            response = response,
+        )
     }
 
     /**

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoDownloadManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoDownloadManager.kt
@@ -52,13 +52,19 @@ internal class GeckoDownloadManager(
             .build()
         // WorkerがENQUEUED状態の間もUI上に表示するため、事前にレコードを挿入する
         coroutineScope.launch {
-            downloadRepository.insertEnqueued(
-                workerId = workRequest.id.toString(),
-                url = url,
-                referrerUrl = referrerUrl,
-                enqueuedAt = System.currentTimeMillis(),
-            )
-            WorkManager.getInstance(context).enqueue(workRequest)
+            try {
+                downloadRepository.insertEnqueued(
+                    workerId = workRequest.id.toString(),
+                    url = url,
+                    referrerUrl = referrerUrl,
+                    enqueuedAt = System.currentTimeMillis(),
+                )
+                WorkManager.getInstance(context).enqueue(workRequest)
+            } catch (e: Throwable) {
+                // エンキュー失敗・キャンセル時は保持した元レスポンスのボディを確実に閉じてリークを防ぐ
+                PendingDownloadBodyStore.discard(workId.toString())
+                throw e
+            }
             // Workerが起動する前から即座に通知を表示する
             val notification = NotificationCompat.Builder(context, DownloadWorker.CHANNEL_ID)
                 .setSmallIcon(android.R.drawable.stat_sys_download)

--- a/app/src/main/kotlin/net/matsudamper/browser/download/DownloadEngine.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/download/DownloadEngine.kt
@@ -1,0 +1,57 @@
+package net.matsudamper.browser.download
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+/** ダウンロードが途中で切断され、期待バイト数に達しなかったことを表す例外 */
+class DownloadTruncatedException(
+    val totalRead: Long,
+    val expectedLength: Long,
+) : IOException("ダウンロードが途中で切断されました ($totalRead / $expectedLength bytes)")
+
+/**
+ * ダウンロードのコアロジック。Android非依存でJVMテスト可能。
+ * HTTPレスポンスのボディをシンクへコピーし、進捗通知と切断検出を行う。
+ *
+ * 進捗通知のレート制限は呼び出し側（Worker）の責務とする。ここでは読み取りのたびに onProgress を呼ぶ。
+ */
+class DownloadEngine {
+    /**
+     * body を sink にコピーする。
+     *
+     * @param expectedTotalLength 期待される総バイト数（startBytes を含む）。不明な場合は -1。
+     *   0より大きく、かつ読み取り総量がこれ未満で終端に達した場合は切断とみなして例外を投げる。
+     * @param startBytes 再開時に既に書き込み済みのバイト数。進捗計算の起点。
+     * @param onProgress 進捗コールバック。引数は startBytes を含む累計読み取りバイト数。
+     *   読み取りのたびに呼ばれるため、重い処理は呼び出し側でレート制限すること。
+     * @return 書き込み完了後の累計バイト数（startBytes を含む）
+     * @throws DownloadTruncatedException 期待バイト数に達せず終端に達した場合
+     */
+    suspend fun copyTo(
+        body: InputStream,
+        sink: OutputStream,
+        expectedTotalLength: Long,
+        startBytes: Long = 0L,
+        onProgress: suspend (totalRead: Long) -> Unit = {},
+    ): Long {
+        val buffer = ByteArray(BUFFER_SIZE)
+        var totalRead = startBytes
+        var bytesRead: Int
+        while (body.read(buffer).also { bytesRead = it } != -1) {
+            sink.write(buffer, 0, bytesRead)
+            totalRead += bytesRead
+            onProgress(totalRead)
+        }
+        // 期待総量が判明していて、それに満たないまま終端に達した場合は切断とみなす。
+        // これにより Content-Length あり・本文途中切断（0バイト含む）を「成功」ではなく失敗として扱える。
+        if (expectedTotalLength > 0 && totalRead < expectedTotalLength) {
+            throw DownloadTruncatedException(totalRead = totalRead, expectedLength = expectedTotalLength)
+        }
+        return totalRead
+    }
+
+    companion object {
+        const val BUFFER_SIZE = 8192
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/download/DownloadHttpClient.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/download/DownloadHttpClient.kt
@@ -1,0 +1,36 @@
+package net.matsudamper.browser.download
+
+import java.io.InputStream
+
+/**
+ * ダウンロードのHTTPレスポンスを表す抽象。
+ * GeckoViewのWebResponseや、テスト用のHTTPクライアント実装を同一インターフェースで扱う。
+ */
+interface DownloadHttpResponse : AutoCloseable {
+    /** HTTPステータスコード */
+    val statusCode: Int
+
+    /** リダイレクト後の最終URL（ファイル名推測に使用） */
+    val finalUrl: String
+
+    /** レスポンスボディ。null の場合はボディ無し */
+    val body: InputStream?
+
+    /** 指定ヘッダーの値を取得する（大文字小文字を区別しない）。複数ある場合は最初の値 */
+    fun header(name: String): String?
+
+    /** ボディを確実にクローズする */
+    override fun close()
+}
+
+/**
+ * ダウンロード用のHTTPクライアント抽象。
+ * 本番はGeckoWebExecutorを用いた実装、テストはHttpURLConnectionを用いた実装を注入する。
+ */
+fun interface DownloadHttpClient {
+    /**
+     * 指定URLをGET取得する。
+     * @param rangeStart 0より大きい場合 Range: bytes=rangeStart- を付与して途中から取得する
+     */
+    fun fetch(url: String, referrerUrl: String, rangeStart: Long): DownloadHttpResponse
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/download/DownloadMetadata.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/download/DownloadMetadata.kt
@@ -1,0 +1,25 @@
+package net.matsudamper.browser.download
+
+/** HTTPヘッダーからダウンロードのメタデータを解析するユーティリティ */
+object DownloadMetadata {
+    private const val DEFAULT_MIME_TYPE = "application/octet-stream"
+
+    /** Content-Type からメディアタイプ（パラメータ部を除去）を取り出す。空なら application/octet-stream */
+    fun parseMimeType(contentType: String?): String {
+        return contentType?.substringBefore(';')?.trim()?.takeIf { it.isNotEmpty() }
+            ?: DEFAULT_MIME_TYPE
+    }
+
+    /** Content-Length ヘッダーを数値化する。解析できなければ -1 */
+    fun parseContentLength(contentLength: String?): Long {
+        return contentLength?.trim()?.toLongOrNull() ?: -1L
+    }
+
+    /**
+     * Content-Range: bytes START-END/TOTAL の TOTAL を取り出す。
+     * 取得できない場合（"*" やヘッダー無し）は null を返す。
+     */
+    fun parseTotalFromContentRange(contentRange: String?): Long? {
+        return contentRange?.substringAfter('/', "")?.trim()?.toLongOrNull()
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/download/GeckoDownloadHttpClient.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/download/GeckoDownloadHttpClient.kt
@@ -1,0 +1,57 @@
+package net.matsudamper.browser.download
+
+import java.io.IOException
+import java.io.InputStream
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoWebExecutor
+import org.mozilla.geckoview.WebRequest
+import org.mozilla.geckoview.WebResponse
+
+/** GeckoViewのWebResponseをDownloadHttpResponseとして扱うアダプタ */
+class WebResponseDownloadResponse(private val response: WebResponse) : DownloadHttpResponse {
+    override val statusCode: Int get() = response.statusCode
+    override val finalUrl: String get() = response.uri
+    override val body: InputStream? get() = response.body
+
+    override fun header(name: String): String? {
+        // WebResponse.headers は大文字小文字を区別しないMap
+        return response.headers[name]
+    }
+
+    override fun close() {
+        response.body?.close()
+    }
+}
+
+/**
+ * GeckoWebExecutorを用いたDownloadHttpClient実装。
+ * GeckoViewのCookie/セッション情報を共有してリクエストするため、ログイン後のダウンロード等で
+ * セッションを引き継げる。
+ */
+class GeckoDownloadHttpClient(
+    private val geckoRuntime: GeckoRuntime,
+    private val timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS,
+) : DownloadHttpClient {
+    override fun fetch(url: String, referrerUrl: String, rangeStart: Long): DownloadHttpResponse {
+        val executor = GeckoWebExecutor(geckoRuntime)
+        val request = WebRequest.Builder(url)
+            .apply {
+                if (referrerUrl.isNotBlank()) addHeader("Referer", referrerUrl)
+                if (rangeStart > 0) addHeader("Range", "bytes=$rangeStart-")
+            }
+            .build()
+        val response = try {
+            executor.fetch(request).poll(timeoutMillis)
+                ?: throw IOException("レスポンスがnullです。")
+        } catch (e: IOException) {
+            throw e
+        } catch (e: Throwable) {
+            throw IOException("Geckoリクエスト失敗", e)
+        }
+        return WebResponseDownloadResponse(response)
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_MILLIS = 60_000L
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/download/PendingDownloadBodyStore.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/download/PendingDownloadBodyStore.kt
@@ -1,0 +1,37 @@
+package net.matsudamper.browser.download
+
+import java.util.concurrent.ConcurrentHashMap
+import org.mozilla.geckoview.WebResponse
+
+/**
+ * GeckoViewが onExternalResponse で受け取った WebResponse（実データ入りのボディ）を、
+ * WorkManager の Worker へ同一プロセス内で引き渡すための一時保管庫。
+ *
+ * パスワード submit(POST) のレスポンス・ワンタイムURL・セッション/トークン依存・blob などの
+ * ダウンロードは、URLを GET で再取得しても元のデータが取得できず 0 バイトになる。
+ * そのため元レスポンスのボディを保持し、Worker がそれを直接保存できるようにする。
+ *
+ * WorkManager の inputData には InputStream を渡せないため、workId をキーにプロセス内で受け渡す。
+ * プロセスが再起動した場合はここから取得できず、Worker 側は URL 再取得にフォールバックする。
+ */
+object PendingDownloadBodyStore {
+    private val responses = ConcurrentHashMap<String, WebResponse>()
+
+    /** 指定 workId に対応するボディ付きレスポンスを保持する */
+    fun put(workId: String, response: WebResponse) {
+        responses[workId] = response
+    }
+
+    /**
+     * 指定 workId のレスポンスを取り出して保管庫から削除する。
+     * 取り出した側がボディをクローズする責務を負う。存在しなければ null。
+     */
+    fun take(workId: String): WebResponse? {
+        return responses.remove(workId)
+    }
+
+    /** 指定 workId のレスポンスを破棄し、ボディをクローズする（エンキュー失敗・キャンセル時など） */
+    fun discard(workId: String) {
+        responses.remove(workId)?.body?.close()
+    }
+}

--- a/app/src/test/kotlin/net/matsudamper/browser/download/DownloadEndToEndTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/download/DownloadEndToEndTest.kt
@@ -1,0 +1,207 @@
+package net.matsudamper.browser.download
+
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.test.runTest
+import net.matsudamper.browser.download.LocalDownloadServer.Companion.respondChunked
+import net.matsudamper.browser.download.LocalDownloadServer.Companion.respondFixed
+import net.matsudamper.browser.download.LocalDownloadServer.Companion.respondNoBody
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * ローカルHTTPサーバーに対して、様々なダウンロード実装を再現するエンドツーエンドテスト。
+ * 本番Workerと同じコア（DownloadEngine.copyTo / DownloadMetadata）を通して保存し、
+ * 0バイトになるケースを炙り出す。
+ */
+class DownloadEndToEndTest {
+
+    private lateinit var server: LocalDownloadServer
+    private val client = UrlConnectionDownloadClient()
+    private val engine = DownloadEngine()
+
+    @Before
+    fun setUp() {
+        server = LocalDownloadServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    private class SaveResult(val statusCode: Int, val bytes: ByteArray, val failed: Boolean)
+
+    /** WorkerのdownloadFileと同じ標準フロー（ステータス確認→body→copyTo）でURLを保存する */
+    private suspend fun fetchAndSave(path: String): SaveResult {
+        client.fetch(server.baseUrl + path, "", 0L).use { response ->
+            if (response.statusCode !in 200 until 300) {
+                return SaveResult(response.statusCode, ByteArray(0), failed = true)
+            }
+            val body = response.body ?: return SaveResult(response.statusCode, ByteArray(0), failed = true)
+            val out = ByteArrayOutputStream()
+            val contentLength = DownloadMetadata.parseContentLength(response.header("Content-Length"))
+            engine.copyTo(body, out, contentLength)
+            return SaveResult(response.statusCode, out.toByteArray(), failed = false)
+        }
+    }
+
+    @Test
+    fun normalGetDownload() = runTest {
+        val payload = "%PDF-1.4 normal download body".toByteArray()
+        server.handle("/file.pdf") { ex ->
+            ex.respondFixed(200, payload, mapOf("Content-Type" to "application/pdf"))
+        }
+
+        val result = fetchAndSave("/file.pdf")
+
+        assertEquals(200, result.statusCode)
+        assertArrayEquals(payload, result.bytes)
+    }
+
+    @Test
+    fun chunkedWithoutContentLength() = runTest {
+        val payload = ByteArray(5000) { (it % 251).toByte() }
+        server.handle("/chunked") { ex -> ex.respondChunked(200, payload) }
+
+        val result = fetchAndSave("/chunked")
+
+        assertArrayEquals(payload, result.bytes)
+    }
+
+    @Test
+    fun followsRedirect() = runTest {
+        val payload = "redirected-content".toByteArray()
+        server.handle("/target") { ex -> ex.respondFixed(200, payload) }
+        server.handle("/redirect") { ex -> ex.respondNoBody(302, mapOf("Location" to "/target")) }
+
+        val result = fetchAndSave("/redirect")
+
+        assertArrayEquals(payload, result.bytes)
+    }
+
+    @Test
+    fun followsRedirectChain() = runTest {
+        val payload = "deep-target-data".toByteArray()
+        server.handle("/r1") { ex -> ex.respondNoBody(301, mapOf("Location" to "/r2")) }
+        server.handle("/r2") { ex -> ex.respondNoBody(302, mapOf("Location" to "/r3")) }
+        server.handle("/r3") { ex -> ex.respondNoBody(307, mapOf("Location" to "/final")) }
+        server.handle("/final") { ex -> ex.respondFixed(200, payload) }
+
+        val result = fetchAndSave("/r1")
+
+        assertArrayEquals(payload, result.bytes)
+    }
+
+    @Test
+    fun exposesContentDispositionHeader() = runTest {
+        val payload = "x".toByteArray()
+        server.handle("/dl") { ex ->
+            ex.respondFixed(200, payload, mapOf("Content-Disposition" to "attachment; filename=\"report.pdf\""))
+        }
+
+        client.fetch(server.baseUrl + "/dl", "", 0L).use { response ->
+            assertEquals("attachment; filename=\"report.pdf\"", response.header("Content-Disposition"))
+        }
+    }
+
+    @Test
+    fun emptyBodyWithoutContentLengthIsZeroByteSuccess() = runTest {
+        // Content-Length 不明で本当に空のレスポンスは 0 バイト成功（正当な空ファイルと区別できない）
+        server.handle("/empty") { ex -> ex.respondChunked(200, ByteArray(0)) }
+
+        val result = fetchAndSave("/empty")
+
+        assertEquals(0, result.bytes.size)
+        assertFalse(result.failed)
+    }
+
+    @Test
+    fun contentLengthMismatchFailsAsTruncated() = runTest {
+        // Content-Length: 1000 と宣言しつつ 400 バイトで切断 → 切断検出で失敗する
+        server.handle("/truncated") { ex ->
+            ex.responseHeaders.add("Content-Type", "application/octet-stream")
+            ex.sendResponseHeaders(200, 1000)
+            ex.responseBody.write(ByteArray(400))
+            // 残り 600 バイトを書かずに終了（finally で close）
+        }
+
+        var failed = false
+        try {
+            fetchAndSave("/truncated")
+        } catch (e: Exception) {
+            failed = true
+        }
+
+        assertTrue("Content-Length 未達は失敗として扱われるべき", failed)
+    }
+
+    @Test
+    fun passwordSubmitPostBodyIsSavedWhileGetRefetchReturnsZeroBytes() = runTest {
+        // パスワード submit(POST) でのみ実データが返り、URLを GET し直すと空になるエンドポイント。
+        // これがユーザー報告の「パスワード入れて submit してダウンロード開始されるタイプ」の再現。
+        val pdf = "%PDF-1.4 secret report after login".toByteArray()
+        server.handle("/download") { ex ->
+            if (ex.requestMethod == "POST") {
+                ex.respondFixed(200, pdf, mapOf("Content-Type" to "application/pdf"))
+            } else {
+                // URL再取得（GET）ではログインページ相当の空レスポンス
+                ex.respondChunked(200, ByteArray(0))
+            }
+        }
+
+        // 旧実装の再現: URLをGETで再取得 → 0バイト（これがバグ）
+        val refetched = fetchAndSave("/download")
+        assertEquals("URL再取得(GET)では0バイトになる", 0, refetched.bytes.size)
+
+        // 新実装: POSTで得たレスポンスのボディを直接保存 → 実データが保存される
+        client.fetchPost(server.baseUrl + "/download", "password=secret".toByteArray()).use { response ->
+            assertEquals(200, response.statusCode)
+            val out = ByteArrayOutputStream()
+            val contentLength = DownloadMetadata.parseContentLength(response.header("Content-Length"))
+            engine.copyTo(response.body!!, out, contentLength)
+            assertArrayEquals("ボディ直接保存なら実データが保存される", pdf, out.toByteArray())
+        }
+    }
+
+    @Test
+    fun serverError500Fails() = runTest {
+        server.handle("/error") { ex -> ex.respondNoBody(500) }
+
+        val result = fetchAndSave("/error")
+
+        assertTrue(result.failed)
+        assertEquals(500, result.statusCode)
+    }
+
+    @Test
+    fun rangeResumeContinuesFromOffset() = runTest {
+        val full = ByteArray(1000) { (it % 256).toByte() }
+        server.handle("/range") { ex ->
+            val range = ex.requestHeaders.getFirst("Range")
+            if (range != null) {
+                val start = range.removePrefix("bytes=").substringBefore("-").toInt()
+                val part = full.copyOfRange(start, full.size)
+                ex.responseHeaders.add("Content-Range", "bytes $start-${full.size - 1}/${full.size}")
+                ex.sendResponseHeaders(206, part.size.toLong())
+                ex.responseBody.write(part)
+            } else {
+                ex.respondFixed(200, full)
+            }
+        }
+
+        client.fetch(server.baseUrl + "/range", "", 400L).use { response ->
+            assertEquals(206, response.statusCode)
+            val total = DownloadMetadata.parseTotalFromContentRange(response.header("Content-Range"))
+            assertEquals(1000L, total)
+            val out = ByteArrayOutputStream()
+            engine.copyTo(response.body!!, out, total ?: -1L, startBytes = 400L)
+            assertArrayEquals(full.copyOfRange(400, 1000), out.toByteArray())
+        }
+    }
+}

--- a/app/src/test/kotlin/net/matsudamper/browser/download/DownloadEngineTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/download/DownloadEngineTest.kt
@@ -1,0 +1,111 @@
+package net.matsudamper.browser.download
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadEngineTest {
+
+    private val engine = DownloadEngine()
+
+    @Test
+    fun copyToCopiesAllBytes() = runTest {
+        // 複数バッファをまたぐサイズでも全バイトが欠落なくコピーされる
+        val data = ByteArray(DownloadEngine.BUFFER_SIZE * 2 + 123) { (it % 256).toByte() }
+        val out = ByteArrayOutputStream()
+
+        val total = engine.copyTo(ByteArrayInputStream(data), out, expectedTotalLength = data.size.toLong())
+
+        assertEquals(data.size.toLong(), total)
+        assertArrayEquals(data, out.toByteArray())
+    }
+
+    @Test
+    fun copyToWorksWithoutContentLength() = runTest {
+        // Content-Length 不明（-1）でもストリーム終端まで読み切る
+        val data = ByteArray(1000) { 7 }
+        val out = ByteArrayOutputStream()
+
+        val total = engine.copyTo(ByteArrayInputStream(data), out, expectedTotalLength = -1L)
+
+        assertEquals(1000L, total)
+        assertArrayEquals(data, out.toByteArray())
+    }
+
+    @Test
+    fun copyToThrowsWhenTruncated() = runTest {
+        // Content-Length が判明しているのに本文が途中で終端した場合は切断として失敗する。
+        // これにより「Content-Length ありで 0 バイト/部分バイト」を成功扱いにしない。
+        val data = ByteArray(50)
+        val out = ByteArrayOutputStream()
+
+        var thrown: DownloadTruncatedException? = null
+        try {
+            engine.copyTo(ByteArrayInputStream(data), out, expectedTotalLength = 100L)
+        } catch (e: DownloadTruncatedException) {
+            thrown = e
+        }
+
+        assertNotNull("期待バイト数に満たない場合は例外を投げるべき", thrown)
+        assertEquals(50L, thrown?.totalRead)
+        assertEquals(100L, thrown?.expectedLength)
+    }
+
+    @Test
+    fun copyToThrowsWhenContentLengthSetButBodyEmpty() = runTest {
+        // Content-Length > 0 だが本文が完全に空（0バイト）のケース = 0バイト「成功」の防止
+        val out = ByteArrayOutputStream()
+
+        var thrown: DownloadTruncatedException? = null
+        try {
+            engine.copyTo(ByteArrayInputStream(ByteArray(0)), out, expectedTotalLength = 2048L)
+        } catch (e: DownloadTruncatedException) {
+            thrown = e
+        }
+
+        assertNotNull("Content-Length あり・空ボディは切断として失敗すべき", thrown)
+        assertEquals(0L, thrown?.totalRead)
+    }
+
+    @Test
+    fun copyToReportsCumulativeProgress() = runTest {
+        val data = ByteArray(DownloadEngine.BUFFER_SIZE * 3) { 1 }
+        val out = ByteArrayOutputStream()
+        val progresses = mutableListOf<Long>()
+
+        engine.copyTo(ByteArrayInputStream(data), out, expectedTotalLength = data.size.toLong()) { totalRead ->
+            progresses.add(totalRead)
+        }
+
+        // 進捗は単調増加し、最後は総バイト数に一致する
+        assertEquals(data.size.toLong(), progresses.last())
+        assertTrue("進捗は単調増加すべき", progresses.zipWithNext().all { (a, b) -> a < b })
+    }
+
+    @Test
+    fun copyToUsesStartBytesAsProgressBase() = runTest {
+        // 再開時: startBytes を進捗の起点とし、書き込みは今回読み取った分のみ
+        val data = ByteArray(200) { 9 }
+        val out = ByteArrayOutputStream()
+        val progresses = mutableListOf<Long>()
+
+        val total = engine.copyTo(
+            body = ByteArrayInputStream(data),
+            sink = out,
+            expectedTotalLength = 1200L,
+            startBytes = 1000L,
+        ) { totalRead ->
+            progresses.add(totalRead)
+        }
+
+        assertEquals(1200L, total)
+        assertEquals(1200L, progresses.last())
+        assertTrue("進捗は startBytes 以上であるべき", progresses.all { it >= 1000L })
+        assertArrayEquals(data, out.toByteArray())
+    }
+}

--- a/app/src/test/kotlin/net/matsudamper/browser/download/DownloadMetadataTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/download/DownloadMetadataTest.kt
@@ -1,0 +1,41 @@
+package net.matsudamper.browser.download
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DownloadMetadataTest {
+
+    @Test
+    fun parseMimeTypeStripsParameters() {
+        // Content-Type のパラメータ部（charset 等）を除去する
+        assertEquals("application/pdf", DownloadMetadata.parseMimeType("application/pdf; charset=utf-8"))
+        assertEquals("text/html", DownloadMetadata.parseMimeType("text/html"))
+    }
+
+    @Test
+    fun parseMimeTypeFallsBackToOctetStream() {
+        // null・空・空白は application/octet-stream にフォールバックする
+        assertEquals("application/octet-stream", DownloadMetadata.parseMimeType(null))
+        assertEquals("application/octet-stream", DownloadMetadata.parseMimeType(""))
+        assertEquals("application/octet-stream", DownloadMetadata.parseMimeType("   "))
+    }
+
+    @Test
+    fun parseContentLengthParsesNumber() {
+        assertEquals(1234L, DownloadMetadata.parseContentLength("1234"))
+        assertEquals(0L, DownloadMetadata.parseContentLength("0"))
+        // 解析できない値は -1（不明）
+        assertEquals(-1L, DownloadMetadata.parseContentLength(null))
+        assertEquals(-1L, DownloadMetadata.parseContentLength("abc"))
+    }
+
+    @Test
+    fun parseTotalFromContentRangeExtractsTotal() {
+        // Content-Range: bytes START-END/TOTAL の TOTAL を取り出す
+        assertEquals(5000L, DownloadMetadata.parseTotalFromContentRange("bytes 1000-4999/5000"))
+        // TOTAL が "*" の場合は不明
+        assertNull(DownloadMetadata.parseTotalFromContentRange("bytes 1000-4999/*"))
+        assertNull(DownloadMetadata.parseTotalFromContentRange(null))
+    }
+}

--- a/app/src/test/kotlin/net/matsudamper/browser/download/LocalDownloadServer.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/download/LocalDownloadServer.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser.download
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import java.net.InetSocketAddress
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 /**
@@ -11,17 +12,21 @@ import java.util.concurrent.Executors
  */
 class LocalDownloadServer {
     private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    private var executor: ExecutorService? = null
 
     /** 割り当てられたポートを含むベースURL */
     val baseUrl: String get() = "http://127.0.0.1:${server.address.port}"
 
     fun start() {
-        server.executor = Executors.newCachedThreadPool()
+        // HttpServer.stop() は外部設定の executor を終了しないため、参照を保持して stop() で解放する
+        executor = Executors.newCachedThreadPool().also { server.executor = it }
         server.start()
     }
 
     fun stop() {
         server.stop(0)
+        executor?.shutdownNow()
+        executor = null
     }
 
     /** パスにハンドラを登録する。ハンドラ例外時もExchangeを確実にクローズする */

--- a/app/src/test/kotlin/net/matsudamper/browser/download/LocalDownloadServer.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/download/LocalDownloadServer.kt
@@ -1,0 +1,60 @@
+package net.matsudamper.browser.download
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+
+/**
+ * テスト用のローカルHTTPサーバー。
+ * リダイレクト・chunked・Range・POST必須など、様々なダウンロード実装を再現するために使う。
+ */
+class LocalDownloadServer {
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+
+    /** 割り当てられたポートを含むベースURL */
+    val baseUrl: String get() = "http://127.0.0.1:${server.address.port}"
+
+    fun start() {
+        server.executor = Executors.newCachedThreadPool()
+        server.start()
+    }
+
+    fun stop() {
+        server.stop(0)
+    }
+
+    /** パスにハンドラを登録する。ハンドラ例外時もExchangeを確実にクローズする */
+    fun handle(path: String, handler: (HttpExchange) -> Unit) {
+        server.createContext(path) { exchange ->
+            try {
+                handler(exchange)
+            } finally {
+                exchange.close()
+            }
+        }
+    }
+
+    companion object {
+        /** Content-Length 固定長レスポンスを送る */
+        fun HttpExchange.respondFixed(status: Int, body: ByteArray, headers: Map<String, String> = emptyMap()) {
+            headers.forEach { (k, v) -> responseHeaders.add(k, v) }
+            sendResponseHeaders(status, body.size.toLong())
+            responseBody.write(body)
+        }
+
+        /** chunked（Content-Length なし）でレスポンスを送る */
+        fun HttpExchange.respondChunked(status: Int, body: ByteArray, headers: Map<String, String> = emptyMap()) {
+            headers.forEach { (k, v) -> responseHeaders.add(k, v) }
+            // responseLength == 0 で chunked transfer encoding になる
+            sendResponseHeaders(status, 0)
+            responseBody.write(body)
+        }
+
+        /** ヘッダーのみ（ボディ無し）でレスポンスを送る。リダイレクトやエラーに用いる */
+        fun HttpExchange.respondNoBody(status: Int, headers: Map<String, String> = emptyMap()) {
+            headers.forEach { (k, v) -> responseHeaders.add(k, v) }
+            sendResponseHeaders(status, -1)
+        }
+    }
+}

--- a/app/src/test/kotlin/net/matsudamper/browser/download/UrlConnectionDownloadClient.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/download/UrlConnectionDownloadClient.kt
@@ -1,0 +1,86 @@
+package net.matsudamper.browser.download
+
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * テスト用: HttpURLConnection を用いた DownloadHttpClient 実装。
+ * 本番の GeckoWebExecutor の代わりに、ローカルHTTPサーバーへ実際にHTTPリクエストを送る。
+ * リダイレクトは手動で追従する（最大段数・相対Location対応）。
+ */
+class UrlConnectionDownloadClient(
+    private val maxRedirects: Int = MAX_REDIRECTS,
+) : DownloadHttpClient {
+
+    override fun fetch(url: String, referrerUrl: String, rangeStart: Long): DownloadHttpResponse {
+        return open(url, "GET", referrerUrl, rangeStart, postBody = null, redirects = 0)
+    }
+
+    /** フォーム submit(POST) を模したリクエスト。パスワード送信→ダウンロード開始の再現に用いる */
+    fun fetchPost(url: String, formData: ByteArray, referrerUrl: String = ""): DownloadHttpResponse {
+        return open(url, "POST", referrerUrl, rangeStart = 0L, postBody = formData, redirects = 0)
+    }
+
+    private fun open(
+        url: String,
+        method: String,
+        referrerUrl: String,
+        rangeStart: Long,
+        postBody: ByteArray?,
+        redirects: Int,
+    ): DownloadHttpResponse {
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            instanceFollowRedirects = false
+            requestMethod = method
+            connectTimeout = TIMEOUT_MILLIS
+            readTimeout = TIMEOUT_MILLIS
+            if (referrerUrl.isNotBlank()) setRequestProperty("Referer", referrerUrl)
+            if (rangeStart > 0) setRequestProperty("Range", "bytes=$rangeStart-")
+            if (postBody != null) {
+                doOutput = true
+                outputStream.use { it.write(postBody) }
+            }
+        }
+
+        val status = connection.responseCode
+        if (status in REDIRECT_CODES && redirects < maxRedirects) {
+            val location = connection.getHeaderField("Location")
+            connection.disconnect()
+            if (location != null) {
+                // 相対Locationにも対応する。リダイレクト後は GET で取得する
+                val next = URL(URL(url), location).toString()
+                return open(next, "GET", referrerUrl, rangeStart, postBody = null, redirects = redirects + 1)
+            }
+        }
+        return UrlConnectionDownloadResponse(connection, url)
+    }
+
+    private companion object {
+        const val MAX_REDIRECTS = 20
+        const val TIMEOUT_MILLIS = 10_000
+        val REDIRECT_CODES = setOf(
+            HttpURLConnection.HTTP_MOVED_PERM,
+            HttpURLConnection.HTTP_MOVED_TEMP,
+            HttpURLConnection.HTTP_SEE_OTHER,
+            307, // Temporary Redirect（HttpURLConnection に定数なし）
+            308, // Permanent Redirect（HttpURLConnection に定数なし）
+        )
+    }
+}
+
+private class UrlConnectionDownloadResponse(
+    private val connection: HttpURLConnection,
+    override val finalUrl: String,
+) : DownloadHttpResponse {
+    override val statusCode: Int = connection.responseCode
+    override val body: InputStream? =
+        if (statusCode >= HttpURLConnection.HTTP_BAD_REQUEST) connection.errorStream else connection.inputStream
+
+    override fun header(name: String): String? = connection.getHeaderField(name)
+
+    override fun close() {
+        runCatching { body?.close() }
+        connection.disconnect()
+    }
+}


### PR DESCRIPTION
## 概要

PDF などのダウンロードが **0 バイトのまま「完了」してしまう**不具合を修正します。特に、フォームにパスワードを入力して submit するとダウンロードが始まるタイプ（POST レスポンスのダウンロード）で発生していました。

## 原因

ダウンロード時、GeckoView が受け取った**実データ入りのレスポンスボディを破棄**し、URL だけを使ってバックグラウンドで **GET で取り直す**実装になっていました。このため POST・ワンタイム URL・セッション依存・`blob:` のダウンロードでは、取り直した GET にサーバーが空レスポンス（ログインページ等）を返し、**0 バイトで成功扱い**になっていました。

## 解決

WorkManager によるバックグラウンドダウンロードは維持したまま、**元レスポンスのボディをそのまま保存する**方式に変更しました。ボディが使えない場合（URL のみのダウンロードやプロセス再起動時）は従来の URL 再取得にフォールバックします。あわせて、Content-Length に満たない途中切断を「成功」ではなく失敗として扱うようにしました。

## テスト

ローカル HTTP サーバーを立て、通常ダウンロード・リダイレクト・Content-Length なし・Range 再開・POST 必須など様々なパターンを再現する JVM ユニットテストを追加しました。

## 補足

- ダウンロードのコアロジックをテスト可能な形に切り出す小規模なリファクタを含みます。
- レビュー指摘を受け、リソースリークの防止と、POST 由来ダウンロードの不正な再開の防止も対応済みです。

https://claude.ai/code/session_01DFmaqmnH63MSFppx2rq2uh