### PR TITLE
test(diag): ランダム失敗テストの診断ログを追加

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -101,9 +101,21 @@ class GeckoSurfaceResumeTest {
         val latch = CountDownLatch(1)
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            requireNotNull(composeRule.activity.window.decorView.findGeckoView()) {
-                "GeckoView was not found in the activity view hierarchy"
-            }.capturePixels().accept(
+            val geckoView = composeRule.activity.window.decorView.findGeckoView()
+            if (geckoView == null) {
+                // GeckoView が見つからない場合にビュー階層を記録し、原因特定を容易にする。
+                // Compose の AndroidView ラッパーがまだアタッチ中か、ライフサイクル復帰の
+                // タイミングずれで一時的に除外されている可能性がある。
+                val hierarchy = composeRule.activity.window.decorView.summarizeViewHierarchy(maxDepth = 4)
+                errorRef.set(
+                    AssertionError(
+                        "GeckoView was not found in the activity view hierarchy.\n$hierarchy"
+                    )
+                )
+                latch.countDown()
+                return@runOnMainSync
+            }
+            geckoView.capturePixels().accept(
                 { bitmap ->
                     bitmapRef.set(bitmap)
                     latch.countDown()
@@ -120,6 +132,29 @@ class GeckoSurfaceResumeTest {
         return requireNotNull(bitmapRef.get()) {
             "GeckoView.capturePixels() returned null"
         }
+    }
+
+    /**
+     * ビュー階層を `maxDepth` 段まで辿り、クラス名と可視状態(V/I/G)の1行サマリを返す。
+     * GeckoView 不在時の診断用。
+     */
+    private fun View.summarizeViewHierarchy(maxDepth: Int, currentDepth: Int = 0): String {
+        val indent = "  ".repeat(currentDepth)
+        val visChar = when (visibility) {
+            View.VISIBLE -> "V"
+            View.INVISIBLE -> "I"
+            View.GONE -> "G"
+            else -> "?"
+        }
+        val self = "$indent${javaClass.simpleName}($visChar)"
+        if (currentDepth >= maxDepth || this !is ViewGroup) return self
+        val children = buildString {
+            for (i in 0 until childCount) {
+                append("\n")
+                append(getChildAt(i).summarizeViewHierarchy(maxDepth, currentDepth + 1))
+            }
+        }
+        return "$self$children"
     }
 
     private fun Bitmap.blackRatio(): Double {

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -128,7 +128,11 @@ class GeckoSurfaceResumeTest {
         }
 
         assertTrue("Timed out waiting for GeckoView.capturePixels()", latch.await(10, TimeUnit.SECONDS))
-        errorRef.get()?.let { throw AssertionError("GeckoView.capturePixels() failed", it) }
+        errorRef.get()?.let { error ->
+            // AssertionError はそのまま再throw して診断メッセージ（階層ダンプ等）を保持する。
+            if (error is AssertionError) throw error
+            throw AssertionError("GeckoView.capturePixels() failed", error)
+        }
         return requireNotNull(bitmapRef.get()) {
             "GeckoView.capturePixels() returned null"
         }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
@@ -461,7 +461,26 @@ class GmdSmokeTest {
             if (imeVisible && System.currentTimeMillis() >= stableWindowStart) {
                 imeVisibleInStableWindow = true
             }
-            assertTrue("URL bar focus was dropped while observing keyboard state", focused)
+            if (!focused) {
+                // フォーカスが外れた原因を特定するため診断情報を収集する。
+                // ノード自体が消えた（Compose の一時的なリコンポーズ）か、ノードは
+                // あるがフォーカスが解除されたかを区別できるようにする。
+                val elapsedMs = System.currentTimeMillis() - start
+                val nodeExists = runCatching {
+                    composeRule.onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag).fetchSemanticsNode()
+                    true
+                }.getOrDefault(false)
+                val urlBarText = runCatching { getUrlBarText() }.getOrDefault("<error>")
+                val geckoCount = runCatching {
+                    composeRule.onAllNodesWithTag(GeckoBrowserTabTestTags.GeckoContainer.testTag)
+                        .fetchSemanticsNodes().size
+                }.getOrDefault(-1)
+                throw AssertionError(
+                    "URL bar focus was dropped while observing keyboard state " +
+                        "(elapsed=${elapsedMs}ms nodeExists=$nodeExists " +
+                        "urlBarText=\"$urlBarText\" geckoCount=$geckoCount)"
+                )
+            }
             Thread.sleep(100)
         }
         if (requireImeWasVisibleBeforeTap) {

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser
 
+import android.os.SystemClock
 import android.view.WindowInsets
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.hasAnyDescendant
@@ -446,11 +447,11 @@ class GmdSmokeTest {
         observeMillis: Long = 1_500L,
         requireImeWasVisibleBeforeTap: Boolean = false,
     ) {
-        val start = System.currentTimeMillis()
+        val start = SystemClock.elapsedRealtime()
         val deadline = start + observeMillis
         val stableWindowStart = start + 700L
         var imeVisibleInStableWindow = false
-        while (System.currentTimeMillis() < deadline) {
+        while (SystemClock.elapsedRealtime() < deadline) {
             val focused = isUrlBarFocused()
             var imeVisible = false
             composeRule.runOnIdle {
@@ -458,14 +459,14 @@ class GmdSmokeTest {
                 imeVisible = insets?.isVisible(WindowInsets.Type.ime()) == true
             }
 
-            if (imeVisible && System.currentTimeMillis() >= stableWindowStart) {
+            if (imeVisible && SystemClock.elapsedRealtime() >= stableWindowStart) {
                 imeVisibleInStableWindow = true
             }
             if (!focused) {
                 // フォーカスが外れた原因を特定するため診断情報を収集する。
                 // ノード自体が消えた（Compose の一時的なリコンポーズ）か、ノードは
                 // あるがフォーカスが解除されたかを区別できるようにする。
-                val elapsedMs = System.currentTimeMillis() - start
+                val elapsedMs = SystemClock.elapsedRealtime() - start
                 val nodeExists = runCatching {
                     composeRule.onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag).fetchSemanticsNode()
                     true


### PR DESCRIPTION
## 概要

Android Instrumentation テスト（GMD: Pixel 6, API 34）でランダムに失敗している可能性のある2箇所に診断ログを追加し、次回失敗時に原因を特定しやすくする。

今日は情報が不足しているためログ追加のみ実施。失敗ログが蓄積されたら根本修正へ進む。

## 対象テスト・変更内容

### `GeckoSurfaceResumeTest.geckoPixelsRemainVisibleAfterActivityReturnsFromBackground`

**懸念点**: Activity を CREATED→RESUMED させた直後、`findGeckoView()` が null を返すことがある。  
Compose の `AndroidView` ラッパーがアタッチ中か、ライフサイクル復帰のタイミングずれが原因かを区別できなかった。

**変更**: `findGeckoView()` が null の場合、decorView の4階層分のビュー階層サマリ（クラス名＋可視状態 V/I/G）をエラーメッセージに含める。

### `GmdSmokeTest.openingUrlBarFromGeckoViewDoesNotImmediatelyCloseKeyboard`

**懸念点**: `assertUrlBarFocusAndImeStayStableAfterOpening` のフォーカス確認ループで `isUrlBarFocused()` が false になった際、「URL bar focus was dropped」しか分からなかった。  
ノード自体が消えた（Compose の一時的なリコンポーズ）か、ノードはあるがフォーカスが解除されたかを区別できなかった。

**変更**: フォーカスが false になった時点で次の情報を収集してエラーメッセージに含める。
- URL バーノードの存在有無 (`nodeExists`)
- URL バーの現在テキスト
- GeckoContainer ノードの数
- 観測開始からの経過時間

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzP4t41fwB679ZBjr67g4M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced diagnostic output in test failures to improve debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->