### PR TITLE
サイト設定画面にCookie・キャッシュ削除機能を追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.androidx.browser)
     implementation(libs.mozilla.geckoview)
+    implementation(libs.mozilla.publicsuffixlist)
     implementation(libs.mlkit.translate)
     implementation(libs.mlkit.language.id)
     implementation(libs.kotlinx.coroutines.play.services)

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -81,6 +81,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.work.WorkManager
 import net.matsudamper.browser.data.BackupRepository
 import org.koin.compose.koinInject
+import org.mozilla.geckoview.GeckoRuntime
 
 @Composable
 internal fun BrowserApp(
@@ -435,10 +436,12 @@ private fun BrowserAppContent(
 
                     is AppDestination.SiteSettings -> navEntry(key) {
                         val siteSettingsRepository: SiteSettingsRepository = koinInject()
+                        val geckoRuntime: GeckoRuntime = koinInject()
                         val siteSettingsViewModel = composeViewModel(initializer = {
                             SiteSettingsScreenViewModel(
                                 host = key.host,
                                 siteSettingsRepository = siteSettingsRepository,
+                                geckoRuntime = geckoRuntime,
                             )
                         })
                         val siteSettingsUiState by siteSettingsViewModel.uiState.collectAsState()

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TabGroupId
@@ -437,11 +438,13 @@ private fun BrowserAppContent(
                     is AppDestination.SiteSettings -> navEntry(key) {
                         val siteSettingsRepository: SiteSettingsRepository = koinInject()
                         val geckoRuntime: GeckoRuntime = koinInject()
+                        val publicSuffixList: PublicSuffixList = koinInject()
                         val siteSettingsViewModel = composeViewModel(initializer = {
                             SiteSettingsScreenViewModel(
                                 host = key.host,
                                 siteSettingsRepository = siteSettingsRepository,
                                 geckoRuntime = geckoRuntime,
+                                publicSuffixList = publicSuffixList,
                             )
                         })
                         // 「実際の位置情報」選択時に OS の位置情報権限を要求する

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser.di
 
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import net.matsudamper.browser.BrowserViewModel
 import net.matsudamper.browser.DownloadWorker
 import net.matsudamper.browser.FindInPageWebExtension
@@ -55,6 +56,8 @@ val appModule = module {
     single { FindInPageWebExtension().also { it.install(get()) } }
     single { MockLocationWebExtension().also { it.install(get()) } }
     single { ViewportScaleWebExtension().also { it.install(get()) } }
+    // eTLD+1 (基底ドメイン) の算出に使用する Public Suffix List。初回ロードを共有するため single
+    single { PublicSuffixList(androidContext()) }
     factory { GeckoDownloadManager(androidContext(), get()) }
     viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     worker { DownloadWorker(get(), get(), get()) }

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import net.matsudamper.browser.awaitGecko
 import net.matsudamper.browser.data.SiteGeolocationState
 import net.matsudamper.browser.data.SitePermissionState
@@ -21,6 +22,7 @@ internal class SiteSettingsScreenViewModel(
     private val host: String,
     private val siteSettingsRepository: SiteSettingsRepository,
     private val geckoRuntime: GeckoRuntime,
+    private val publicSuffixList: PublicSuffixList,
 ) : ViewModel() {
 
     val eventHandler = Channel<(Event) -> Unit>(Channel.UNLIMITED)
@@ -113,15 +115,23 @@ internal class SiteSettingsScreenViewModel(
 
     private suspend fun clearData(type: SiteSettingsScreenUiState.ClearDataType) {
         val flags = when (type) {
-            SiteSettingsScreenUiState.ClearDataType.Cookie -> StorageController.ClearFlags.COOKIES
+            // ログイン状態は親ドメインの Cookie や localStorage にも保持されるため、
+            // Cookie だけでなく DOM ストレージ・認証セッションも併せて削除する
+            SiteSettingsScreenUiState.ClearDataType.Cookie ->
+                StorageController.ClearFlags.COOKIES or
+                    StorageController.ClearFlags.DOM_STORAGES or
+                    StorageController.ClearFlags.AUTH_SESSIONS
             SiteSettingsScreenUiState.ClearDataType.Cache -> StorageController.ClearFlags.ALL_CACHES
         }
         val targetName = when (type) {
-            SiteSettingsScreenUiState.ClearDataType.Cookie -> "Cookie"
+            SiteSettingsScreenUiState.ClearDataType.Cookie -> "Cookieとサイトデータ"
             SiteSettingsScreenUiState.ClearDataType.Cache -> "キャッシュ"
         }
         val message = runCatching {
-            geckoRuntime.storageController.clearDataFromHost(host, flags).awaitGecko()
+            // Cookie は Domain=.example.com のように基底ドメインへ設定されることが多く、
+            // ホスト単位の削除では消えないため eTLD+1 単位で削除する
+            val baseDomain = publicSuffixList.getPublicSuffixPlusOne(host).await() ?: host
+            geckoRuntime.storageController.clearDataFromBaseDomain(baseDomain, flags).awaitGecko()
         }.fold(
             onSuccess = { "${targetName}を削除しました" },
             onFailure = { "${targetName}の削除に失敗しました" },

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -8,13 +8,17 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.matsudamper.browser.awaitGecko
 import net.matsudamper.browser.data.SitePermissionState
 import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.ui.settings.SiteSettingsScreenUiState
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.StorageController
 
 internal class SiteSettingsScreenViewModel(
     private val host: String,
     private val siteSettingsRepository: SiteSettingsRepository,
+    private val geckoRuntime: GeckoRuntime,
 ) : ViewModel() {
 
     private val callbacks = object : SiteSettingsScreenUiState.Callbacks {
@@ -23,19 +27,61 @@ internal class SiteSettingsScreenViewModel(
                 siteSettingsRepository.setMicrophonePermission(host, state)
             }
         }
+
+        override fun requestClearData(type: SiteSettingsScreenUiState.ClearDataType) {
+            uiStateFlow.update { it.copy(clearDataConfirmDialog = type) }
+        }
+
+        override fun confirmClearData() {
+            val type = uiStateFlow.value.clearDataConfirmDialog ?: return
+            uiStateFlow.update { it.copy(clearDataConfirmDialog = null) }
+            viewModelScope.launch {
+                clearData(type)
+            }
+        }
+
+        override fun dismissClearDataConfirm() {
+            uiStateFlow.update { it.copy(clearDataConfirmDialog = null) }
+        }
+
+        override fun consumeClearDataResultMessage() {
+            uiStateFlow.update { it.copy(clearDataResultMessage = null) }
+        }
     }
 
-    val uiState: StateFlow<SiteSettingsScreenUiState> = MutableStateFlow(
+    private val uiStateFlow: MutableStateFlow<SiteSettingsScreenUiState> = MutableStateFlow(
         SiteSettingsScreenUiState(
             callbacks = callbacks,
             host = host,
             microphonePermission = null,
+            clearDataConfirmDialog = null,
+            clearDataResultMessage = null,
         ),
-    ).also { uiStateFlow ->
+    )
+
+    val uiState: StateFlow<SiteSettingsScreenUiState> = uiStateFlow.also {
         viewModelScope.launch {
             siteSettingsRepository.requestedMicrophonePermission(host).collectLatest { permission ->
                 uiStateFlow.update { it.copy(microphonePermission = permission) }
             }
         }
     }.asStateFlow()
+
+    private suspend fun clearData(type: SiteSettingsScreenUiState.ClearDataType) {
+        val flags = when (type) {
+            SiteSettingsScreenUiState.ClearDataType.Cookie -> StorageController.ClearFlags.COOKIES
+            SiteSettingsScreenUiState.ClearDataType.Cache -> StorageController.ClearFlags.ALL_CACHES
+        }
+        val targetName = when (type) {
+            SiteSettingsScreenUiState.ClearDataType.Cookie -> "Cookie"
+            SiteSettingsScreenUiState.ClearDataType.Cache -> "キャッシュ"
+        }
+        val message = runCatching {
+            geckoRuntime.storageController.clearDataFromHost(host, flags).awaitGecko()
+        }.fold(
+            onSuccess = { "${targetName}を削除しました" },
+            onFailure = { "${targetName}の削除に失敗しました" },
+        )
+        uiStateFlow.update { it.copy(clearDataResultMessage = message) }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 mozilla-geckoview = { module = "org.mozilla.geckoview:geckoview", version.ref = "geckoview" }
+mozilla-publicsuffixlist = { module = "org.mozilla.components:lib-publicsuffixlist", version = "151.0.4" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -183,7 +183,7 @@ fun SiteSettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(
-                        text = "Cookieを削除",
+                        text = "Cookieとサイトデータを削除",
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
@@ -210,13 +210,20 @@ fun SiteSettingsScreen(
     val confirmDialog = uiState.clearDataConfirmDialog
     if (confirmDialog != null) {
         val targetName = when (confirmDialog) {
-            SiteSettingsScreenUiState.ClearDataType.Cookie -> "Cookie"
+            SiteSettingsScreenUiState.ClearDataType.Cookie -> "Cookieとサイトデータ"
             SiteSettingsScreenUiState.ClearDataType.Cache -> "キャッシュ"
+        }
+        val description = when (confirmDialog) {
+            SiteSettingsScreenUiState.ClearDataType.Cookie ->
+                "「${uiState.host}」のCookieとサイトデータを削除しますか？" +
+                    "このサイトからログアウトされます。この操作は取り消せません。"
+            SiteSettingsScreenUiState.ClearDataType.Cache ->
+                "「${uiState.host}」のキャッシュを削除しますか？この操作は取り消せません。"
         }
         AlertDialog(
             onDismissRequest = uiState.callbacks::dismissClearDataConfirm,
             title = { Text("${targetName}を削除") },
-            text = { Text("「${uiState.host}」の${targetName}を削除しますか？この操作は取り消せません。") },
+            text = { Text(description) },
             confirmButton = {
                 TextButton(onClick = uiState.callbacks::confirmClearData) {
                     Text("削除", color = MaterialTheme.colorScheme.error)

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -4,19 +4,28 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
@@ -36,6 +45,17 @@ fun SiteSettingsScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val currentCallbacks by rememberUpdatedState(uiState.callbacks)
+    val clearDataResultMessage = uiState.clearDataResultMessage
+
+    LaunchedEffect(clearDataResultMessage) {
+        if (clearDataResultMessage != null) {
+            snackbarHostState.showSnackbar(clearDataResultMessage)
+            currentCallbacks.consumeClearDataResultMessage()
+        }
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -51,6 +71,7 @@ fun SiteSettingsScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -114,8 +135,73 @@ fun SiteSettingsScreen(
                 )
             }
 
+            Spacer(Modifier.height(12.dp))
+
+            SettingSection(title = "データの削除") {
+                TextButton(
+                    onClick = {
+                        uiState.callbacks.requestClearData(
+                            SiteSettingsScreenUiState.ClearDataType.Cookie,
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = "Cookieを削除",
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+                TextButton(
+                    onClick = {
+                        uiState.callbacks.requestClearData(
+                            SiteSettingsScreenUiState.ClearDataType.Cache,
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = "キャッシュを削除",
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+
             Spacer(Modifier.padding(bottom = paddingValues.calculateBottomPadding()))
         }
+    }
+
+    // 削除操作の確認ダイアログ（画面の上に重ねて表示する）
+    val confirmDialog = uiState.clearDataConfirmDialog
+    if (confirmDialog != null) {
+        val targetName = when (confirmDialog) {
+            SiteSettingsScreenUiState.ClearDataType.Cookie -> "Cookie"
+            SiteSettingsScreenUiState.ClearDataType.Cache -> "キャッシュ"
+        }
+        AlertDialog(
+            onDismissRequest = uiState.callbacks::dismissClearDataConfirm,
+            title = { Text("${targetName}を削除") },
+            text = { Text("「${uiState.host}」の${targetName}を削除しますか？この操作は取り消せません。") },
+            confirmButton = {
+                TextButton(onClick = uiState.callbacks::confirmClearData) {
+                    Text("削除", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = uiState.callbacks::dismissClearDataConfirm) {
+                    Text("キャンセル")
+                }
+            },
+        )
+    }
+}
+
+private fun previewCallbacks(): SiteSettingsScreenUiState.Callbacks {
+    return object : SiteSettingsScreenUiState.Callbacks {
+        override fun setMicrophonePermission(state: SitePermissionState) = Unit
+        override fun requestClearData(type: SiteSettingsScreenUiState.ClearDataType) = Unit
+        override fun confirmClearData() = Unit
+        override fun dismissClearDataConfirm() = Unit
+        override fun consumeClearDataResultMessage() = Unit
     }
 }
 
@@ -125,11 +211,11 @@ private fun SiteSettingsScreenPreview() {
     MaterialTheme {
         SiteSettingsScreen(
             uiState = SiteSettingsScreenUiState(
-                callbacks = object : SiteSettingsScreenUiState.Callbacks {
-                    override fun setMicrophonePermission(state: SitePermissionState) = Unit
-                },
+                callbacks = previewCallbacks(),
                 host = "www.example.com",
                 microphonePermission = SitePermissionState.SITE_PERMISSION_ASK,
+                clearDataConfirmDialog = null,
+                clearDataResultMessage = null,
             ),
             onBack = {},
         )
@@ -142,11 +228,28 @@ private fun SiteSettingsScreenNoRequestedPermissionPreview() {
     MaterialTheme {
         SiteSettingsScreen(
             uiState = SiteSettingsScreenUiState(
-                callbacks = object : SiteSettingsScreenUiState.Callbacks {
-                    override fun setMicrophonePermission(state: SitePermissionState) = Unit
-                },
+                callbacks = previewCallbacks(),
                 host = "www.example.com",
                 microphonePermission = null,
+                clearDataConfirmDialog = null,
+                clearDataResultMessage = null,
+            ),
+            onBack = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SiteSettingsScreenClearCookieConfirmPreview() {
+    MaterialTheme {
+        SiteSettingsScreen(
+            uiState = SiteSettingsScreenUiState(
+                callbacks = previewCallbacks(),
+                host = "www.example.com",
+                microphonePermission = null,
+                clearDataConfirmDialog = SiteSettingsScreenUiState.ClearDataType.Cookie,
+                clearDataResultMessage = null,
             ),
             onBack = {},
         )

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
@@ -9,8 +9,21 @@ data class SiteSettingsScreenUiState(
     val host: String,
     /** マイク権限の状態。サイトから一度も要求されていない場合は null で、項目を表示しない */
     val microphonePermission: SitePermissionState?,
+    /** 削除確認ダイアログの対象。null の場合はダイアログを表示しない */
+    val clearDataConfirmDialog: ClearDataType?,
+    /** 削除完了スナックバーのメッセージ。表示後に consumeClearDataResultMessage で消費する */
+    val clearDataResultMessage: String?,
 ) {
+    enum class ClearDataType {
+        Cookie,
+        Cache,
+    }
+
     interface Callbacks {
         fun setMicrophonePermission(state: SitePermissionState)
+        fun requestClearData(type: ClearDataType)
+        fun confirmClearData()
+        fun dismissClearDataConfirm()
+        fun consumeClearDataResultMessage()
     }
 }


### PR DESCRIPTION
## 概要
サイト設定画面に、特定サイトの Cookie・サイトデータとキャッシュを個別に削除する機能を追加しました。削除前に確認ダイアログを表示し、完了後にスナックバーでメッセージを表示します。

## 主な変更

### UI層 (`SiteSettingsScreen.kt`)
- 「データの削除」セクションに「Cookieとサイトデータを削除」「キャッシュを削除」ボタンを追加
- 削除前に確認ダイアログを表示（Cookie 削除時はログアウトされる旨を明記）
- 削除完了/失敗時にスナックバーでメッセージを表示
- 確認ダイアログ表示時のプレビューを追加

### ViewModel層 (`SiteSettingsScreenViewModel.kt`)
- GeckoView の `StorageController.clearDataFromBaseDomain` で **eTLD+1（基底ドメイン）単位** で削除
  - `clearDataFromHost` はホスト完全一致でしか削除せず、`Domain=.example.com` のように親ドメインへ設定されたセッション Cookie が残りログイン状態が解除されない問題があったため
  - 基底ドメインの算出には Mozilla の Public Suffix List ライブラリ（`lib-publicsuffixlist`）を使用（`example.co.jp` 等の複合 TLD にも正しく対応）
- Cookie 削除時は `COOKIES` に加えて `DOM_STORAGES`（localStorage のログイントークン対策）と `AUTH_SESSIONS` も削除
- キャッシュ削除は `ALL_CACHES`（ネットワーク + 画像キャッシュ）

### UiState (`SiteSettingsScreenUiState.kt`)
- `ClearDataType` enum（Cookie / Cache）を定義
- `clearDataConfirmDialog`（確認ダイアログ状態）と `clearDataResultMessage`（結果通知）を追加
- Callbacks に削除要求・確定・キャンセル・メッセージ消費の4メソッドを追加

### DI・依存関係 (`AppModule.kt` / `BrowserApp.kt` / `libs.versions.toml`)
- `org.mozilla.components:lib-publicsuffixlist:151.0.4` を追加
- `PublicSuffixList` を Koin の single で提供し、`GeckoRuntime` とともに ViewModel へ注入

## 動作仕様の補足
- 削除は基底ドメイン単位のため、`www.example.com` の画面から削除すると同一ドメイン配下のサブドメイン（`mail.example.com` 等）のデータも削除されます。ログアウトを確実にするための仕様で、Firefox for Android と同じ挙動です

https://claude.ai/code/session_017fQESBA9sHCnzKneRSFXHL

## Summary by CodeRabbit

* **New Features**
  * Users can now clear cookies and cached data directly from the site settings screen for individual websites
  * A confirmation dialog prevents accidental deletion of site data
  * Clear operations display feedback messages upon completion
