### PR TITLE
ツールバーメニューのホームとサイト設定を2段目に統合

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
@@ -18,6 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.ripple
@@ -29,7 +31,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import net.matsudamper.browser.ui.common.BrowserTheme
 import net.matsudamper.browser.resources.R as ResourcesR
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -68,6 +72,70 @@ internal fun ToolbarMenu(
         expanded = visibleMenu,
         onDismissRequest = { onDismissRequest() }
     ) {
+        ToolbarMenuContent(
+            onDismissRequest = onDismissRequest,
+            onRefresh = onRefresh,
+            onSuperRefresh = onSuperRefresh,
+            onHome = onHome,
+            onForward = onForward,
+            canGoForward = canGoForward,
+            onBack = onBack,
+            canGoBack = canGoBack,
+            onLongPressHistory = onLongPressHistory,
+            isPcMode = isPcMode,
+            onPcModeToggle = onPcModeToggle,
+            showInstallExtensionItem = showInstallExtensionItem,
+            onInstallExtension = onInstallExtension,
+            onTranslatePage = onTranslatePage,
+            onShare = onShare,
+            onFindInPage = onFindInPage,
+            onOpenSettings = onOpenSettings,
+            onAddToHomeScreen = onAddToHomeScreen,
+            pageZoomPercent = pageZoomPercent,
+            onPageZoomIn = onPageZoomIn,
+            onPageZoomOut = onPageZoomOut,
+            onResetPageZoom = onResetPageZoom,
+            showOpenSettings = showOpenSettings,
+            showAddToHomeScreen = showAddToHomeScreen,
+            showHome = showHome,
+            onOpenInBrowser = onOpenInBrowser,
+            onOpenSiteSettings = onOpenSiteSettings,
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ToolbarMenuContent(
+    onDismissRequest: () -> Unit,
+    onRefresh: () -> Unit,
+    onSuperRefresh: () -> Unit,
+    onHome: () -> Unit,
+    onForward: () -> Unit,
+    canGoForward: Boolean,
+    onBack: () -> Unit,
+    canGoBack: Boolean,
+    onLongPressHistory: () -> Unit,
+    isPcMode: Boolean,
+    onPcModeToggle: () -> Unit,
+    showInstallExtensionItem: Boolean,
+    onInstallExtension: () -> Unit,
+    onTranslatePage: () -> Unit,
+    onShare: () -> Unit,
+    onFindInPage: () -> Unit,
+    onOpenSettings: () -> Unit,
+    onAddToHomeScreen: () -> Unit,
+    pageZoomPercent: Int,
+    onPageZoomIn: () -> Unit,
+    onPageZoomOut: () -> Unit,
+    onResetPageZoom: () -> Unit,
+    showOpenSettings: Boolean,
+    showAddToHomeScreen: Boolean,
+    showHome: Boolean,
+    onOpenInBrowser: (() -> Unit)?,
+    onOpenSiteSettings: (() -> Unit)?,
+) {
+    Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -203,6 +271,8 @@ internal fun ToolbarMenu(
                 if (showHome) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         IconButton(
+                            modifier = Modifier
+                                .testTag(BrowserToolbarMenuTestTags.HomeButton.testTag),
                             onClick = {
                                 onDismissRequest()
                                 onHome()
@@ -419,6 +489,45 @@ internal fun ToolbarMenu(
     }
 }
 
+@Preview(name = "ToolbarMenuLight")
+@Preview(name = "ToolbarMenuDark", uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PreviewToolbarMenuContent() {
+    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_SYSTEM) {
+        Surface(modifier = Modifier.width(280.dp)) {
+            ToolbarMenuContent(
+                onDismissRequest = {},
+                onRefresh = {},
+                onSuperRefresh = {},
+                onHome = {},
+                onForward = {},
+                canGoForward = true,
+                onBack = {},
+                canGoBack = true,
+                onLongPressHistory = {},
+                isPcMode = false,
+                onPcModeToggle = {},
+                showInstallExtensionItem = true,
+                onInstallExtension = {},
+                onTranslatePage = {},
+                onShare = {},
+                onFindInPage = {},
+                onOpenSettings = {},
+                onAddToHomeScreen = {},
+                pageZoomPercent = 100,
+                onPageZoomIn = {},
+                onPageZoomOut = {},
+                onResetPageZoom = {},
+                showOpenSettings = true,
+                showAddToHomeScreen = true,
+                showHome = true,
+                onOpenInBrowser = null,
+                onOpenSiteSettings = {},
+            )
+        }
+    }
+}
+
 sealed interface BrowserToolbarMenuTestTags {
     val id: String
     val testTag get() = "${BrowserToolbarMenuTestTags::class.java.name}#$id"
@@ -428,4 +537,5 @@ sealed interface BrowserToolbarMenuTestTags {
     object RefreshButton : BrowserToolbarMenuTestTags { override val id = "refresh_button" }
     object FindInPageButton : BrowserToolbarMenuTestTags { override val id = "find_in_page_button" }
     object SiteSettingsButton : BrowserToolbarMenuTestTags { override val id = "site_settings_button" }
+    object HomeButton : BrowserToolbarMenuTestTags { override val id = "home_button" }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
@@ -156,25 +156,6 @@ internal fun ToolbarMenu(
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
-            if (showHome) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    IconButton(
-                        onClick = {
-                            onDismissRequest()
-                            onHome()
-                        }
-                    ) {
-                        Icon(
-                            painter = painterResource(ResourcesR.drawable.ic_home_24dp),
-                            contentDescription = null,
-                        )
-                    }
-                    Text(
-                        text = "ホーム",
-                        style = MaterialTheme.typography.labelSmall,
-                    )
-                }
-            }
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 // 短押しで通常更新、長押しでキャッシュをバイパスしてスーパーリフレッシュ
                 androidx.compose.foundation.layout.Box(
@@ -210,25 +191,54 @@ internal fun ToolbarMenu(
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
-            if (onOpenSiteSettings != null) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    IconButton(
-                        modifier = Modifier
-                            .testTag(BrowserToolbarMenuTestTags.SiteSettingsButton.testTag),
-                        onClick = {
-                            onDismissRequest()
-                            onOpenSiteSettings()
-                        },
-                    ) {
-                        Icon(
-                            painter = painterResource(ResourcesR.drawable.ic_settings_24dp),
-                            contentDescription = null,
+        }
+        // 二段目: ホームとサイトの設定を中央寄せで表示
+        if (showHome || onOpenSiteSettings != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterHorizontally),
+            ) {
+                if (showHome) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        IconButton(
+                            onClick = {
+                                onDismissRequest()
+                                onHome()
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(ResourcesR.drawable.ic_home_24dp),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = "ホーム",
+                            style = MaterialTheme.typography.labelSmall,
                         )
                     }
-                    Text(
-                        text = "サイトの設定",
-                        style = MaterialTheme.typography.labelSmall,
-                    )
+                }
+                if (onOpenSiteSettings != null) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        IconButton(
+                            modifier = Modifier
+                                .testTag(BrowserToolbarMenuTestTags.SiteSettingsButton.testTag),
+                            onClick = {
+                                onDismissRequest()
+                                onOpenSiteSettings()
+                            },
+                        ) {
+                            Icon(
+                                painter = painterResource(ResourcesR.drawable.ic_settings_24dp),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = "サイトの設定",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 概要
ツールバーメニューのレイアウトを改善し、ホームボタンとサイト設定ボタンを2段目に統合しました。これにより、メニューの視覚的な階層構造が明確になり、ユーザーインターフェースが整理されます。

## 主な変更
- ホームボタンとサイト設定ボタンを1段目から2段目に移動
- 2段目を新しい `Row` レイアウトで構成し、`spacedBy(24.dp)` で均等に配置
- 両ボタンが存在する場合のみ2段目を表示する条件付きレンダリングを実装
- `fillMaxWidth()` と `Arrangement.spacedBy(..., Alignment.CenterHorizontally)` で中央寄せの均等配置を実現

## 実装の詳細
- 2段目は `if (showHome || onOpenSiteSettings != null)` で条件付きで表示
- `Row` に `horizontalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterHorizontally)` を設定し、ボタン間の間隔と中央配置を統一
- 既存の更新ボタンは1段目に残し、メニュー構造の一貫性を保持

https://claude.ai/code/session_0113aLFJq6WDZfvu2YBHGdGj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized toolbar menu layout with Home and Site Settings options now displayed together in a secondary row for streamlined navigation when these features are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->