### PR TITLE
テスト出力ログの詳細化を全サブプロジェクトに適用

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,3 +8,15 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.paparazzi) apply false
 }
+
+subprojects {
+    tasks.withType<Test>().configureEach {
+        testLogging {
+            events("failed", "skipped")
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        }
+    }
+}


### PR DESCRIPTION
## 概要
全サブプロジェクトのテストタスクに対して、詳細なテスト出力ログ設定を一括適用します。

## 変更内容
- `build.gradle.kts` のルートプロジェクト設定に `subprojects` ブロックを追加
- 全サブプロジェクトの `Test` タスクに対して `testLogging` を設定
  - 失敗・スキップされたテストイベントのみを出力
  - 例外情報、原因、スタックトレースを詳細に表示
  - テスト例外フォーマットを `FULL` に設定

## 実装の詳細
この設定により、`./gradlew test` 実行時にテスト失敗の原因をより迅速に特定できるようになります。成功したテストの冗長なログは出力されないため、ログの可読性が向上します。

https://claude.ai/code/session_01Rn1UhtuPaZeUkgPzMudrqm