### PR TITLE
サイトごとのマイク権限設定機能を追加

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -50,8 +50,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.matsudamper.browser.data.SettingsRepository
+import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TabGroupId
 import net.matsudamper.browser.data.TabGroupRepository
+import net.matsudamper.browser.data.extractSiteHost
 import net.matsudamper.browser.data.history.HistoryRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
 import net.matsudamper.browser.navigation.AppDestination
@@ -62,6 +64,7 @@ import net.matsudamper.browser.screen.history.HistoryScreenViewModel
 import net.matsudamper.browser.screen.downloads.DownloadManagementScreenViewModel
 import net.matsudamper.browser.screen.backup.BackupProgressViewModel
 import net.matsudamper.browser.screen.settings.SettingsScreenViewModel
+import net.matsudamper.browser.screen.sitesettings.SiteSettingsScreenViewModel
 import net.matsudamper.browser.screen.tab.TabsScreenViewModel
 import net.matsudamper.browser.ui.common.BrowserTheme
 import net.matsudamper.browser.ui.browser.BrowserScreen
@@ -71,6 +74,7 @@ import net.matsudamper.browser.ui.history.HistoryScreen
 import net.matsudamper.browser.ui.settings.BackupProgressScreen
 import net.matsudamper.browser.ui.settings.BackupProgressUiState
 import net.matsudamper.browser.ui.settings.SettingsScreen
+import net.matsudamper.browser.ui.settings.SiteSettingsScreen
 import net.matsudamper.browser.ui.tabs.TabsScreen
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -336,6 +340,12 @@ private fun BrowserAppContent(
                                     onInstallExtensionRequest = onInstallExtensionRequest,
                                     onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
                                     onOpenSettings = { backStack.add(AppDestination.Settings) },
+                                    onOpenSiteSettings = { currentUrl ->
+                                        val host = extractSiteHost(currentUrl)
+                                        if (host != null) {
+                                            backStack.add(AppDestination.SiteSettings(host))
+                                        }
+                                    },
                                     onOpenTabs = { backStack.add(AppDestination.Tabs) },
                                     browserSessionLifecycleController = browserSessionLifecycleController,
                                     onOpenNewSessionRequest = { uri ->
@@ -421,6 +431,21 @@ private fun BrowserAppContent(
                                 onBack = { backStack.removeLastOrNull() },
                             )
                         }
+                    }
+
+                    is AppDestination.SiteSettings -> navEntry(key) {
+                        val siteSettingsRepository: SiteSettingsRepository = koinInject()
+                        val siteSettingsViewModel = composeViewModel(initializer = {
+                            SiteSettingsScreenViewModel(
+                                host = key.host,
+                                siteSettingsRepository = siteSettingsRepository,
+                            )
+                        })
+                        val siteSettingsUiState by siteSettingsViewModel.uiState.collectAsState()
+                        SiteSettingsScreen(
+                            uiState = siteSettingsUiState,
+                            onBack = { backStack.removeLastOrNull() },
+                        )
                     }
 
                     AppDestination.History -> navEntry(key) {

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -71,6 +71,31 @@ internal fun BrowserTabDialogLayer(
         )
     }
 
