### PR TITLE
サイト設定画面に TLS 証明書情報を表示

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -344,7 +344,12 @@ private fun BrowserAppContent(
                                     onOpenSiteSettings = { currentUrl ->
                                         val host = extractSiteHost(currentUrl)
                                         if (host != null) {
-                                            backStack.add(AppDestination.SiteSettings(host))
+                                            backStack.add(
+                                                AppDestination.SiteSettings(
+                                                    host = host,
+                                                    tabId = key.tabId,
+                                                ),
+                                            )
                                         }
                                     },
                                     onOpenTabs = { backStack.add(AppDestination.Tabs) },
@@ -439,6 +444,10 @@ private fun BrowserAppContent(
                             SiteSettingsScreenViewModel(
                                 host = key.host,
                                 siteSettingsRepository = siteSettingsRepository,
+                                // 開いた元のタブの現在の接続から TLS 証明書情報を取得する
+                                securityInfo = key.tabId
+                                    ?.let { browserTabController.findTab(it) }
+                                    ?.securityInfo,
                             )
                         })
                         // 「実際の位置情報」選択時に OS の位置情報権限を要求する

--- a/app/src/main/kotlin/net/matsudamper/browser/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/navigation/AppDestination.kt
@@ -14,9 +14,9 @@ sealed interface AppDestination : NavKey, java.io.Serializable {
     @Serializable
     data object Settings : AppDestination, java.io.Serializable
 
-    /** サイトごとの設定画面。host は対象サイトのホスト名 */
+    /** サイトごとの設定画面。host は対象サイトのホスト名、tabId は開いた元のタブ (TLS 証明書の取得に使用) */
     @Serializable
-    data class SiteSettings(val host: String) : AppDestination, java.io.Serializable
+    data class SiteSettings(val host: String, val tabId: String? = null) : AppDestination, java.io.Serializable
 
     @Serializable
     data object Extensions : AppDestination, java.io.Serializable

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/sitesettings/SiteSettingsScreenViewModel.kt
@@ -2,6 +2,10 @@ package net.matsudamper.browser.screen.sitesettings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import java.security.MessageDigest
+import java.security.cert.X509Certificate
+import java.text.SimpleDateFormat
+import java.util.Locale
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -9,6 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.matsudamper.browser.TabSecurityInfo
 import net.matsudamper.browser.data.SiteGeolocationState
 import net.matsudamper.browser.data.SitePermissionState
 import net.matsudamper.browser.data.SiteSettingsRepository
@@ -17,6 +22,7 @@ import net.matsudamper.browser.ui.settings.SiteSettingsScreenUiState
 internal class SiteSettingsScreenViewModel(
     private val host: String,
     private val siteSettingsRepository: SiteSettingsRepository,
+    securityInfo: TabSecurityInfo?,
 ) : ViewModel() {
 
     val eventHandler = Channel<(Event) -> Unit>(Channel.UNLIMITED)
@@ -69,6 +75,7 @@ internal class SiteSettingsScreenViewModel(
             host = host,
             microphonePermission = null,
             geolocationState = null,
+            tlsCertificate = createTlsCertificateUiState(securityInfo),
         ),
     ).also { uiStateFlow ->
         viewModelScope.launch {
@@ -82,4 +89,33 @@ internal class SiteSettingsScreenViewModel(
             }
         }
     }.asStateFlow()
+
+    private fun createTlsCertificateUiState(
+        securityInfo: TabSecurityInfo?,
+    ): SiteSettingsScreenUiState.TlsCertificate? {
+        securityInfo ?: return null
+        val certificate = securityInfo.certificate
+        if (!securityInfo.isSecure || certificate == null) {
+            return SiteSettingsScreenUiState.TlsCertificate.Insecure
+        }
+        val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault())
+        return SiteSettingsScreenUiState.TlsCertificate.Available(
+            subjectCommonName = extractCommonName(certificate.subjectX500Principal.name),
+            issuer = extractCommonName(certificate.issuerX500Principal.name),
+            validFrom = dateFormat.format(certificate.notBefore),
+            validUntil = dateFormat.format(certificate.notAfter),
+            sha256Fingerprint = sha256Fingerprint(certificate),
+        )
+    }
+
+    /** DN から CN を抽出する。CN が無い場合は DN 全体を返す */
+    private fun extractCommonName(distinguishedName: String): String {
+        return Regex("""CN=([^,]+)""").find(distinguishedName)?.groupValues?.get(1)
+            ?: distinguishedName
+    }
+
+    private fun sha256Fingerprint(certificate: X509Certificate): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(certificate.encoded)
+        return digest.joinToString(":") { "%02X".format(it) }
+    }
 }

