### PR TITLE
apple-touch-icon のデフォルトサイズを補完

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/HomeScreenIconFetcher.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/HomeScreenIconFetcher.kt
@@ -25,6 +25,7 @@ internal object HomeScreenIconFetcher {
     private const val MAX_DECODED_ICON_DIMENSION = 1024
     private const val MAX_SHORTCUT_ICON_SIZE = 192
     private const val MAX_ICON_FETCH_ATTEMPTS = 20
+    private const val APPLE_TOUCH_ICON_DEFAULT_SIZE = 180
     private const val USER_AGENT = "Mozilla/5.0 (Android) Browsem"
 
     private val linkTagRegex = Regex("""<link\b[^>]*>""", RegexOption.IGNORE_CASE)
@@ -117,9 +118,20 @@ internal object HomeScreenIconFetcher {
             }
             if (relValues.any { it == "icon" || it == "apple-touch-icon" || it == "apple-touch-icon-precomposed" }) {
                 val url = resolveUrl(pageUri, href) ?: return@forEach
+                val declaredSize = parseIconSize(attributes["sizes"])
+                val isAppleTouchIcon = relValues.any {
+                    it == "apple-touch-icon" || it == "apple-touch-icon-precomposed"
+                }
+                // apple-touch-icon は sizes 未指定でも 180x180 が標準。
+                // favicon.ico (32x32 程度) より優先するためデフォルトサイズを補完する。
+                val effectiveSize = if (declaredSize == 0 && isAppleTouchIcon) {
+                    APPLE_TOUCH_ICON_DEFAULT_SIZE
+                } else {
+                    declaredSize
+                }
                 icons += IconCandidate(
                     url = url,
-                    size = parseIconSize(attributes["sizes"]),
+                    size = effectiveSize,
                     type = attributes["type"],
                     source = IconSource.Html,
                 )


### PR DESCRIPTION
## 概要
ホームスクリーン用アイコン取得時に、`apple-touch-icon` で `sizes` 属性が未指定の場合、標準サイズ 180x180 をデフォルト値として補完するようにしました。

## 変更内容
- `APPLE_TOUCH_ICON_DEFAULT_SIZE` 定数（180）を追加
- `apple-touch-icon` / `apple-touch-icon-precomposed` の判定ロジックを追加
- `sizes` 属性が未指定（0）かつ apple-touch-icon の場合、デフォルトサイズ 180 を使用するように変更

## 実装の詳細
apple-touch-icon は sizes 属性を指定しなくても 180x180 が標準仕様です。この変更により、favicon.ico（32x32 程度）よりも優先度の高い適切なサイズでアイコンが選択されるようになります。

https://claude.ai/code/session_01Eq1tAnhUgdimrRgmXChmBr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home screen icon handling for Apple devices. The app now correctly displays touch icons that don't have a specified size by defaulting them to 180x180 pixels. Previously, such icons would fail to render properly or appear broken. This fix ensures consistent icon display across all compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->