+    // サイトごとのマイク許可確認ダイアログ。
+    // OS の権限ダイアログより前に表示され、選択はサイト設定として永続化される。
+    state.microphonePermissionDialog?.let { dialog ->
+        AlertDialog(
+            onDismissRequest = state::dismissMicrophonePermissionDialog,
+            title = { Text("マイクの使用許可") },
+            text = {
+                Text(
+                    "${dialog.host} がマイクの使用を求めています。" +
+                        "この設定はメニューの「サイトの設定」から変更できます。",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { state.confirmMicrophonePermissionDialog(true) }) {
+                    Text("許可")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { state.confirmMicrophonePermissionDialog(false) }) {
+                    Text("ブロック")
+                }
+            },
+        )
+    }
+
     state.pendingDownloadResponse?.let { response ->
         AlertDialog(
             onDismissRequest = state::dismissPendingDownload,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -19,13 +20,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.net.URL
+import net.matsudamper.browser.data.SitePermissionState
+import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TranslationProvider
+import net.matsudamper.browser.data.extractSiteHost
 import net.matsudamper.browser.translate.TranslationPriorityLanguage
 import org.json.JSONObject
 import org.koin.compose.koinInject
@@ -66,6 +71,7 @@ internal fun rememberBrowserTabScreenState(
     val coroutineScope = rememberCoroutineScope()
     val geckoDownloadManager: GeckoDownloadManager = koinInject()
     val findInPageWebExtension: FindInPageWebExtension = koinInject()
+    val siteSettingsRepository: SiteSettingsRepository = koinInject()
     val state = remember(browserTab) {
         BrowserTabScreenState(
             browserTab = browserTab,
@@ -75,6 +81,7 @@ internal fun rememberBrowserTabScreenState(
             coroutineScope = coroutineScope,
             geckoDownloadManager = geckoDownloadManager,
             findInPageWebExtension = findInPageWebExtension,
+            siteSettingsRepository = siteSettingsRepository,
             context = context,
             onHistoryRecord = onHistoryRecord,
             onHistoryTitleUpdate = onHistoryTitleUpdate,
@@ -98,6 +105,7 @@ internal class BrowserTabScreenState(
     private val coroutineScope: CoroutineScope,
     private val geckoDownloadManager: GeckoDownloadManager,
     internal val findInPageWebExtension: FindInPageWebExtension,
+    private val siteSettingsRepository: SiteSettingsRepository,
     private val context: Context,
     private val onRequestDownloadNotificationPermission: suspend () -> Unit = {},
     private val onRequestAndroidPermissions: suspend (Array<String>) -> Array<String> = { emptyArray() },
@@ -192,6 +200,65 @@ internal class BrowserTabScreenState(
 
     // --- プロンプトダイアログ状態（分離済み） ---
     val promptDialogState = PromptDialogState(coroutineScope)
+
+    // --- サイトごとのマイク許可確認ダイアログ状態 ---
+    var microphonePermissionDialog by mutableStateOf<MicrophonePermissionDialogState?>(null)
+        private set
+
+    /**
+     * @param onResult true=許可(永続化), false=ブロック(永続化), null=今回のみ拒否
+     */
+    @Stable
+    class MicrophonePermissionDialogState(
+        val host: String,
+        internal val onResult: (Boolean?) -> Unit,
+    )
+
+    fun confirmMicrophonePermissionDialog(allow: Boolean) {
+        val dialog = microphonePermissionDialog ?: return
+        microphonePermissionDialog = null
+        dialog.onResult(allow)
+    }
+
+    fun dismissMicrophonePermissionDialog() {
+        val dialog = microphonePermissionDialog ?: return
+        microphonePermissionDialog = null
+        dialog.onResult(null)
+    }
+
+    /**
+     * サイトごとのマイク権限を解決する。
+     * 未設定 (ASK) の場合は確認ダイアログを表示してユーザーの応答を待ち、
+     * 許可/ブロックの選択をサイト設定として永続化する。
+     */
+    private suspend fun resolveMicrophonePermission(host: String): Boolean {
+        when (siteSettingsRepository.getMicrophonePermission(host)) {
+            SitePermissionState.SITE_PERMISSION_ALLOW -> return true
+            SitePermissionState.SITE_PERMISSION_DENY -> return false
+            else -> Unit
+        }
+        // 表示中のダイアログが残っている場合は今回のみ拒否として閉じる
+        microphonePermissionDialog?.also { previous ->
+            microphonePermissionDialog = null
+            previous.onResult(null)
+        }
+        val result = CompletableDeferred<Boolean?>()
+        microphonePermissionDialog = MicrophonePermissionDialogState(host) { allow ->
+            result.complete(allow)
+        }
+        val choice = result.await()
+        if (choice != null) {
+            siteSettingsRepository.setMicrophonePermission(
+                host = host,
+                state = if (choice) {
+                    SitePermissionState.SITE_PERMISSION_ALLOW
+                } else {
+                    SitePermissionState.SITE_PERMISSION_DENY
+                },
+            )
+        }
+        return choice == true
+    }
 
     // --- ファイルダウンロード確認ダイアログ用state ---
     var pendingDownloadResponse by mutableStateOf<WebResponse?>(null)
@@ -1080,6 +1147,14 @@ internal class BrowserTabScreenState(
     ) {
         val perms = permissions ?: run { onReject(); return }
         coroutineScope.launch {
+            // OS の権限要求の前に、サイトごとのマイク許可を確認する
+            if (Manifest.permission.RECORD_AUDIO in perms) {
+                val host = extractSiteHost(currentPageUrl)
+                if (host == null || !resolveMicrophonePermission(host)) {
+                    onReject()
+                    return@launch
+                }
+            }
             runCatching {
                 onRequestAndroidPermissions(perms)
             }.onSuccess { granted ->
@@ -1087,6 +1162,26 @@ internal class BrowserTabScreenState(
             }.onFailure {
                 onReject()
             }
+        }
+    }
+
+    override fun onMediaPermissionRequest(
+        uri: String,
+        hasVideo: Boolean,
+        hasAudio: Boolean,
+        onResult: (grantVideo: Boolean, grantAudio: Boolean) -> Unit,
+    ) {
+        // マイクを含まない要求（カメラのみ等）は従来通り許可する
+        if (!hasAudio) {
+            onResult(hasVideo, false)
+            return
+        }
+        coroutineScope.launch {
+            // OS 権限が許可済みの場合は onAndroidPermissionsRequest を経由しないため、
+            // ここでもサイトごとのマイク許可を確認する（未設定ならダイアログを表示する）
+            val host = extractSiteHost(uri) ?: extractSiteHost(currentPageUrl)
+            val grantAudio = host != null && resolveMicrophonePermission(host)
+            onResult(hasVideo, grantAudio)
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -114,6 +114,7 @@ internal fun BrowserToolBar(
     showTabActions: Boolean = true,
     onHorizontalDrag: (Float) -> Unit = {},
     onHorizontalDragEnd: () -> Unit = {},
+    onOpenSiteSettings: (() -> Unit)? = null,
 ) {
     var visibleMenu by remember { mutableStateOf(false) }
     BrowserToolbar(
@@ -177,6 +178,7 @@ internal fun BrowserToolBar(
                 onPageZoomIn = onPageZoomIn,
                 onPageZoomOut = onPageZoomOut,
                 onResetPageZoom = onResetPageZoom,
+                onOpenSiteSettings = onOpenSiteSettings,
             )
         }
     )

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
@@ -62,6 +62,7 @@ internal fun ToolbarMenu(
     showAddToHomeScreen: Boolean = true,
     showHome: Boolean = true,
     onOpenInBrowser: (() -> Unit)? = null,
+    onOpenSiteSettings: (() -> Unit)? = null,
 ) {
     DropdownMenu(
         expanded = visibleMenu,
@@ -208,6 +209,27 @@ internal fun ToolbarMenu(
                     text = "更新",
                     style = MaterialTheme.typography.labelSmall,
                 )
+            }
+            if (onOpenSiteSettings != null) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    IconButton(
+                        modifier = Modifier
+                            .testTag(BrowserToolbarMenuTestTags.SiteSettingsButton.testTag),
+                        onClick = {
+                            onDismissRequest()
+                            onOpenSiteSettings()
+                        },
+                    ) {
+                        Icon(
+                            painter = painterResource(ResourcesR.drawable.ic_settings_24dp),
+                            contentDescription = null,
+                        )
+                    }
+                    Text(
+                        text = "サイトの設定",
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
             }
         }
         HorizontalDivider()
@@ -395,4 +417,5 @@ sealed interface BrowserToolbarMenuTestTags {
     object ZoomPercentButton : BrowserToolbarMenuTestTags { override val id = "zoom_percent_button" }
     object RefreshButton : BrowserToolbarMenuTestTags { override val id = "refresh_button" }
     object FindInPageButton : BrowserToolbarMenuTestTags { override val id = "find_in_page_button" }
+    object SiteSettingsButton : BrowserToolbarMenuTestTags { override val id = "site_settings_button" }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -268,6 +268,8 @@ private fun CustomTabScreen(
         onInstallExtensionRequest = {},
         onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
         onOpenSettings = {},
+        // カスタムタブは設定画面のナビゲーションスタックを持たないため非表示
+        onOpenSiteSettings = null,
         onOpenTabs = {},
         enableTabUi = false,
         showInstallExtensionItem = false,

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -94,6 +94,7 @@ internal fun GeckoBrowserTab(
     tabCount: Int?,
     onInstallExtensionRequest: (String) -> Unit,
     onOpenSettings: () -> Unit,
+    onOpenSiteSettings: ((currentUrl: String) -> Unit)?,
     onOpenTabs: () -> Unit,
     onOpenNewSessionRequest: (String) -> GeckoSession?,
     onOpenNewTabRequest: (String) -> Unit,
@@ -748,6 +749,9 @@ internal fun GeckoBrowserTab(
                     showInstallExtensionItem = showInstallExtensionItem && state.showInstallExtensionItem,
                     onInstallExtension = { onInstallExtensionRequest(state.currentPageUrl) },
                     onOpenSettings = onOpenSettings,
+                    onOpenSiteSettings = onOpenSiteSettings?.let { callback ->
+                        { callback(state.currentPageUrl) }
+                    },
                     onShare = state::sharePage,
                     tabCount = tabCount,
                     showTabActions = enableTabUi,

--- a/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
@@ -125,6 +125,8 @@ class WebAppActivity : ComponentActivity() {
                         onInstallExtensionRequest = {},
                         onRequestDownloadNotificationPermission = { requestDownloadNotificationPermission() },
                         onOpenSettings = {},
+                        // ウェブアプリモードは設定画面のナビゲーションスタックを持たないため非表示
+                        onOpenSiteSettings = null,
                         onOpenTabs = {},
                         enableTabUi = false,
                         showInstallExtensionItem = false,

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -9,6 +9,7 @@ import net.matsudamper.browser.ThemeColorWebExtension
 import net.matsudamper.browser.ViewportScaleWebExtension
 import net.matsudamper.browser.data.BackupRepository
 import net.matsudamper.browser.data.SettingsRepository
+import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TabGroupRepository
 import net.matsudamper.browser.data.TabGroupRepositoryImpl
 import net.matsudamper.browser.data.TabRepository
@@ -27,6 +28,7 @@ import org.mozilla.geckoview.GeckoRuntimeSettings
 val dataModule = module {
     single { BackupRepository(androidContext()) }
     single { SettingsRepository(androidContext()) }
+    single { SiteSettingsRepository(androidContext()) }
     single { TabRepository(androidContext()) }
     single<TabGroupRepository> { TabGroupRepositoryImpl(androidContext()) }
     single { HistoryRepository(androidContext()) }

--- a/app/src/main/kotlin/net/matsudamper/browser/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/navigation/AppDestination.kt
@@ -14,6 +14,10 @@ sealed interface AppDestination : NavKey, java.io.Serializable {
     @Serializable
     data object Settings : AppDestination, java.io.Serializable
 
+    /** サイトごとの設定画面。host は対象サイトのホスト名 */
+    @Serializable
+    data class SiteSettings(val host: String) : AppDestination, java.io.Serializable
+
     @Serializable
     data object Extensions : AppDestination, java.io.Serializable
 

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -1,0 +1,41 @@
+package net.matsudamper.browser.screen.sitesettings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import net.matsudamper.browser.data.SitePermissionState
+import net.matsudamper.browser.data.SiteSettingsRepository
+import net.matsudamper.browser.ui.settings.SiteSettingsScreenUiState
+
+internal class SiteSettingsScreenViewModel(
+    private val host: String,
+    private val siteSettingsRepository: SiteSettingsRepository,
+) : ViewModel() {
+
+    private val callbacks = object : SiteSettingsScreenUiState.Callbacks {
+        override fun setMicrophonePermission(state: SitePermissionState) {
+            viewModelScope.launch {
+                siteSettingsRepository.setMicrophonePermission(host, state)
+            }
+        }
+    }
+
+    val uiState: StateFlow<SiteSettingsScreenUiState> = MutableStateFlow(
+        SiteSettingsScreenUiState(
+            callbacks = callbacks,
+            host = host,
+            microphonePermission = SitePermissionState.SITE_PERMISSION_ASK,
+        ),
+    ).also { uiStateFlow ->
+        viewModelScope.launch {
+            siteSettingsRepository.microphonePermission(host).collectLatest { permission ->
+                uiStateFlow.update { it.copy(microphonePermission = permission) }
+            }
+        }
+    }.asStateFlow()
+}

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -36,6 +36,12 @@ interface BrowserSessionStateCallbacks {
         onGrant: () -> Unit,
         onReject: () -> Unit,
     )
+    fun onMediaPermissionRequest(
+        uri: String,
+        hasVideo: Boolean,
+        hasAudio: Boolean,
+        onResult: (grantVideo: Boolean, grantAudio: Boolean) -> Unit,
+    )
 }
 
 /** タブ内ナビゲーション履歴の項目 */
@@ -122,9 +128,23 @@ fun createGeckoSessionDelegateBundle(
                 val audioSource = audio?.firstOrNull()
                 if (videoSource == null && audioSource == null) {
                     callback.reject()
-                } else {
-                    callback.grant(videoSource, audioSource)
+                    return
                 }
+                // マイクの可否はサイトごとの設定に基づいて UI 層で判断する
+                callbacks.onMediaPermissionRequest(
+                    uri = uri,
+                    hasVideo = videoSource != null,
+                    hasAudio = audioSource != null,
+                    onResult = { grantVideo, grantAudio ->
+                        val grantedVideo = videoSource.takeIf { grantVideo }
+                        val grantedAudio = audioSource.takeIf { grantAudio }
+                        if (grantedVideo == null && grantedAudio == null) {
+                            callback.reject()
+                        } else {
+                            callback.grant(grantedVideo, grantedAudio)
+                        }
+                    },
+                )
             }
         },
         navigationDelegate = object : GeckoSession.NavigationDelegate {
@@ -381,6 +401,20 @@ internal class BrowserTabSessionDelegateHost(
                     cb.onAndroidPermissionsRequest(permissions, onGrant, onReject)
                 } else {
                     onReject()
+                }
+            }
+
+            override fun onMediaPermissionRequest(
+                uri: String,
+                hasVideo: Boolean,
+                hasAudio: Boolean,
+                onResult: (grantVideo: Boolean, grantAudio: Boolean) -> Unit,
+            ) {
+                val cb = currentCallbacks()
+                if (cb != null) {
+                    cb.onMediaPermissionRequest(uri, hasVideo, hasAudio, onResult)
+                } else {
+                    onResult(false, false)
                 }
             }
         },

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsRepository.kt
@@ -1,0 +1,54 @@
+package net.matsudamper.browser.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.dataStore
+import java.net.URI
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.siteSettingsDataStore: DataStore<SiteSettings> by dataStore(
+    fileName = "site_settings.pb",
+    serializer = SiteSettingsSerializer,
+    corruptionHandler = ReplaceFileCorruptionHandler { SiteSettings.getDefaultInstance() },
+)
+
+/** サイト（ホスト）ごとの設定を保存するリポジトリ */
+class SiteSettingsRepository(context: Context) {
+    private val dataStore = context.siteSettingsDataStore
+
+    /** 指定ホストのマイク権限の状態を監視する。未設定の場合は ASK を返す */
+    fun microphonePermission(host: String): Flow<SitePermissionState> {
+        return dataStore.data
+            .map { settings ->
+                settings.hostPermissionsMap[host]?.microphone
+                    ?: SitePermissionState.SITE_PERMISSION_ASK
+            }
+            .distinctUntilChanged()
+    }
+
+    /** 指定ホストの現在のマイク権限の状態を取得する */
+    suspend fun getMicrophonePermission(host: String): SitePermissionState {
+        return microphonePermission(host).first()
+    }
+
+    suspend fun setMicrophonePermission(host: String, state: SitePermissionState) {
+        dataStore.updateData { current ->
+            val permissions = (current.hostPermissionsMap[host] ?: SitePermissionSettings.getDefaultInstance())
+                .toBuilder()
+                .setMicrophone(state)
+                .build()
+            current.toBuilder()
+                .putHostPermissions(host, permissions)
+                .build()
+        }
+    }
+}
+
+/** URL からサイト設定のキーとなるホスト名を取り出す。取得できない場合は null */
+fun extractSiteHost(url: String): String? {
+    return runCatching { URI(url) }.getOrNull()?.host
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsSerializer.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsSerializer.kt
@@ -1,0 +1,23 @@
+package net.matsudamper.browser.data
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.google.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+
+internal object SiteSettingsSerializer : Serializer<SiteSettings> {
+    override val defaultValue: SiteSettings = SiteSettings.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): SiteSettings {
+        try {
+            return SiteSettings.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+    }
+
+    override suspend fun writeTo(t: SiteSettings, output: OutputStream) {
+        t.writeTo(output)
+    }
+}

--- a/proto/src/main/proto/site_settings.proto
+++ b/proto/src/main/proto/site_settings.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+option java_package = "net.matsudamper.browser.data";
+option java_multiple_files = true;
+
+// サイトごとの権限の状態
+enum SitePermissionState {
+  // 未設定。要求時にユーザーへ確認する
+  SITE_PERMISSION_ASK = 0;
+  SITE_PERMISSION_ALLOW = 1;
+  SITE_PERMISSION_DENY = 2;
+}
+
+// 1サイト（ホスト）分の権限設定
+message SitePermissionSettings {
+  SitePermissionState microphone = 1;
+}
+
+// サイトごとの設定全体。key はホスト名
+message SiteSettings {
+  map<string, SitePermissionSettings> host_permissions = 1;
+}

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -425,7 +425,7 @@ fun SettingsScreen(
 }
 
 @Composable
-private fun SettingSection(
+internal fun SettingSection(
     title: String,
     content: @Composable () -> Unit,
 ) {
@@ -491,7 +491,7 @@ private fun SettingsScreenPreview() {
 }
 
 @Composable
-private fun SettingsRadioOption(
+internal fun SettingsRadioOption(
     label: String,
     selected: Boolean,
     onClick: () -> Unit,

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -1,0 +1,127 @@
+package net.matsudamper.browser.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import net.matsudamper.browser.data.SitePermissionState
+import net.matsudamper.browser.resources.R as ResourcesR
+
+/**
+ * サイトごとの設定画面。
+ * 今後マイク以外の設定項目も追加するため、画面タイトルは「サイトの設定」の汎用名にしている。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SiteSettingsScreen(
+    uiState: SiteSettingsScreenUiState,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("サイトの設定") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(ResourcesR.drawable.ic_arrow_back_24dp),
+                            contentDescription = "戻る",
+                        )
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(
+                    start = paddingValues.calculateStartPadding(LocalLayoutDirection.current),
+                    end = paddingValues.calculateStartPadding(LocalLayoutDirection.current),
+                    top = paddingValues.calculateTopPadding(),
+                )
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = uiState.host,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 4.dp),
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            SettingSection(title = "マイク") {
+                Column(Modifier.selectableGroup()) {
+                    SettingsRadioOption(
+                        label = "確認する",
+                        selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_ASK,
+                        onClick = {
+                            uiState.callbacks.setMicrophonePermission(
+                                SitePermissionState.SITE_PERMISSION_ASK,
+                            )
+                        },
+                    )
+                    SettingsRadioOption(
+                        label = "許可",
+                        selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_ALLOW,
+                        onClick = {
+                            uiState.callbacks.setMicrophonePermission(
+                                SitePermissionState.SITE_PERMISSION_ALLOW,
+                            )
+                        },
+                    )
+                    SettingsRadioOption(
+                        label = "ブロック",
+                        selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_DENY,
+                        onClick = {
+                            uiState.callbacks.setMicrophonePermission(
+                                SitePermissionState.SITE_PERMISSION_DENY,
+                            )
+                        },
+                    )
+                }
+            }
+
+            Spacer(Modifier.padding(bottom = paddingValues.calculateBottomPadding()))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SiteSettingsScreenPreview() {
+    MaterialTheme {
+        SiteSettingsScreen(
+            uiState = SiteSettingsScreenUiState(
+                callbacks = object : SiteSettingsScreenUiState.Callbacks {
+                    override fun setMicrophonePermission(state: SitePermissionState) = Unit
+                },
+                host = "www.example.com",
+                microphonePermission = SitePermissionState.SITE_PERMISSION_ASK,
+            ),
+            onBack = {},
+        )
+    }
+}

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
@@ -1,0 +1,15 @@
+package net.matsudamper.browser.ui.settings
+
+import androidx.compose.runtime.Stable
+import net.matsudamper.browser.data.SitePermissionState
+
+@Stable
+data class SiteSettingsScreenUiState(
+    val callbacks: Callbacks,
+    val host: String,
+    val microphonePermission: SitePermissionState,
+) {
+    interface Callbacks {
+        fun setMicrophonePermission(state: SitePermissionState)
+    }
+}


### PR DESCRIPTION
## 概要

サイト（ホスト）ごとのマイク権限を管理する機能を追加しました。ユーザーがマイクへのアクセスを要求されたとき、OS の権限ダイアログの前にサイト固有の設定を確認し、その選択をサイト設定として永続化します。

## 主な変更

### データ層
- **SiteSettingsRepository**: ホストごとの権限設定を DataStore で管理するリポジトリを新規作成
- **site_settings.proto**: マイク権限の状態（未設定/許可/ブロック）とホストごとの設定を定義
- **SiteSettingsSerializer**: Protocol Buffers のシリアライザを実装

### UI 層
- **SiteSettingsScreen**: サイトごとの設定画面を新規作成。ラジオボタンでマイク権限を選択可能
- **SiteSettingsScreenViewModel**: 画面の状態管理と設定の永続化を担当
- **BrowserToolbarMenu**: ツールバーメニューに「サイトの設定」ボタンを追加

### ブラウザエンジン連携
- **GeckoSessionDelegateFactory**: メディア権限要求時に `onMediaPermissionRequest` コールバックを追加
- **BrowserTabScreenState**: 
  - マイク権限確認ダイアログの状態管理
  - `resolveMicrophonePermission()` でサイト設定を確認し、未設定時はダイアログを表示
  - `onAndroidPermissionsRequest()` と `onMediaPermissionRequest()` でサイト設定を確認

### ナビゲーション
- **AppDestination**: `SiteSettings(host)` 画面を追加
- **BrowserApp**: サイト設定画面への遷移処理を実装

### UI コンポーネント
- **BrowserTabDialogLayer**: マイク許可確認ダイアログを表示
- **SettingSection** と **SettingsRadioOption**: `internal` に変更して SiteSettingsScreen で再利用

## 実装の特徴

- マイク権限の確認はサイト設定 → OS 権限の順で行われ、サイト設定で拒否されれば OS 権限ダイアログは表示されない
- ユーザーの選択（許可/ブロック）は自動的にサイト設定として永続化される
- 未設定時のみダイアログが表示され、以降は設定に従う
- 複数のダイアログが同時に表示されないよう、前のダイアログが残っている場合は自動的に閉じる

https://claude.ai/code/session_015zdyZdRuSAzEmK6wY5vqBj