### PR TITLE
Android ランタイムパーミッション（マイク・カメラ）の要求機能を実装

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_SET_ORIGIN" />
     <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_QUERY_CANDIDATE_CREDENTIALS" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <!--
         Android 11 (API 30) 以降のパッケージ可視性制限に対応するため、

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,13 @@
     <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_QUERY_CANDIDATE_CREDENTIALS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <!--
+        マイク・カメラはDiscord等のWebRTCで使用するが、これらのハードウェアが
+        ないデバイスでもブラウザとして動作するため required="false" を指定する。
+    -->
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
     <!--
         Android 11 (API 30) 以降のパッケージ可視性制限に対応するため、

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         ないデバイスでもブラウザとして動作するため required="false" を指定する。
     -->
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
-    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
     <!--

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -60,6 +60,7 @@ internal fun rememberBrowserTabScreenState(
     onHistoryRecord: (suspend (url: String, title: String) -> Long)? = null,
     onHistoryTitleUpdate: (suspend (id: Long, title: String) -> Unit)? = null,
     onRequestDownloadNotificationPermission: suspend () -> Unit = {},
+    onRequestAndroidPermissions: suspend (Array<String>) -> Array<String> = { emptyArray() },
 ): BrowserTabScreenState {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -78,6 +79,7 @@ internal fun rememberBrowserTabScreenState(
             onHistoryRecord = onHistoryRecord,
             onHistoryTitleUpdate = onHistoryTitleUpdate,
             onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
+            onRequestAndroidPermissions = onRequestAndroidPermissions,
         )
     }
     state.homepageUrl = homepageUrl