--- a/app/src/test/kotlin/net/matsudamper/browser/PaparazziComposablePreviewTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/PaparazziComposablePreviewTest.kt
@@ -1,6 +1,8 @@
 package net.matsudamper.browser
 
+import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import com.android.resources.ScreenOrientation
 import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -26,6 +28,24 @@ class PaparazziComposablePreviewTest {
                     previewName.contains(filter, ignoreCase = true)
             }
             .forEach { preview ->
+                // @Preview の widthDp/heightDp 指定をデバイス設定に反映する
+                val baseConfig = DeviceConfig.NEXUS_5
+                val pixelsPerDp = baseConfig.density.dpiValue / 160
+                val widthDp = preview.previewInfo.widthDp
+                val heightDp = preview.previewInfo.heightDp
+                val screenWidth = if (widthDp > 0) widthDp * pixelsPerDp else baseConfig.screenWidth
+                val screenHeight = if (heightDp > 0) heightDp * pixelsPerDp else baseConfig.screenHeight
+                paparazzi.unsafeUpdateConfig(
+                    deviceConfig = baseConfig.copy(
+                        screenWidth = screenWidth,
+                        screenHeight = screenHeight,
+                        orientation = if (screenWidth > screenHeight) {
+                            ScreenOrientation.LANDSCAPE
+                        } else {
+                            ScreenOrientation.PORTRAIT
+                        },
+                    ),
+                )
                 paparazzi.snapshot { preview() }
             }
     }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
