### PR TITLE
サイトごとの位置情報設定（モック/拒否/実際）を追加

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,12 +13,19 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <!--
+        サイトごとの設定で「実際の位置情報」を選択した場合のみ実行時に要求する。
+    -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!--
         マイク・カメラはDiscord等のWebRTCで使用するが、これらのハードウェアが
         ないデバイスでもブラウザとして動作するため required="false" を指定する。
     -->
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <!--
         Android 11 (API 30) 以降のパッケージ可視性制限に対応するため、

--- a/app/src/main/assets/web_extensions/mock_location_bridge/content.js
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/content.js
@@ -54,6 +54,12 @@
     try { error(cloneInto({ code: 1, message: 'User denied Geolocation' }, pageWin)); } catch (_) {}
   }
 
+  // 元の geolocation が存在しない環境でのエラーを通知する
+  function notifyUnsupported(error) {
+    if (!error) return;
+    try { error(cloneInto({ code: 2, message: 'Geolocation not supported' }, pageWin)); } catch (_) {}
+  }
+
   // ページが位置情報を要求したことをネイティブへ通知する（ページごとに一度だけ）
   function notifyRequested() {
     if (requestNotified) return;
@@ -75,8 +81,8 @@
       notifyDenied(error);
     } else if (origGeo) {
       origGeo.getCurrentPosition(success, error, options);
-    } else if (error) {
-      try { error(cloneInto({ code: 1, message: 'Geolocation not supported' }, pageWin)); } catch (_) {}
+    } else {
+      notifyUnsupported(error);
     }
   }
 
@@ -110,9 +116,12 @@
     } else if (mode === 'deny') {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
       notifyDenied(error);
-    } else {
-      const realId = origGeo ? origGeo.watchPosition(success, error, options) : undefined;
+    } else if (origGeo) {
+      const realId = origGeo.watchPosition(success, error, options);
       activeWatches.set(id, { success: success, error: error, options: options, realId: realId, pending: false });
+    } else {
+      activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
+      notifyUnsupported(error);
     }
     return id;
   }, pageWin);
@@ -140,7 +149,8 @@
   port.onMessage.addListener(function (msg) {
     if (msg.action !== 'config' && msg.action !== 'update') return;
 
-    const prevMode = geoConfig ? geoConfig.mode : null;
+    const prevConfig = geoConfig;
+    const prevMode = prevConfig ? prevConfig.mode : null;
     geoConfig = msg;
     configLoaded = true;
     const mode = currentMode();
@@ -161,6 +171,19 @@
         notifyDenied(entry.error);
       } else if (origGeo) {
         entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
+      } else {
+        notifyUnsupported(entry.error);
+      }
+    }
+
+    // update 時: モックのまま座標のみ変わった場合、アクティブなモックウォッチへ新座標を配信する
+    if (
+      msg.action === 'update' && prevConfig !== null && prevMode === mode && mode === 'mock' &&
+      (prevConfig.latitude !== msg.latitude || prevConfig.longitude !== msg.longitude)
+    ) {
+      for (const [, entry] of activeWatches) {
+        if (entry.pending || entry.realId !== undefined) continue;
+        try { entry.success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
       }
     }
 
@@ -180,6 +203,8 @@
         } else if (entry.realId === undefined && origGeo) {
           // モック/拒否ウォッチを実 origGeo ウォッチへ切り替え
           entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
+        } else if (entry.realId === undefined) {
+          notifyUnsupported(entry.error);
         }
       }
     }