@@ -98,6 +100,7 @@ internal class BrowserTabScreenState(
     internal val findInPageWebExtension: FindInPageWebExtension,
     private val context: Context,
     private val onRequestDownloadNotificationPermission: suspend () -> Unit = {},
+    private val onRequestAndroidPermissions: suspend (Array<String>) -> Array<String> = { emptyArray() },
     var onHistoryRecord: (suspend (url: String, title: String) -> Long)? = null,
     var onHistoryTitleUpdate: (suspend (id: Long, title: String) -> Unit)? = null,
 ) : BrowserSessionStateCallbacks {
@@ -1068,6 +1071,23 @@ internal class BrowserTabScreenState(
 
     override fun onScrollChanged(scrollY: Int) {
         this.scrollY = scrollY
+    }
+
+    override fun onAndroidPermissionsRequest(
+        permissions: Array<String>?,
+        onGrant: () -> Unit,
+        onReject: () -> Unit,
+    ) {
+        val perms = permissions ?: run { onReject(); return }
+        coroutineScope.launch {
+            runCatching {
+                onRequestAndroidPermissions(perms)
+            }.onSuccess { granted ->
+                if (granted.size == perms.size) onGrant() else onReject()
+            }.onFailure {
+                onReject()
+            }
+        }
     }
 
     private fun maybeResetToolbarColor(fromUrl: String, toUrl: String) {

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -1083,7 +1083,7 @@ internal class BrowserTabScreenState(
             runCatching {
                 onRequestAndroidPermissions(perms)
             }.onSuccess { granted ->
-                if (granted.size == perms.size) onGrant() else onReject()
+                if (perms.all { it in granted }) onGrant() else onReject()
             }.onFailure {
                 onReject()
             }

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -35,6 +35,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import android.content.pm.PackageManager
+import kotlinx.coroutines.CompletableDeferred
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -115,6 +119,21 @@ internal fun GeckoBrowserTab(
     var clipboardUrl by remember { mutableStateOf<String?>(null) }
     // タブ履歴BottomSheetの表示状態
     var showTabHistorySheet by remember { mutableStateOf(false) }
+
+    // Androidランタイムパーミッション要求用（マイク・カメラ等）
+    val pendingPermissionsRef = remember {
+        object {
+            var pending: CompletableDeferred<Array<String>>? = null
+        }
+    }
+    val requestPermissionsLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { results ->
+        val granted = results.filterValues { it }.keys.toTypedArray()
+        pendingPermissionsRef.pending?.complete(granted)
+        pendingPermissionsRef.pending = null
+    }
+
     val state = rememberBrowserTabScreenState(
         browserTab = browserTab,
         homepageUrl = homepageUrl,
@@ -123,6 +142,23 @@ internal fun GeckoBrowserTab(
         onHistoryRecord = onHistoryRecord,
         onHistoryTitleUpdate = onHistoryTitleUpdate,
         onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
+        onRequestAndroidPermissions = { permissions ->
+            val alreadyGranted = permissions.filter {
+                ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+            }
+            val notGranted = permissions.filter {
+                ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
+            }
+            if (notGranted.isEmpty()) {
+                alreadyGranted.toTypedArray()
+            } else {
+                val deferred = CompletableDeferred<Array<String>>()
+                pendingPermissionsRef.pending = deferred
+                requestPermissionsLauncher.launch(notGranted.toTypedArray())
+                val newlyGranted = deferred.await()
+                (alreadyGranted + newlyGranted).toTypedArray()
+            }
+        },
     )
 
     // ツールバー色の輝度に応じてステータスバーアイコン色（黒/白）を動的に切り替える

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -31,6 +31,11 @@ interface BrowserSessionStateCallbacks {
         request: GeckoSession.NavigationDelegate.LoadRequest,
     ): GeckoResult<AllowOrDeny>?
     fun onHistoryStateChange(items: List<HistoryStateItem>, currentIndex: Int)
+    fun onAndroidPermissionsRequest(
+        permissions: Array<String>?,
+        onGrant: () -> Unit,
+        onReject: () -> Unit,
+    )
 }
 
 /** タブ内ナビゲーション履歴の項目 */
@@ -79,6 +84,22 @@ fun createGeckoSessionDelegateBundle(
                 Log.d("BrowserTabPermission", "non-notification permission prompted")
                 return GeckoResult.fromValue(
                     GeckoSession.PermissionDelegate.ContentPermission.VALUE_PROMPT
+                )
+            }
+
+            override fun onAndroidPermissionsRequest(
+                session: GeckoSession,
+                permissions: Array<out String>?,
+                callback: GeckoSession.PermissionDelegate.Callback,
+            ) {
+                Log.d(
+                    "BrowserTabPermission",
+                    "onAndroidPermissionsRequest: permissions=${permissions?.toList()}"
+                )
+                callbacks.onAndroidPermissionsRequest(
+                    permissions = permissions?.let { it.toList().toTypedArray() },
+                    onGrant = { callback.grant() },
+                    onReject = { callback.reject() },
                 )
             }
         },
@@ -324,6 +345,19 @@ internal class BrowserTabSessionDelegateHost(
 
             override fun onHistoryStateChange(items: List<HistoryStateItem>, currentIndex: Int) {
                 // bindToSession で設定する historyDelegate 経由で呼ばれるため、ここでは何もしない
+            }
+
+            override fun onAndroidPermissionsRequest(
+                permissions: Array<String>?,
+                onGrant: () -> Unit,
+                onReject: () -> Unit,
+            ) {
+                val cb = currentCallbacks()
+                if (cb != null) {
+                    cb.onAndroidPermissionsRequest(permissions, onGrant, onReject)
+                } else {
+                    onReject()
+                }
             }
         },
         browserTab = browserTab,

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -96,8 +96,9 @@ fun createGeckoSessionDelegateBundle(
                     "BrowserTabPermission",
                     "onAndroidPermissionsRequest: permissions=${permissions?.toList()}"
                 )
+                @Suppress("UNCHECKED_CAST")
                 callbacks.onAndroidPermissionsRequest(
-                    permissions = permissions?.let { it.toList().toTypedArray() },
+                    permissions = permissions as Array<String>?,
                     onGrant = { callback.grant() },
                     onReject = { callback.reject() },
                 )

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -103,6 +103,29 @@ fun createGeckoSessionDelegateBundle(
                     onReject = { callback.reject() },
                 )
             }
+
+            // getUserMedia のデバイス選択。デフォルト実装は reject するため、
+            // 未実装だと Android パーミッションを許可してもマイク・カメラが拒否される。
+            override fun onMediaPermissionRequest(
+                session: GeckoSession,
+                uri: String,
+                video: Array<out GeckoSession.PermissionDelegate.MediaSource>?,
+                audio: Array<out GeckoSession.PermissionDelegate.MediaSource>?,
+                callback: GeckoSession.PermissionDelegate.MediaCallback,
+            ) {
+                Log.d(
+                    "BrowserTabPermission",
+                    "onMediaPermissionRequest: uri=$uri, " +
+                        "video=${video?.map { it.name }}, audio=${audio?.map { it.name }}"
+                )
+                val videoSource = video?.firstOrNull()
+                val audioSource = audio?.firstOrNull()
+                if (videoSource == null && audioSource == null) {
+                    callback.reject()
+                } else {
+                    callback.grant(videoSource, audioSource)
+                }
+            }
         },
         navigationDelegate = object : GeckoSession.NavigationDelegate {
             override fun onCanGoBack(session: GeckoSession, value: Boolean) {


### PR DESCRIPTION
## 概要
GeckoView からのマイク・カメラなどの Android ランタイムパーミッション要求に対応する機能を実装しました。Web コンテンツがこれらのパーミッションを必要とする場合、ユーザーに対して適切に要求・許可できるようになります。

## 主な変更

### 1. パーミッション要求フロー の実装
- **GeckoSessionDelegateFactory.kt**: `GeckoSession.PermissionDelegate` に `onAndroidPermissionsRequest` ハンドラを追加
  - Gecko からのパーミッション要求を `BrowserSessionStateCallbacks` 経由で上位層に伝播
  - `onGrant`/`onReject` コールバックで Gecko に結果を返却

### 2. UI 層でのパーミッション処理
- **GeckoBrowserTab.kt**: `rememberLauncherForActivityResult` で `RequestMultiplePermissions` コントラクトを設定
  - 既に許可されているパーミッションと未許可のパーミッションを分別
  - 未許可のパーミッションのみをシステムダイアログで要求
  - `CompletableDeferred` を使用して非同期結果を待機

### 3. State Holder への統合
- **BrowserTabScreenState.kt**: `onRequestAndroidPermissions` コールバックを追加
  - `onAndroidPermissionsRequest` オーバーライドで要求されたパーミッションを処理
  - 全パーミッションが許可された場合のみ `onGrant()` を呼び出し

### 4. マニフェスト更新
- **AndroidManifest.xml**: `RECORD_AUDIO` と `CAMERA` パーミッションを宣言

## 実装の特徴
- 既に許可されているパーミッションは再度要求しない（UX 向上）
- 非同期処理を `CompletableDeferred` で適切に管理
- Gecko → ネイティブ → UI → システムダイアログ → Gecko という双方向フローを実現

https://claude.ai/code/session_01FNSJ4PjwUJRp4ZRPLmPVH3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added microphone and camera permission declarations so the app can request audio/video access.
  * Implemented runtime permission prompts and handling so the browser asks for and grants camera/microphone access when needed, while allowing devices without those features to still use WebRTC in-browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->