@@ -6,8 +6,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import java.security.cert.X509Certificate
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
+
+/** タブの現在の接続のセキュリティ情報 (TLS) */
+data class TabSecurityInfo(
+    val isSecure: Boolean,
+    val certificate: X509Certificate?,
+)
 
 @Stable
 class BrowserTab(
@@ -79,6 +86,9 @@ class BrowserTab(
 
     // ページのfavicon（ホーム追加時のアイコンに使用、永続化は不要）
     var faviconBitmap: Bitmap? by mutableStateOf(null)
+
+    // 現在の接続のセキュリティ情報。サイトの設定画面での TLS 証明書確認に使用する（永続化は不要）
+    var securityInfo: TabSecurityInfo? by mutableStateOf(null)
 
     // スクロール位置（永続化は不要）。BrowserTabScreenState がタブ切替で再生成されても
     // GeckoSession と同じ寿命を持つここで保持することで、復元タブのスクロール位置を維持する。

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/GeckoSessionDelegateFactory.kt
@@ -261,11 +261,23 @@ fun createGeckoSessionDelegateBundle(
             }
 
             override fun onPageStart(session: GeckoSession, url: String) {
+                // 新しいページでは前ページの証明書情報を持ち越さない
+                browserTab.securityInfo = null
                 callbacks.onPageStart(url)
             }
 
             override fun onPageStop(session: GeckoSession, success: Boolean) {
                 callbacks.onPageStop(success)
+            }
+
+            override fun onSecurityChange(
+                session: GeckoSession,
+                securityInfo: GeckoSession.ProgressDelegate.SecurityInformation,
+            ) {
+                browserTab.securityInfo = TabSecurityInfo(
+                    isSecure = securityInfo.isSecure,
+                    certificate = securityInfo.certificate,
+                )
             }
         },
         translationsDelegate = object : TranslationsController.SessionTranslation.Delegate {

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -412,6 +412,7 @@ internal fun SettingSection(
     content: @Composable () -> Unit,
 ) {
     Surface(
+        modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceContainer,
     ) {

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -72,6 +73,32 @@ fun SiteSettingsScreen(
             )
 
             Spacer(Modifier.height(12.dp))
+
+            if (uiState.tlsCertificate != null) {
+                SettingSection(title = "TLS証明書") {
+                    when (val certificate = uiState.tlsCertificate) {
+                        is SiteSettingsScreenUiState.TlsCertificate.Available -> {
+                            CertificateInfoRow(label = "発行先", value = certificate.subjectCommonName)
+                            CertificateInfoRow(label = "発行者", value = certificate.issuer)
+                            CertificateInfoRow(label = "有効期間の開始", value = certificate.validFrom)
+                            CertificateInfoRow(label = "有効期間の終了", value = certificate.validUntil)
+                            CertificateInfoRow(
+                                label = "SHA-256 フィンガープリント",
+                                value = certificate.sha256Fingerprint,
+                            )
+                        }
+
+                        SiteSettingsScreenUiState.TlsCertificate.Insecure -> {
+                            Text(
+                                text = "この接続は保護されていません",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+            }
 
             // 権限は一度でも要求された項目だけ表示する
             if (uiState.geolocationState != null) {
@@ -155,6 +182,27 @@ fun SiteSettingsScreen(
     }
 }
 
+/** 証明書のラベルと値の1行分を表示する */
+@Composable
+private fun CertificateInfoRow(
+    label: String,
+    value: String,
+) {
+    Column(Modifier.padding(vertical = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SelectionContainer {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
 private val previewCallbacks = object : SiteSettingsScreenUiState.Callbacks {
     override fun setMicrophonePermission(state: SitePermissionState) = Unit
     override fun setGeolocationState(state: SiteGeolocationState) = Unit
@@ -170,6 +218,14 @@ private fun SiteSettingsScreenPreview() {
                 host = "www.example.com",
                 microphonePermission = SitePermissionState.SITE_PERMISSION_ASK,
                 geolocationState = SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+                tlsCertificate = SiteSettingsScreenUiState.TlsCertificate.Available(
+                    subjectCommonName = "www.example.com",
+                    issuer = "Example CA",
+                    validFrom = "2026/01/01 00:00",
+                    validUntil = "2027/01/01 00:00",
+                    sha256Fingerprint = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:" +
+                        "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+                ),
             ),
             onBack = {},
         )
@@ -186,6 +242,7 @@ private fun SiteSettingsScreenGeolocationOnlyPreview() {
                 host = "www.example.com",
                 microphonePermission = null,
                 geolocationState = SiteGeolocationState.SITE_GEOLOCATION_DENY,
+                tlsCertificate = SiteSettingsScreenUiState.TlsCertificate.Insecure,
             ),
             onBack = {},
         )
@@ -202,6 +259,7 @@ private fun SiteSettingsScreenNoRequestedPermissionPreview() {
                 host = "www.example.com",
                 microphonePermission = null,
                 geolocationState = null,
+                tlsCertificate = null,
             ),
             onBack = {},
         )

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -340,6 +340,46 @@ private fun SiteSettingsScreenGeolocationOnlyPreview() {
     }
 }
 
+/** セクション内のコンテンツが短い場合でもコンテナが画面幅いっぱいに広がることを確認する */
+@Preview(showBackground = true)
+@Composable
+private fun SiteSettingsScreenShortContentPreview() {
+    MaterialTheme {
+        SiteSettingsScreen(
+            uiState = SiteSettingsScreenUiState(
+                callbacks = previewCallbacks,
+                host = "a.test",
+                microphonePermission = null,
+                geolocationState = null,
+                tlsCertificate = SiteSettingsScreenUiState.TlsCertificate.Insecure,
+                clearDataConfirmDialog = null,
+                clearDataResultMessage = null,
+            ),
+            onBack = {},
+        )
+    }
+}
+
+/** 横向きでもコンテナが画面幅いっぱいに広がることを確認する */
+@Preview(showBackground = true, widthDp = 800, heightDp = 360)
+@Composable
+private fun SiteSettingsScreenLandscapePreview() {
+    MaterialTheme {
+        SiteSettingsScreen(
+            uiState = SiteSettingsScreenUiState(
+                callbacks = previewCallbacks,
+                host = "a.test",
+                microphonePermission = null,
+                geolocationState = null,
+                tlsCertificate = SiteSettingsScreenUiState.TlsCertificate.Insecure,
+                clearDataConfirmDialog = null,
+                clearDataResultMessage = null,
+            ),
+            onBack = {},
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun SiteSettingsScreenNoRequestedPermissionPreview() {

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreenUiState.kt
@@ -12,7 +12,24 @@ data class SiteSettingsScreenUiState(
     val microphonePermission: SitePermissionState?,
     /** 位置情報の扱い。サイトから一度も要求されていない場合は null で、項目を表示しない */
     val geolocationState: SiteGeolocationState?,
+    /** TLS 証明書の表示情報。タブから取得できない場合は null で、項目を表示しない */
+    val tlsCertificate: TlsCertificate?,
 ) {
+    @Stable
+    sealed interface TlsCertificate {
+        /** HTTPS で保護されていない接続 */
+        data object Insecure : TlsCertificate
+
+        /** 保護された接続の証明書詳細 */
+        data class Available(
+            val subjectCommonName: String,
+            val issuer: String,
+            val validFrom: String,
+            val validUntil: String,
+            val sha256Fingerprint: String,
+        ) : TlsCertificate
+    }
+
     interface Callbacks {
         fun setMicrophonePermission(state: SitePermissionState)
         fun setGeolocationState(state: SiteGeolocationState)


### PR DESCRIPTION
## 概要
サイト設定画面に現在の接続の TLS 証明書情報を表示する機能を追加しました。HTTPS で保護された接続の場合は証明書の詳細（発行先、発行者、有効期間、SHA-256 フィンガープリント）を表示し、保護されていない接続の場合はその旨を表示します。

## 主な変更

### UI 層
- `SiteSettingsScreen` に TLS 証明書情報を表示するセクションを追加
  - `CertificateInfoRow` コンポーネントを新規作成し、ラベルと値をペアで表示
  - `SelectionContainer` でテキスト選択を可能に
- `SiteSettingsScreenUiState` に `TlsCertificate` sealed interface を追加
  - `Insecure`: 保護されていない接続
  - `Available`: 証明書詳細を保持

### ViewModel 層
- `SiteSettingsScreenViewModel` で `TabSecurityInfo` を受け取り、TLS 証明書情報を UI State に変換
  - `createTlsCertificateUiState()`: セキュリティ情報から UI State を生成
  - `extractCommonName()`: DN から CN を抽出
  - `sha256Fingerprint()`: X509Certificate から SHA-256 フィンガープリントを計算

### データ層
- `BrowserTab` に `securityInfo: TabSecurityInfo?` プロパティを追加
- `TabSecurityInfo` data class を新規作成（isSecure と X509Certificate を保持）
- `GeckoSessionDelegateFactory` で `onSecurityChange()` を実装し、ページ遷移時にセキュリティ情報を更新

### ナビゲーション
- `AppDestination.SiteSettings` に `tabId` パラメータを追加
  - サイト設定画面を開く際に元のタブ ID を渡し、そのタブの現在の接続情報を取得

### プレビュー
- 3 つのプレビューを更新し、TLS 証明書情報を含める
  - 証明書あり、保護されていない接続、証明書なしのパターンをカバー

## 実装の詳細
- 日付フォーマットは `SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault())` で統一
- SHA-256 フィンガープリントは `AA:BB:CC:...` 形式で表示
- ページ遷移時に前ページの証明書情報を持ち越さないよう `onPageStart()` で `securityInfo` をリセット

https://claude.ai/code/session_01M7oND7ZSZVyjY4MLib1reH