--- a/app/src/main/assets/web_extensions/mock_location_bridge/content.js
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/content.js
@@ -1,14 +1,18 @@
-// navigator.geolocation をモック位置情報で上書きするコンテンツスクリプト
+// navigator.geolocation をサイトごとの設定（mock/deny/real）に応じて差し替えるコンテンツスクリプト
 // document_start で実行され、ページのスクリプトより先に geolocation を差し替える。
 (function () {
   'use strict';
 
-  // ページコンテキストの navigator.geolocation を保持（モック無効時のフォールバック用）
+  // ページコンテキストの navigator.geolocation を保持（real モード時のフォールバック用）
   const pageWin = window.wrappedJSObject;
   const origGeo = pageWin.navigator.geolocation;
 
   let configLoaded = false;
-  let mockConfig = null;
+  // ネイティブから受信した設定。{ mode: 'mock'|'deny'|'real', latitude, longitude }
+  let geoConfig = null;
+
+  // ページが位置情報を要求したことをネイティブへ一度だけ通知するためのフラグ
+  let requestNotified = false;
 
   // 設定が届く前にページから呼ばれた getCurrentPosition を一時保留するキュー
   let pendingCurrentCalls = [];
@@ -17,10 +21,14 @@
   // key: クライアントに返す合成watchID（常に正の整数）
   // value: { success, error, options, realId: number|undefined, pending: boolean }
   //   pending=true  : config 未到着のため未処理
-  //   realId 定義済み: origGeo に転送中（モック無効時）
-  //   realId 未定義 : モックウォッチ（origGeo 未使用）
+  //   realId 定義済み: origGeo に転送中（real モード時）
+  //   realId 未定義 : モック/拒否ウォッチ（origGeo 未使用）
   const activeWatches = new Map();
   let nextWatchId = 1;
+
+  function currentMode() {
+    return geoConfig ? geoConfig.mode : 'mock';
+  }
 
   function buildPosition(lat, lng) {
     return cloneInto(
@@ -40,15 +48,31 @@
     );
   }
 
+  // PERMISSION_DENIED(code: 1) のエラーを通知する
+  function notifyDenied(error) {
+    if (!error) return;
+    try { error(cloneInto({ code: 1, message: 'User denied Geolocation' }, pageWin)); } catch (_) {}
+  }
+
+  // ページが位置情報を要求したことをネイティブへ通知する（ページごとに一度だけ）
+  function notifyRequested() {
+    if (requestNotified) return;
+    requestNotified = true;
+    try { port.postMessage({ action: 'geolocationRequested' }); } catch (_) {}
+  }
+
   function handleGetCurrentPosition(success, error, options) {
-    if (mockConfig && mockConfig.enabled) {
+    const mode = currentMode();
+    if (mode === 'mock') {
       try {
-        success(buildPosition(mockConfig.latitude, mockConfig.longitude));
+        success(buildPosition(geoConfig.latitude, geoConfig.longitude));
       } catch (e) {
         if (error) {
           try { error(cloneInto({ code: 2, message: 'mock error' }, pageWin)); } catch (_) {}
         }
       }
+    } else if (mode === 'deny') {
+      notifyDenied(error);
     } else if (origGeo) {
       origGeo.getCurrentPosition(success, error, options);
     } else if (error) {
@@ -60,6 +84,7 @@
   const mockGeo = cloneInto({}, pageWin);
 
   mockGeo.getCurrentPosition = exportFunction(function (success, error, options) {
+    notifyRequested();
     if (!configLoaded) {
       pendingCurrentCalls.push({ success: success, error: error, options: options });
       return;
@@ -68,7 +93,8 @@
   }, pageWin);
 
   mockGeo.watchPosition = exportFunction(function (success, error, options) {
-    // 常に合成IDを返すことでモック有効/無効切り替え時にウォッチを追跡可能にする
+    notifyRequested();
+    // 常に合成IDを返すことでモード切り替え時にウォッチを追跡可能にする
     const id = nextWatchId++;
 
     if (!configLoaded) {
@@ -77,9 +103,13 @@
       return id;
     }
 
-    if (mockConfig && mockConfig.enabled) {
+    const mode = currentMode();
+    if (mode === 'mock') {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
-      try { success(buildPosition(mockConfig.latitude, mockConfig.longitude)); } catch (_) {}
+      try { success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+    } else if (mode === 'deny') {
+      activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
+      notifyDenied(error);
     } else {
       const realId = origGeo ? origGeo.watchPosition(success, error, options) : undefined;
       activeWatches.set(id, { success: success, error: error, options: options, realId: realId, pending: false });
@@ -110,9 +140,10 @@
   port.onMessage.addListener(function (msg) {
     if (msg.action !== 'config' && msg.action !== 'update') return;
 
-    const wasEnabled = mockConfig ? mockConfig.enabled : null;
-    mockConfig = msg;
+    const prevMode = geoConfig ? geoConfig.mode : null;
+    geoConfig = msg;
     configLoaded = true;
+    const mode = currentMode();
 
     // 設定待ちの getCurrentPosition を処理
     const currCalls = pendingCurrentCalls.splice(0);
@@ -124,32 +155,31 @@
     for (const [, entry] of activeWatches) {
       if (!entry.pending) continue;
       entry.pending = false;
-      if (mockConfig.enabled) {
-        try { entry.success(buildPosition(mockConfig.latitude, mockConfig.longitude)); } catch (_) {}
+      if (mode === 'mock') {
+        try { entry.success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+      } else if (mode === 'deny') {
+        notifyDenied(entry.error);
       } else if (origGeo) {
         entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
       }
     }
 
-    // update 時: モック有効/無効の切り替えによるアクティブウォッチの移行
-    if (msg.action === 'update') {
-      if (mockConfig.enabled && wasEnabled === false) {
-        // 無効→有効: 既存の origGeo ウォッチをキャンセルしてモック座標を配信
-        for (const [, entry] of activeWatches) {
-          if (entry.pending) continue;
-          if (entry.realId !== undefined && origGeo) {
-            origGeo.clearWatch(entry.realId);
-            entry.realId = undefined;
-          }
-          try { entry.success(buildPosition(mockConfig.latitude, mockConfig.longitude)); } catch (_) {}
+    // update 時: モード切り替えによるアクティブウォッチの移行
+    if (msg.action === 'update' && prevMode !== null && prevMode !== mode) {
+      for (const [, entry] of activeWatches) {
+        if (entry.pending) continue;
+        // real から離れる場合は origGeo ウォッチをキャンセルする
+        if (mode !== 'real' && entry.realId !== undefined && origGeo) {
+          origGeo.clearWatch(entry.realId);
+          entry.realId = undefined;
         }
-      } else if (!mockConfig.enabled && wasEnabled === true) {
-        // 有効→無効: モックウォッチを実 origGeo ウォッチへ切り替え
-        for (const [, entry] of activeWatches) {
-          if (entry.pending || entry.realId !== undefined) continue;
-          if (origGeo) {
-            entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
-          }
+        if (mode === 'mock') {
+          try { entry.success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+        } else if (mode === 'deny') {
+          notifyDenied(entry.error);
+        } else if (entry.realId === undefined && origGeo) {
+          // モック/拒否ウォッチを実 origGeo ウォッチへ切り替え
+          entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
         }
       }
     }
@@ -157,6 +187,6 @@
 
   port.onDisconnect.addListener(function () {
     configLoaded = false;
-    mockConfig = null;
+    geoConfig = null;
   });
 })();

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser
 
+import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.BackHandler
@@ -440,6 +441,26 @@ private fun BrowserAppContent(
                                 siteSettingsRepository = siteSettingsRepository,
                             )
                         })
+                        // 「実際の位置情報」選択時に OS の位置情報権限を要求する
+                        val locationPermissionLauncher = rememberLauncherForActivityResult(
+                            ActivityResultContracts.RequestMultiplePermissions(),
+                        ) { results ->
+                            siteSettingsViewModel.onLocationPermissionResult(results.values.any { it })
+                        }
+                        LaunchedEffect(siteSettingsViewModel) {
+                            siteSettingsViewModel.eventHandler.receiveAsFlow().collect { handler ->
+                                handler(object : SiteSettingsScreenViewModel.Event {
+                                    override fun onRequestLocationPermission() {
+                                        locationPermissionLauncher.launch(
+                                            arrayOf(
+                                                Manifest.permission.ACCESS_FINE_LOCATION,
+                                                Manifest.permission.ACCESS_COARSE_LOCATION,
+                                            ),
+                                        )
+                                    }
+                                })
+                            }
+                        }
                         val siteSettingsUiState by siteSettingsViewModel.uiState.collectAsState()
                         SiteSettingsScreen(
                             uiState = siteSettingsUiState,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -391,9 +391,8 @@ private fun BrowserAppContent(
                     }
 
                     AppDestination.Settings -> navEntry(key) {
-                        val mockLocationWebExtension: MockLocationWebExtension = koinInject()
                         val settingsViewModel = composeViewModel(initializer = {
-                            SettingsScreenViewModel(settingsRepository, mockLocationWebExtension)
+                            SettingsScreenViewModel(settingsRepository)
                         })
                         val settingsUiState by settingsViewModel.uiState.collectAsState()
                         LaunchedEffect(settingsViewModel) {

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -1192,14 +1193,24 @@ internal class BrowserTabScreenState(
         uri: String?,
         onResult: (allow: Boolean) -> Unit,
     ) {
-        coroutineScope.launch {
+        // Gecko の GeckoResult を未解決のまま残さないよう、onResult は必ず一度呼ぶ
+        val completed = AtomicBoolean(false)
+        val job = coroutineScope.launch {
             // モック/拒否はコンテンツスクリプトが処理するため、Gecko 本体の位置情報は
             // サイトごとの設定が「実際の位置情報」の場合のみ許可する
             val host = uri?.let { extractSiteHost(it) } ?: extractSiteHost(currentPageUrl)
             val allow = host != null &&
-                siteSettingsRepository.getGeolocationState(host) ==
+                runCatching { siteSettingsRepository.getGeolocationState(host) }.getOrNull() ==
                 SiteGeolocationState.SITE_GEOLOCATION_REAL
-            onResult(allow)
+            if (completed.compareAndSet(false, true)) {
+                onResult(allow)
+            }
+        }
+        job.invokeOnCompletion { cause ->
+            // スコープのキャンセル等で onResult まで到達しなかった場合は拒否として完了させる
+            if (cause != null && completed.compareAndSet(false, true)) {
+                onResult(false)
+            }
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.net.URL
+import net.matsudamper.browser.data.SiteGeolocationState
 import net.matsudamper.browser.data.SitePermissionState
 import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TranslationProvider
@@ -1184,6 +1185,21 @@ internal class BrowserTabScreenState(
             val host = extractSiteHost(uri) ?: extractSiteHost(currentPageUrl)
             val grantAudio = host != null && resolveMicrophonePermission(host)
             onResult(hasVideo, grantAudio)
+        }
+    }
+
+    override fun onGeolocationPermissionRequest(
+        uri: String?,
+        onResult: (allow: Boolean) -> Unit,
+    ) {
+        coroutineScope.launch {
+            // モック/拒否はコンテンツスクリプトが処理するため、Gecko 本体の位置情報は
+            // サイトごとの設定が「実際の位置情報」の場合のみ許可する
+            val host = uri?.let { extractSiteHost(it) } ?: extractSiteHost(currentPageUrl)
+            val allow = host != null &&
+                siteSettingsRepository.getGeolocationState(host) ==
+                SiteGeolocationState.SITE_GEOLOCATION_REAL
+            onResult(allow)
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -22,6 +23,8 @@ import kotlinx.coroutines.withContext
 import net.matsudamper.browser.data.ResolvedBrowserSettings
 import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.MockLocationWebExtension
+import net.matsudamper.browser.data.SiteGeolocationState
+import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TabGroupRepository
 import net.matsudamper.browser.data.TabRepository
 import net.matsudamper.browser.data.ThemeMode
@@ -64,6 +67,7 @@ internal class BrowserViewModel(
     private val tabRepository: TabRepository,
     private val tabGroupRepository: TabGroupRepository,
     private val mockLocationWebExtension: MockLocationWebExtension,
+    private val siteSettingsRepository: SiteSettingsRepository,
 ) : ViewModel() {
     val browserTabController = BrowserTabController(
         tabRepository = tabRepository,
@@ -108,21 +112,32 @@ internal class BrowserViewModel(
                     runtime.settings.setEnterpriseRootsEnabled(enableThirdPartyCa)
                 }
         }
-        // アプリ起動時にモック位置情報設定を拡張機能へ反映する。
+        // アプリ起動時に位置情報設定（モック座標・サイトごとの扱い）を拡張機能へ反映する。
         // 設定画面を開かなくても前回セッションの設定が即座に有効になる。
         viewModelScope.launch {
-            settingsRepository.settings.collectLatest { settings ->
-                val lat = settings.mockLocationLatitude
-                val lng = settings.mockLocationLongitude
-                val resolvedLat = if (lat == 0.0 && lng == 0.0) MockLocationWebExtension.DEFAULT_LATITUDE else lat
-                val resolvedLng = if (lat == 0.0 && lng == 0.0) MockLocationWebExtension.DEFAULT_LONGITUDE else lng
-                mockLocationWebExtension.updateConfig(
-                    MockLocationWebExtension.MockLocationConfig(
-                        enabled = settings.mockLocationEnabled,
-                        latitude = resolvedLat,
-                        longitude = resolvedLng,
+            combine(
+                settingsRepository.settings,
+                siteSettingsRepository.geolocationStates(),
+            ) { settings, geolocationStates -> settings to geolocationStates }
+                .collectLatest { (settings, geolocationStates) ->
+                    val lat = settings.mockLocationLatitude
+                    val lng = settings.mockLocationLongitude
+                    val resolvedLat = if (lat == 0.0 && lng == 0.0) MockLocationWebExtension.DEFAULT_LATITUDE else lat
+                    val resolvedLng = if (lat == 0.0 && lng == 0.0) MockLocationWebExtension.DEFAULT_LONGITUDE else lng
+                    mockLocationWebExtension.updateConfig(
+                        MockLocationWebExtension.GeolocationConfig(
+                            forceMock = settings.mockLocationEnabled,
+                            latitude = resolvedLat,
+                            longitude = resolvedLng,
+                            siteModes = geolocationStates.mapValues { (_, state) -> state.toGeolocationMode() },
+                        )
                     )
-                )
+                }
+        }
+        // ページが位置情報を要求したら記録し、「サイトの設定」画面に位置情報の項目を表示できるようにする
+        mockLocationWebExtension.onGeolocationRequested = { host ->
+            viewModelScope.launch {
+                siteSettingsRepository.markGeolocationRequested(host)
             }
         }
         // ViewModel 生成時にタブ復元を開始する。
@@ -278,3 +293,11 @@ private fun ResolvedBrowserSettings.toLogicSettings(): BrowserLogicSettings = Br
     translationProvider = translationProvider,
     enableThirdPartyCa = enableThirdPartyCa,
 )
+
+/** サイトごとの位置情報設定を拡張機能のモードへ変換する */
+private fun SiteGeolocationState.toGeolocationMode(): MockLocationWebExtension.GeolocationMode {
+    return when (this) {
+        SiteGeolocationState.SITE_GEOLOCATION_DENY -> MockLocationWebExtension.GeolocationMode.DENY
+        else -> MockLocationWebExtension.GeolocationMode.MOCK
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
@@ -126,7 +126,6 @@ internal class BrowserViewModel(
                     val resolvedLng = if (lat == 0.0 && lng == 0.0) MockLocationWebExtension.DEFAULT_LONGITUDE else lng
                     mockLocationWebExtension.updateConfig(
                         MockLocationWebExtension.GeolocationConfig(
-                            forceMock = settings.mockLocationEnabled,
                             latitude = resolvedLat,
                             longitude = resolvedLng,
                             siteModes = geolocationStates.mapValues { (_, state) -> state.toGeolocationMode() },

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
@@ -298,6 +298,7 @@ private fun ResolvedBrowserSettings.toLogicSettings(): BrowserLogicSettings = Br
 private fun SiteGeolocationState.toGeolocationMode(): MockLocationWebExtension.GeolocationMode {
     return when (this) {
         SiteGeolocationState.SITE_GEOLOCATION_DENY -> MockLocationWebExtension.GeolocationMode.DENY
+        SiteGeolocationState.SITE_GEOLOCATION_REAL -> MockLocationWebExtension.GeolocationMode.REAL
         else -> MockLocationWebExtension.GeolocationMode.MOCK
     }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -56,6 +56,6 @@ val appModule = module {
     single { MockLocationWebExtension().also { it.install(get()) } }
     single { ViewportScaleWebExtension().also { it.install(get()) } }
     factory { GeckoDownloadManager(androidContext(), get()) }
-    viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     worker { DownloadWorker(get(), get(), get()) }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
@@ -131,9 +131,9 @@ internal class SettingsScreenViewModel(
             // 入力欄が変化したら UiState を再構築する
             viewModelScope.launch {
                 mockLocationInputFlow.collectLatest { input ->
-                    val current = uiStateFlow.value ?: return@collectLatest
-                    uiStateFlow.update {
-                        current.copy(
+                    // update のラムダ内で最新値を参照し、他のコレクタの更新を上書きしない
+                    uiStateFlow.update { current ->
+                        current?.copy(
                             mockLocationInput = input,
                             mockLocationInputError = validateMockLocationInput(input),
                         )

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.matsudamper.browser.MockLocationWebExtension
 import net.matsudamper.browser.data.BrowserSettings
 import net.matsudamper.browser.data.HomepageType
 import net.matsudamper.browser.data.SearchProvider

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import net.matsudamper.browser.MockLocationWebExtension
 import net.matsudamper.browser.data.BrowserSettings
 import net.matsudamper.browser.data.HomepageType
 import net.matsudamper.browser.data.SearchProvider
@@ -22,7 +21,6 @@ import net.matsudamper.browser.ui.settings.SettingsScreenUiState
 
 internal class SettingsScreenViewModel(
     private val settingsRepository: SettingsRepository,
-    private val mockLocationWebExtension: MockLocationWebExtension,
 ) : ViewModel() {
 
     val eventHandler = Channel<(Event) -> Unit>(Channel.UNLIMITED)
@@ -132,20 +130,7 @@ internal class SettingsScreenViewModel(
                             backupConfirmDialog = confirmDialog,
                         )
                     }
-                    // 拡張機能にも最新設定を通知する
-                    // 座標が未保存（0,0）の場合はデフォルト値（皇居）を使用し、
-                    // UI表示と拡張機能への返却値を一致させる
-                    val (resolvedLat, resolvedLng) = resolveCoordinates(
-                        settings.mockLocationLatitude,
-                        settings.mockLocationLongitude,
-                    )
-                    mockLocationWebExtension.updateConfig(
-                        MockLocationWebExtension.MockLocationConfig(
-                            enabled = settings.mockLocationEnabled,
-                            latitude = resolvedLat,
-                            longitude = resolvedLng,
-                        )
-                    )
+                    // 拡張機能への反映は BrowserViewModel が設定の Flow を監視して行う
                 }
             }
             // 入力欄が変化したら UiState を再構築する

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
@@ -69,12 +69,6 @@ internal class SettingsScreenViewModel(
             viewModelScope.launch { settingsRepository.setEnableWebSuggestions(enabled) }
         }
 
-        override fun setMockLocationEnabled(enabled: Boolean) {
-            viewModelScope.launch {
-                settingsRepository.setMockLocationEnabled(enabled)
-            }
-        }
-
         override fun setMockLocationInput(input: String) {
             mockLocationInputFlow.value = input
             val parsed = parseMockLocationInput(input) ?: return
@@ -213,7 +207,6 @@ private fun BrowserSettings.toUiState(
         translationProvider = translationProvider,
         enableThirdPartyCa = enableThirdPartyCa,
         enableWebSuggestions = resolvedEnableWebSuggestions(),
-        mockLocationEnabled = mockLocationEnabled,
         mockLocationInput = mockLocationInput,
         mockLocationInputError = validateMockLocationInput(mockLocationInput),
         backupConfirmDialog = backupConfirmDialog,

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser.screen.sitesettings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,6 +19,13 @@ internal class SiteSettingsScreenViewModel(
     private val siteSettingsRepository: SiteSettingsRepository,
 ) : ViewModel() {
 
+    val eventHandler = Channel<(Event) -> Unit>(Channel.UNLIMITED)
+
+    interface Event {
+        /** OS の位置情報権限を要求する。結果は onLocationPermissionResult で受け取る */
+        fun onRequestLocationPermission()
+    }
+
     private val callbacks = object : SiteSettingsScreenUiState.Callbacks {
         override fun setMicrophonePermission(state: SitePermissionState) {
             viewModelScope.launch {
@@ -26,9 +34,26 @@ internal class SiteSettingsScreenViewModel(
         }
 
         override fun setGeolocationState(state: SiteGeolocationState) {
+            // 実際の位置情報は OS の位置情報権限が必要なため、ここでは保存せず権限要求を行い、
+            // 許可された場合のみ onLocationPermissionResult で保存する
+            if (state == SiteGeolocationState.SITE_GEOLOCATION_REAL) {
+                eventHandler.trySend { it.onRequestLocationPermission() }
+                return
+            }
             viewModelScope.launch {
                 siteSettingsRepository.setGeolocationState(host, state)
             }
+        }
+    }
+
+    /** OS の位置情報権限要求の結果。許可された場合のみ「実際の位置情報」を保存する */
+    fun onLocationPermissionResult(granted: Boolean) {
+        if (!granted) return
+        viewModelScope.launch {
+            siteSettingsRepository.setGeolocationState(
+                host = host,
+                state = SiteGeolocationState.SITE_GEOLOCATION_REAL,
+            )
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.matsudamper.browser.data.SiteGeolocationState
 import net.matsudamper.browser.data.SitePermissionState
 import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.ui.settings.SiteSettingsScreenUiState
@@ -23,6 +24,12 @@ internal class SiteSettingsScreenViewModel(
                 siteSettingsRepository.setMicrophonePermission(host, state)
             }
         }
+
+        override fun setGeolocationState(state: SiteGeolocationState) {
+            viewModelScope.launch {
+                siteSettingsRepository.setGeolocationState(host, state)
+            }
+        }
     }
 
     val uiState: StateFlow<SiteSettingsScreenUiState> = MutableStateFlow(
@@ -30,11 +37,17 @@ internal class SiteSettingsScreenViewModel(
             callbacks = callbacks,
             host = host,
             microphonePermission = null,
+            geolocationState = null,
         ),
     ).also { uiStateFlow ->
         viewModelScope.launch {
             siteSettingsRepository.requestedMicrophonePermission(host).collectLatest { permission ->
                 uiStateFlow.update { it.copy(microphonePermission = permission) }
+            }
+        }
+        viewModelScope.launch {
+            siteSettingsRepository.requestedGeolocationState(host).collectLatest { state ->
+                uiStateFlow.update { it.copy(geolocationState = state) }
             }
         }
     }.asStateFlow()

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -26,6 +26,9 @@ internal class SiteSettingsScreenViewModel(
         fun onRequestLocationPermission()
     }
 
+    // 権限要求の多重発行を防ぐ in-flight フラグ
+    private var isLocationPermissionRequestInFlight = false
+
     private val callbacks = object : SiteSettingsScreenUiState.Callbacks {
         override fun setMicrophonePermission(state: SitePermissionState) {
             viewModelScope.launch {
@@ -37,6 +40,8 @@ internal class SiteSettingsScreenViewModel(
             // 実際の位置情報は OS の位置情報権限が必要なため、ここでは保存せず権限要求を行い、
             // 許可された場合のみ onLocationPermissionResult で保存する
             if (state == SiteGeolocationState.SITE_GEOLOCATION_REAL) {
+                if (isLocationPermissionRequestInFlight) return
+                isLocationPermissionRequestInFlight = true
                 eventHandler.trySend { it.onRequestLocationPermission() }
                 return
             }
@@ -48,6 +53,7 @@ internal class SiteSettingsScreenViewModel(
 
     /** OS の位置情報権限要求の結果。許可された場合のみ「実際の位置情報」を保存する */
     fun onLocationPermissionResult(granted: Boolean) {
+        isLocationPermissionRequestInFlight = false
         if (!granted) return
         viewModelScope.launch {
             siteSettingsRepository.setGeolocationState(

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -95,7 +95,9 @@ fun createGeckoSessionDelegateBundle(
                             if (allow) {
                                 GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW
                             } else {
-                                GeckoSession.PermissionDelegate.ContentPermission.VALUE_DENY
+                                // DENY は Gecko に永続化され、後で「実際の位置情報」へ変更しても
+                                // このデリゲートが呼ばれなくなるため、永続化されない PROMPT で拒否する
+                                GeckoSession.PermissionDelegate.ContentPermission.VALUE_PROMPT
                             },
                         )
                     }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -42,6 +42,10 @@ interface BrowserSessionStateCallbacks {
         hasAudio: Boolean,
         onResult: (grantVideo: Boolean, grantAudio: Boolean) -> Unit,
     )
+    fun onGeolocationPermissionRequest(
+        uri: String?,
+        onResult: (allow: Boolean) -> Unit,
+    )
 }
 
 /** タブ内ナビゲーション履歴の項目 */
@@ -82,12 +86,20 @@ fun createGeckoSessionDelegateBundle(
                     )
                 }
                 if (perm.permission == GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION) {
-                    // 位置情報はコンテンツスクリプトがサイトごとの設定（モック/拒否）で処理するため、
-                    // Gecko 本体の位置情報は拒否する
-                    Log.d("BrowserTabPermission", "geolocation permission denied")
-                    return GeckoResult.fromValue(
-                        GeckoSession.PermissionDelegate.ContentPermission.VALUE_DENY
-                    )
+                    // モック/拒否はコンテンツスクリプトが処理する。Gecko 本体の位置情報へ
+                    // 到達するのは「実際の位置情報」設定時のみ許可する
+                    Log.d("BrowserTabPermission", "geolocation permission delegated to site settings")
+                    val result = GeckoResult<Int>()
+                    callbacks.onGeolocationPermissionRequest(perm.uri) { allow ->
+                        result.complete(
+                            if (allow) {
+                                GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW
+                            } else {
+                                GeckoSession.PermissionDelegate.ContentPermission.VALUE_DENY
+                            },
+                        )
+                    }
+                    return result
                 }
                 if (perm.permission == GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION) {
                     Log.d("BrowserTabPermission", "desktop notification denied")
@@ -423,6 +435,18 @@ internal class BrowserTabSessionDelegateHost(
                     cb.onMediaPermissionRequest(uri, hasVideo, hasAudio, onResult)
                 } else {
                     onResult(false, false)
+                }
+            }
+
+            override fun onGeolocationPermissionRequest(
+                uri: String?,
+                onResult: (allow: Boolean) -> Unit,
+            ) {
+                val cb = currentCallbacks()
+                if (cb != null) {
+                    cb.onGeolocationPermissionRequest(uri, onResult)
+                } else {
+                    onResult(false)
                 }
             }
         },

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -81,6 +81,14 @@ fun createGeckoSessionDelegateBundle(
                         GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW
                     )
                 }
+                if (perm.permission == GeckoSession.PermissionDelegate.PERMISSION_GEOLOCATION) {
+                    // 位置情報はコンテンツスクリプトがサイトごとの設定（モック/拒否）で処理するため、
+                    // Gecko 本体の位置情報は拒否する
+                    Log.d("BrowserTabPermission", "geolocation permission denied")
+                    return GeckoResult.fromValue(
+                        GeckoSession.PermissionDelegate.ContentPermission.VALUE_DENY
+                    )
+                }
                 if (perm.permission == GeckoSession.PermissionDelegate.PERMISSION_DESKTOP_NOTIFICATION) {
                     Log.d("BrowserTabPermission", "desktop notification denied")
                     return GeckoResult.fromValue(

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
@@ -1,31 +1,34 @@
 package net.matsudamper.browser
 
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import org.json.JSONObject
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.WebExtension
+import java.net.URI
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * navigator.geolocation をモック位置情報で上書きするビルトイン WebExtension。
+ * navigator.geolocation をサイトごとの設定に応じて差し替えるビルトイン WebExtension。
  * コンテンツスクリプトが connectNative でポートを確立し、
- * ネイティブ側から現在の設定を返す。設定が更新された場合は update メッセージを送信する。
+ * ネイティブ側から接続元ホストに応じたモード（mock/deny/real）を返す。
+ * 設定が更新された場合は update メッセージを送信する。
  */
 class MockLocationWebExtension {
     private var extension: WebExtension? = null
-    private val mainHandler = Handler(Looper.getMainLooper())
 
-    // 現在のモック位置情報設定
-    @Volatile private var currentConfig: MockLocationConfig = MockLocationConfig(
-        enabled = false,
+    // 現在の位置情報設定
+    @Volatile private var currentConfig: GeolocationConfig = GeolocationConfig(
+        forceMock = false,
         latitude = DEFAULT_LATITUDE,
         longitude = DEFAULT_LONGITUDE,
+        siteModes = emptyMap(),
     )
+
+    /** ページが位置情報を要求した際にホスト名を通知するコールバック */
+    @Volatile var onGeolocationRequested: ((host: String) -> Unit)? = null
 
     // セッションごとの接続ポート
     private val sessionPorts = ConcurrentHashMap<GeckoSession, WebExtension.Port>()
@@ -68,16 +71,33 @@ class MockLocationWebExtension {
         }
     }
 
-    /** モック位置情報設定を更新し、接続済みの全セッションに通知する */
-    fun updateConfig(config: MockLocationConfig) {
+    /** 位置情報設定を更新し、接続済みの全セッションへ各ホストに応じたモードを通知する */
+    fun updateConfig(config: GeolocationConfig) {
         currentConfig = config
-        val message = config.toJson().apply { put("action", "update") }
         sessionPorts.values.forEach { port ->
+            val message = buildConfigMessage(portHost(port), action = "update")
             try {
                 port.postMessage(message)
             } catch (e: Exception) {
                 Log.w(TAG, "updateConfig: ポートへの送信に失敗", e)
             }
+        }
+    }
+
+    /** 接続元ページの URL からホスト名を取り出す */
+    private fun portHost(port: WebExtension.Port): String? {
+        val url = port.sender.url ?: return null
+        return runCatching { URI(url) }.getOrNull()?.host
+    }
+
+    /** ホストに応じた設定メッセージを構築する */
+    private fun buildConfigMessage(host: String?, action: String): JSONObject {
+        val config = currentConfig
+        return JSONObject().apply {
+            put("action", action)
+            put("mode", config.resolveMode(host).jsonValue)
+            put("latitude", config.latitude)
+            put("longitude", config.longitude)
         }
     }
 
@@ -101,12 +121,20 @@ class MockLocationWebExtension {
                     port.setDelegate(object : WebExtension.PortDelegate {
                         override fun onPortMessage(message: Any, port: WebExtension.Port) {
                             val json = message as? JSONObject ?: return
-                            if (json.optString("action") == "getConfig") {
-                                val response = currentConfig.toJson().apply { put("action", "config") }
-                                try {
-                                    port.postMessage(response)
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "getConfig 応答に失敗", e)
+                            when (json.optString("action")) {
+                                "getConfig" -> {
+                                    val response = buildConfigMessage(portHost(port), action = "config")
+                                    try {
+                                        port.postMessage(response)
+                                    } catch (e: Exception) {
+                                        Log.w(TAG, "getConfig 応答に失敗", e)
+                                    }
+                                }
+                                // ページが位置情報を要求したことの通知。
+                                // 「サイトの設定」画面に位置情報の項目を表示するために記録する
+                                "geolocationRequested" -> {
+                                    val host = portHost(port) ?: return
+                                    onGeolocationRequested?.invoke(host)
                                 }
                             }
                         }
@@ -122,15 +150,28 @@ class MockLocationWebExtension {
         )
     }
 
-    data class MockLocationConfig(
-        val enabled: Boolean,
+    /** サイトごとの位置情報の扱い */
+    enum class GeolocationMode(val jsonValue: String) {
+        // モック座標を返す
+        MOCK("mock"),
+        // 位置情報の取得を拒否する
+        DENY("deny"),
+    }
+
+    /**
+     * 位置情報設定全体。
+     * [forceMock] はアプリ設定の「モック位置情報を使用する」で、有効な場合は
+     * サイトごとの設定に関わらず全サイトへモック座標を返す。
+     */
+    data class GeolocationConfig(
+        val forceMock: Boolean,
         val latitude: Double,
         val longitude: Double,
+        val siteModes: Map<String, GeolocationMode>,
     ) {
-        fun toJson(): JSONObject = JSONObject().apply {
-            put("enabled", enabled)
-            put("latitude", latitude)
-            put("longitude", longitude)
+        fun resolveMode(host: String?): GeolocationMode {
+            if (forceMock) return GeolocationMode.MOCK
+            return siteModes[host] ?: GeolocationMode.MOCK
         }
     }
 

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
@@ -86,8 +86,7 @@ class MockLocationWebExtension {
 
     /** 接続元ページの URL からホスト名を取り出す */
     private fun portHost(port: WebExtension.Port): String? {
-        val url = port.sender.url ?: return null
-        return runCatching { URI(url) }.getOrNull()?.host
+        return runCatching { URI(port.sender.url) }.getOrNull()?.host
     }
 
     /** ホストに応じた設定メッセージを構築する */

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
@@ -21,7 +21,6 @@ class MockLocationWebExtension {
 
     // 現在の位置情報設定
     @Volatile private var currentConfig: GeolocationConfig = GeolocationConfig(
-        forceMock = false,
         latitude = DEFAULT_LATITUDE,
         longitude = DEFAULT_LONGITUDE,
         siteModes = emptyMap(),
@@ -162,17 +161,14 @@ class MockLocationWebExtension {
 
     /**
      * 位置情報設定全体。
-     * [forceMock] はアプリ設定の「モック位置情報を使用する」で、有効な場合は
-     * サイトごとの設定に関わらず全サイトへモック座標を返す。
+     * サイトごとの設定が無いホストにはモック座標を返す（デフォルト）。
      */
     data class GeolocationConfig(
-        val forceMock: Boolean,
         val latitude: Double,
         val longitude: Double,
         val siteModes: Map<String, GeolocationMode>,
     ) {
         fun resolveMode(host: String?): GeolocationMode {
-            if (forceMock) return GeolocationMode.MOCK
             return siteModes[host] ?: GeolocationMode.MOCK
         }
     }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
@@ -156,6 +156,9 @@ class MockLocationWebExtension {
         MOCK("mock"),
         // 位置情報の取得を拒否する
         DENY("deny"),
+
+        // 実際の位置情報を返す（Gecko 本体の geolocation へ委譲）
+        REAL("real"),
     }
 
     /**

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
@@ -102,14 +102,6 @@ class SettingsRepository(context: Context) {
         }
     }
 
-    suspend fun setMockLocationEnabled(enabled: Boolean) {
-        dataStore.updateData { current ->
-            current.toBuilder()
-                .setMockLocationEnabled(enabled)
-                .build()
-        }
-    }
-
     suspend fun setMockLocationCoordinates(latitude: Double, longitude: Double) {
         dataStore.updateData { current ->
             current.toBuilder()

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsRepository.kt
@@ -81,6 +81,21 @@ class SiteSettingsRepository(context: Context) {
         }
     }
 
+    /** 指定ホストの位置情報の扱いを監視する。未設定の場合は MOCK を返す */
+    fun geolocationState(host: String): Flow<SiteGeolocationState> {
+        return dataStore.data
+            .map { settings ->
+                settings.hostPermissionsMap[host]?.geolocation
+                    ?: SiteGeolocationState.SITE_GEOLOCATION_MOCK
+            }
+            .distinctUntilChanged()
+    }
+
+    /** 指定ホストの現在の位置情報の扱いを取得する */
+    suspend fun getGeolocationState(host: String): SiteGeolocationState {
+        return geolocationState(host).first()
+    }
+
     /** 全ホストの位置情報の扱いを監視する。key はホスト名 */
     fun geolocationStates(): Flow<Map<String, SiteGeolocationState>> {
         return dataStore.data

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SiteSettingsRepository.kt
@@ -80,6 +80,60 @@ class SiteSettingsRepository(context: Context) {
                 .build()
         }
     }
+
+    /** 全ホストの位置情報の扱いを監視する。key はホスト名 */
+    fun geolocationStates(): Flow<Map<String, SiteGeolocationState>> {
+        return dataStore.data
+            .map { settings ->
+                settings.hostPermissionsMap.mapValues { (_, permissions) -> permissions.geolocation }
+            }
+            .distinctUntilChanged()
+    }
+
+    /**
+     * 指定ホストの位置情報の扱いを監視する。
+     * サイトから一度も要求されていない場合は null を返す
+     */
+    fun requestedGeolocationState(host: String): Flow<SiteGeolocationState?> {
+        return dataStore.data
+            .map { settings ->
+                val permissions = settings.hostPermissionsMap[host] ?: return@map null
+                if (permissions.geolocationRequested ||
+                    permissions.geolocation != SiteGeolocationState.SITE_GEOLOCATION_MOCK
+                ) {
+                    permissions.geolocation
+                } else {
+                    null
+                }
+            }
+            .distinctUntilChanged()
+    }
+
+    /** 指定ホストが位置情報を要求したことを記録する */
+    suspend fun markGeolocationRequested(host: String) {
+        dataStore.updateData { current ->
+            val permissions = current.hostPermissionsMap[host] ?: SitePermissionSettings.getDefaultInstance()
+            if (permissions.geolocationRequested) return@updateData current
+            current.toBuilder()
+                .putHostPermissions(
+                    host,
+                    permissions.toBuilder().setGeolocationRequested(true).build(),
+                )
+                .build()
+        }
+    }
+
+    suspend fun setGeolocationState(host: String, state: SiteGeolocationState) {
+        dataStore.updateData { current ->
+            val permissions = (current.hostPermissionsMap[host] ?: SitePermissionSettings.getDefaultInstance())
+                .toBuilder()
+                .setGeolocation(state)
+                .build()
+            current.toBuilder()
+                .putHostPermissions(host, permissions)
+                .build()
+        }
+    }
 }
 
 /** URL からサイト設定のキーとなるホスト名を取り出す。取得できない場合は null */

--- a/proto/src/main/proto/browser_settings.proto
+++ b/proto/src/main/proto/browser_settings.proto
@@ -37,7 +37,8 @@ message BrowserSettings {
   TranslationProvider translation_provider = 9;
   bool enable_third_party_ca = 10;
   optional bool enable_web_suggestions = 11;
-  bool mock_location_enabled = 12;
+  // 廃止: モックの有効/無効はサイトごとの設定 (site_settings.proto) へ移行した
+  bool mock_location_enabled = 12 [deprecated = true];
   double mock_location_latitude = 13;
   double mock_location_longitude = 14;
 }

--- a/proto/src/main/proto/site_settings.proto
+++ b/proto/src/main/proto/site_settings.proto
@@ -17,6 +17,8 @@ enum SiteGeolocationState {
   SITE_GEOLOCATION_MOCK = 0;
   // 位置情報の取得を拒否する
   SITE_GEOLOCATION_DENY = 1;
+  // 実際の位置情報を返す。OS の位置情報権限が必要
+  SITE_GEOLOCATION_REAL = 2;
 }
 
 // 1サイト（ホスト）分の権限設定

--- a/proto/src/main/proto/site_settings.proto
+++ b/proto/src/main/proto/site_settings.proto
@@ -11,12 +11,24 @@ enum SitePermissionState {
   SITE_PERMISSION_DENY = 2;
 }
 
+// サイトごとの位置情報の扱い
+enum SiteGeolocationState {
+  // モック位置情報を返す（デフォルト）。OS の位置情報権限は不要
+  SITE_GEOLOCATION_MOCK = 0;
+  // 位置情報の取得を拒否する
+  SITE_GEOLOCATION_DENY = 1;
+}
+
 // 1サイト（ホスト）分の権限設定
 message SitePermissionSettings {
   SitePermissionState microphone = 1;
   // このサイトがマイク権限を要求したことがあるか。
   // 一度も要求されていない権限は「サイトの設定」画面に表示しない
   bool microphone_requested = 2;
+  SiteGeolocationState geolocation = 3;
+  // このサイトが位置情報を要求したことがあるか。
+  // 一度も要求されていない権限は「サイトの設定」画面に表示しない
+  bool geolocation_requested = 4;
 }
 
 // サイトごとの設定全体。key はホスト名

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -245,33 +245,15 @@ fun SettingsScreen(
 
             SettingSection(title = "位置情報") {
                 Column {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .toggleable(
-                                value = uiState.mockLocationEnabled,
-                                role = Role.Switch,
-                                onValueChange = uiState.callbacks::setMockLocationEnabled,
-                            )
-                            .padding(vertical = 4.dp),
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = "モック位置情報を使用する",
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Text(
-                                text = "Webページへの位置情報要求に実際の位置ではなく指定した座標を返します",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        Switch(
-                            checked = uiState.mockLocationEnabled,
-                            onCheckedChange = null,
-                        )
-                    }
+                    Text(
+                        text = "モック位置情報の座標",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = "サイトごとの設定が「モック位置情報」のサイトへ、実際の位置ではなくこの座標を返します",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                     Spacer(Modifier.height(4.dp))
                     OutlinedTextField(
                         value = uiState.mockLocationInput,
@@ -461,7 +443,6 @@ private fun SettingsScreenPreview() {
                     override fun setTranslationProvider(provider: TranslationProvider) = Unit
                     override fun setEnableThirdPartyCa(enabled: Boolean) = Unit
                     override fun setEnableWebSuggestions(enabled: Boolean) = Unit
-                    override fun setMockLocationEnabled(enabled: Boolean) = Unit
                     override fun setMockLocationInput(input: String) = Unit
                     override fun openMockLocationOnMap() = Unit
                     override fun requestBackupExport() = Unit
@@ -477,7 +458,6 @@ private fun SettingsScreenPreview() {
                 translationProvider = TranslationProvider.TRANSLATION_PROVIDER_GECKO,
                 enableThirdPartyCa = false,
                 enableWebSuggestions = false,
-                mockLocationEnabled = true,
                 mockLocationInput = "35.685175,139.752797",
                 mockLocationInputError = null,
                 backupConfirmDialog = null,

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreenUiState.kt
@@ -17,7 +17,6 @@ data class SettingsScreenUiState(
     val translationProvider: TranslationProvider,
     val enableThirdPartyCa: Boolean,
     val enableWebSuggestions: Boolean,
-    val mockLocationEnabled: Boolean,
     val mockLocationInput: String,
     val mockLocationInputError: String?,
     val backupConfirmDialog: BackupConfirmType?,
@@ -33,7 +32,6 @@ data class SettingsScreenUiState(
         fun setTranslationProvider(provider: TranslationProvider)
         fun setEnableThirdPartyCa(enabled: Boolean)
         fun setEnableWebSuggestions(enabled: Boolean)
-        fun setMockLocationEnabled(enabled: Boolean)
         fun setMockLocationInput(input: String)
         fun openMockLocationOnMap()
         /** バックアップのエクスポートを要求する（確認ダイアログを表示） */

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -87,6 +87,15 @@ fun SiteSettingsScreen(
                             },
                         )
                         SettingsRadioOption(
+                            label = "実際の位置情報",
+                            selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_REAL,
+                            onClick = {
+                                uiState.callbacks.setGeolocationState(
+                                    SiteGeolocationState.SITE_GEOLOCATION_REAL,
+                                )
+                            },
+                        )
+                        SettingsRadioOption(
                             label = "ブロック",
                             selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_DENY,
                             onClick = {

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import net.matsudamper.browser.data.SiteGeolocationState
 import net.matsudamper.browser.data.SitePermissionState
 import net.matsudamper.browser.resources.R as ResourcesR
 
@@ -73,6 +74,31 @@ fun SiteSettingsScreen(
             Spacer(Modifier.height(12.dp))
 
             // 権限は一度でも要求された項目だけ表示する
+            if (uiState.geolocationState != null) {
+                SettingSection(title = "位置情報") {
+                    Column(Modifier.selectableGroup()) {
+                        SettingsRadioOption(
+                            label = "モック位置情報",
+                            selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+                            onClick = {
+                                uiState.callbacks.setGeolocationState(
+                                    SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+                                )
+                            },
+                        )
+                        SettingsRadioOption(
+                            label = "ブロック",
+                            selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_DENY,
+                            onClick = {
+                                uiState.callbacks.setGeolocationState(
+                                    SiteGeolocationState.SITE_GEOLOCATION_DENY,
+                                )
+                            },
+                        )
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+            }
             if (uiState.microphonePermission != null) {
                 SettingSection(title = "マイク") {
                     Column(Modifier.selectableGroup()) {
@@ -105,7 +131,8 @@ fun SiteSettingsScreen(
                         )
                     }
                 }
-            } else {
+            }
+            if (uiState.geolocationState == null && uiState.microphonePermission == null) {
                 Text(
                     text = "このサイトが要求した権限はありません",
                     style = MaterialTheme.typography.bodyMedium,
@@ -119,17 +146,37 @@ fun SiteSettingsScreen(
     }
 }
 
+private val previewCallbacks = object : SiteSettingsScreenUiState.Callbacks {
+    override fun setMicrophonePermission(state: SitePermissionState) = Unit
+    override fun setGeolocationState(state: SiteGeolocationState) = Unit
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun SiteSettingsScreenPreview() {
     MaterialTheme {
         SiteSettingsScreen(
             uiState = SiteSettingsScreenUiState(
-                callbacks = object : SiteSettingsScreenUiState.Callbacks {
-                    override fun setMicrophonePermission(state: SitePermissionState) = Unit
-                },
+                callbacks = previewCallbacks,
                 host = "www.example.com",
                 microphonePermission = SitePermissionState.SITE_PERMISSION_ASK,
+                geolocationState = SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+            ),
+            onBack = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SiteSettingsScreenGeolocationOnlyPreview() {
+    MaterialTheme {
+        SiteSettingsScreen(
+            uiState = SiteSettingsScreenUiState(
+                callbacks = previewCallbacks,
+                host = "www.example.com",
+                microphonePermission = null,
+                geolocationState = SiteGeolocationState.SITE_GEOLOCATION_DENY,
             ),
             onBack = {},
         )
@@ -142,11 +189,10 @@ private fun SiteSettingsScreenNoRequestedPermissionPreview() {
     MaterialTheme {
         SiteSettingsScreen(
             uiState = SiteSettingsScreenUiState(
-                callbacks = object : SiteSettingsScreenUiState.Callbacks {
-                    override fun setMicrophonePermission(state: SitePermissionState) = Unit
-                },
+                callbacks = previewCallbacks,
                 host = "www.example.com",
                 microphonePermission = null,
+                geolocationState = null,
             ),
             onBack = {},
         )

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
@@ -1,6 +1,7 @@
 package net.matsudamper.browser.ui.settings
 
 import androidx.compose.runtime.Stable
+import net.matsudamper.browser.data.SiteGeolocationState
 import net.matsudamper.browser.data.SitePermissionState
 
 @Stable
@@ -9,8 +10,11 @@ data class SiteSettingsScreenUiState(
     val host: String,
     /** マイク権限の状態。サイトから一度も要求されていない場合は null で、項目を表示しない */
     val microphonePermission: SitePermissionState?,
+    /** 位置情報の扱い。サイトから一度も要求されていない場合は null で、項目を表示しない */
+    val geolocationState: SiteGeolocationState?,
 ) {
     interface Callbacks {
         fun setMicrophonePermission(state: SitePermissionState)
+        fun setGeolocationState(state: SiteGeolocationState)
     }
 }


### PR DESCRIPTION
## 概要

navigator.geolocation の動作をサイトごとに設定できるようにしました。従来のアプリ全体の「モック位置情報を使用する」設定に加えて、個別サイトで「モック座標」「位置情報をブロック」「実際の位置情報」を選択できます。

## 主な変更

### コンテンツスクリプト（content.js）
- モック位置情報の単純なオン/オフから、3つのモード（mock/deny/real）に対応
- `currentMode()` で現在のモードを判定し、各モードに応じた処理を実行
- deny モード時は PERMISSION_DENIED エラーを返す
- real モード時は実際の Gecko geolocation へ委譲
- ページが位置情報を要求したことをネイティブへ通知（`geolocationRequested` メッセージ）
- モード切り替え時にアクティブなウォッチを適切に移行

### ネイティブ側（MockLocationWebExtension）
- `MockLocationConfig` → `GeolocationConfig` に変更
  - `enabled` フラグ → `forceMock` フラグ（アプリ全体の強制設定）
  - `siteModes: Map<String, GeolocationMode>` を追加（サイトごとの設定）
- `GeolocationMode` enum を新規追加（MOCK/DENY/REAL）
- `resolveMode(host)` で接続元ホストに応じたモードを決定
- ページが位置情報を要求したときのコールバック `onGeolocationRequested` を追加

### サイト設定（SiteSettingsRepository）
- `geolocationState(host)` など位置情報設定の監視メソッドを追加
- `markGeolocationRequested(host)` でサイトが位置情報を要求したことを記録
- `setGeolocationState(host, state)` で設定を保存

### UI（SiteSettingsScreen）
- 位置情報セクションを追加（マイクと同様の構成）
- 3つのラジオボタン：「モック位置情報」「実際の位置情報」「ブロック」
- 一度も要求されていないサイトには位置情報セクションを表示しない

### 権限処理
- 「実際の位置情報」選択時に OS の位置情報権限（ACCESS_FINE_LOCATION/ACCESS_COARSE_LOCATION）を要求
- GeckoSessionDelegate で PERMISSION_GEOLOCATION を処理し、サイト設定が REAL の場合のみ許可
- AndroidManifest.xml に位置情報権限を追加

### ViewModel・状態管理
- BrowserViewModel で設定変更時に拡張機能へ反映
- SiteSettingsScreenViewModel で位置情報設定の変更と権限要求を処理
- SettingsScreenViewModel から不要な拡張機能更新処理を削除（BrowserViewModel に統一）

## 実装の詳細

- **forceMock が有効な場合**：サイトごとの設定に関わらず全サイトへモック座標を返す
- **サイトごとの設定が未設定の場合**：デフォルトで MOCK モード
- **モード切り替え時**：アクティブなウォッチを新しいモードに応じて移行（real ↔ mock/deny の切り替

https://claude.ai/code/session_01EddFfJdPbzvz8XwpCwZyLX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-site geolocation configuration with three modes: Mock location, Deny access, or Real location
  * System location permission requests triggered when enabling real geolocation for a site

* **Changed**
  * Removed global mock location on/off toggle from Settings; location behavior is now controlled per-site

<!-- end of auto-generated comment: release notes by coderabbit.ai -->