### PR TITLE
ダウンロード一覧に長押しメニューを追加し開始ページを開けるようにする

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -535,6 +535,24 @@ private fun BrowserAppContent(
                             DownloadManagementScreenViewModel(context.applicationContext as android.app.Application)
                         }
                         val downloadsUiState by downloadsViewModel.uiState.collectAsState()
+                        LaunchedEffect(downloadsViewModel) {
+                            downloadsViewModel.eventHandler.receiveAsFlow().collect {
+                                it(object : DownloadManagementScreenViewModel.Event {
+                                    override fun navigateToUrl(url: String) {
+                                        scope.launch {
+                                            val tabId = UUID.randomUUID().toString()
+                                            withContext(Dispatchers.Main) {
+                                                browserTabController.createAndAppendTab(
+                                                    tabId = tabId,
+                                                    initialUrl = url,
+                                                )
+                                                selectTab(tabId, null)
+                                            }
+                                        }
+                                    }
+                                })
+                            }
+                        }
                         DownloadManagementScreen(
                             uiState = downloadsUiState,
                             onBack = { backStack.removeLastOrNull() },

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,6 +33,8 @@ internal class DownloadManagementScreenViewModel(
     private val downloadRepository = DownloadRepository(application)
     private val geckoDownloadManager = GeckoDownloadManager(application, downloadRepository)
     private val callbacks = buildCallbacks()
+
+    val eventHandler = Channel<(Event) -> Unit>(Channel.UNLIMITED)
 
     /** resumeDownload から最新のレコードを参照するためのキャッシュ */
     private var currentRecords: List<DownloadRecord> = emptyList()
@@ -61,6 +64,7 @@ internal class DownloadManagementScreenViewModel(
         onOpenFile = { fileUri -> openFile(fileUri) },
         onOpenDownloadsFolder = { openDownloadsFolder() },
         onResume = { id -> resumeDownload(id) },
+        onOpenOriginPage = { url -> eventHandler.trySend { it.navigateToUrl(url) } },
     )
 
     private fun DownloadRecord.toDownloadItem(): DownloadManagementScreenUiState.DownloadItem {
@@ -104,6 +108,7 @@ internal class DownloadManagementScreenViewModel(
             },
             status = uiStatus,
             enqueuedAt = enqueuedAt,
+            originPageUrl = referrerUrl.ifBlank { null },
         )
     }
 
@@ -192,5 +197,10 @@ internal class DownloadManagementScreenViewModel(
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
         runCatching { app.startActivity(intent) }
+    }
+
+    interface Event {
+        /** ダウンロード開始時のページURLを新しいタブで開く */
+        fun navigateToUrl(url: String)
     }
 }

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -1,5 +1,7 @@
 package net.matsudamper.browser.ui.downloads
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +14,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,7 +26,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -89,6 +96,7 @@ fun DownloadManagementScreen(
                         onCancel = { uiState.callbacks.onCancel(item.id) },
                         onOpenFile = { fileUri -> uiState.callbacks.onOpenFile(fileUri) },
                         onResume = { uiState.callbacks.onResume(item.id) },
+                        onOpenOriginPage = { url -> uiState.callbacks.onOpenOriginPage(url) },
                     )
                 }
             }
@@ -96,118 +104,140 @@ fun DownloadManagementScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DownloadItemRow(
     item: DownloadManagementScreenUiState.DownloadItem,
     onCancel: () -> Unit,
     onOpenFile: (String) -> Unit,
     onResume: () -> Unit,
+    onOpenOriginPage: (url: String) -> Unit,
 ) {
     val dateFormat = remember { SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault()) }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+    var menuExpanded by remember { mutableStateOf(false) }
+    Box {
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
         ) {
-            Text(
-                text = item.fileName,
-                style = MaterialTheme.typography.bodyLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(end = 8.dp),
+            DropdownMenuItem(
+                text = { Text("開始ページを開く") },
+                enabled = item.originPageUrl != null,
+                onClick = {
+                    menuExpanded = false
+                    item.originPageUrl?.let { onOpenOriginPage(it) }
+                },
             )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    onLongClick = { menuExpanded = true },
+                    onClick = {},
+                )
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = item.fileName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 8.dp),
+                )
+                when (val status = item.status) {
+                    is DownloadManagementScreenUiState.DownloadStatus.InProgress -> {
+                        TextButton(onClick = onCancel) {
+                            Text("キャンセル")
+                        }
+                    }
+
+                    is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
+                        TextButton(onClick = { onOpenFile(status.fileUri) }) {
+                            Text("開く")
+                        }
+                    }
+
+                    is DownloadManagementScreenUiState.DownloadStatus.Failed -> {
+                        if (status.canResume) {
+                            TextButton(onClick = onResume) {
+                                Text("再開")
+                            }
+                        } else {
+                            Text(
+                                text = "失敗",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+
+                    is DownloadManagementScreenUiState.DownloadStatus.Cancelled -> {
+                        Text(
+                            text = "キャンセル",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
             when (val status = item.status) {
                 is DownloadManagementScreenUiState.DownloadStatus.InProgress -> {
-                    TextButton(onClick = onCancel) {
-                        Text("キャンセル")
+                    val sizeText = buildSizeText(status.totalRead, status.contentLength)
+                    Text(
+                        text = sizeText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (status.isIndeterminate) {
+                        LinearProgressIndicator(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp),
+                        )
+                    } else {
+                        LinearProgressIndicator(
+                            progress = { status.progress / 100f },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp),
+                        )
                     }
                 }
 
                 is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
-                    TextButton(onClick = { onOpenFile(status.fileUri) }) {
-                        Text("開く")
-                    }
+                    Text(
+                        text = "完了",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
 
                 is DownloadManagementScreenUiState.DownloadStatus.Failed -> {
-                    if (status.canResume) {
-                        TextButton(onClick = onResume) {
-                            Text("再開")
-                        }
-                    } else {
+                    if (!status.canResume) {
                         Text(
-                            text = "失敗",
-                            style = MaterialTheme.typography.bodyMedium,
+                            text = "再試行するには再度ダウンロードしてください。",
+                            style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.error,
                         )
                     }
                 }
 
-                is DownloadManagementScreenUiState.DownloadStatus.Cancelled -> {
-                    Text(
-                        text = "キャンセル",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                is DownloadManagementScreenUiState.DownloadStatus.Cancelled -> Unit
             }
+            Text(
+                text = dateFormat.format(Date(item.enqueuedAt)),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
-        when (val status = item.status) {
-            is DownloadManagementScreenUiState.DownloadStatus.InProgress -> {
-                val sizeText = buildSizeText(status.totalRead, status.contentLength)
-                Text(
-                    text = sizeText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                if (status.isIndeterminate) {
-                    LinearProgressIndicator(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 4.dp),
-                    )
-                } else {
-                    LinearProgressIndicator(
-                        progress = { status.progress / 100f },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 4.dp),
-                    )
-                }
-            }
-
-            is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
-                Text(
-                    text = "完了",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            is DownloadManagementScreenUiState.DownloadStatus.Failed -> {
-                if (!status.canResume) {
-                    Text(
-                        text = "再試行するには再度ダウンロードしてください。",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                }
-            }
-
-            is DownloadManagementScreenUiState.DownloadStatus.Cancelled -> Unit
-        }
-        Text(
-            text = dateFormat.format(Date(item.enqueuedAt)),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
     }
 }
 
@@ -235,10 +265,12 @@ private fun PreviewFailedCanResume() {
                 fileName = "example.zip",
                 status = DownloadManagementScreenUiState.DownloadStatus.Failed(canResume = true),
                 enqueuedAt = 0L,
+                originPageUrl = "https://example.com/page",
             ),
             onCancel = {},
             onOpenFile = {},
             onResume = {},
+            onOpenOriginPage = {},
         )
     }
 }
@@ -253,10 +285,12 @@ private fun PreviewFailedCannotResume() {
                 fileName = "example.zip",
                 status = DownloadManagementScreenUiState.DownloadStatus.Failed(canResume = false),
                 enqueuedAt = 0L,
+                originPageUrl = null,
             ),
             onCancel = {},
             onOpenFile = {},
             onResume = {},
+            onOpenOriginPage = {},
         )
     }
 }

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -34,6 +34,8 @@ data class DownloadManagementScreenUiState(
         val fileName: String,
         val status: DownloadStatus,
         val enqueuedAt: Long,
+        /** ダウンロード開始時に表示していたページのURL。不明な場合は null */
+        val originPageUrl: String?,
     )
 
     @Stable
@@ -43,5 +45,7 @@ data class DownloadManagementScreenUiState(
         val onOpenDownloadsFolder: () -> Unit,
         /** 失敗したダウンロードを再開する */
         val onResume: (UUID) -> Unit,
+        /** ダウンロード開始時のページを新しいタブで開く */
+        val onOpenOriginPage: (url: String) -> Unit,
     )
 }


### PR DESCRIPTION
## 概要

ダウンロード一覧の項目を長押しするとメニューが表示され、「開始ページを開く」でダウンロード開始時に表示していたページを新しいタブで開けるようにしました。

## 背景

- 「ダウンロード開始時のページURLの保存」は既存実装で対応済みでした。ダウンロード開始時 (`BrowserTabScreenState`) に `currentPageUrl` を `referrerUrl` として取得し、Room の `download` テーブル (`DownloadEntity.referrerUrl`、DB v2 で追加済み) に保存されています
- そのため本PRでは DB 変更・マイグレーションは行わず、既存の `referrerUrl` を流用してUI機能のみを追加しています

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `DownloadManagementScreenUiState.kt` | `DownloadItem` に `originPageUrl` (URLが空なら null)、`Callbacks` に `onOpenOriginPage` を追加 |
| `DownloadManagementScreen.kt` | 項目を `combinedClickable` で長押し可能にし、`DropdownMenu` で「開始ページを開く」を表示。`originPageUrl` が null の場合はメニュー項目を無効化。Preview も新引数に合わせて更新 |
| `DownloadManagementScreenViewModel.kt` | 既存の Channel イベントパターンに従い `eventHandler` と `Event.navigateToUrl(url)` を追加。`referrerUrl` を `originPageUrl` にマッピング |
| `BrowserApp.kt` | Downloads 画面でイベントを購読し、履歴画面と同じ方法で新しいタブを作成して選択 |

## 動作仕様

- 長押しメニューはすべてのステータス (進行中・完了・失敗・キャンセル) の項目で表示される
- 開始ページURLが保存されていない古いレコードではメニュー項目がグレーアウトされる
- 新しいタブはアプリ内操作の方針 (履歴・拡張機能と同様) に従い、デフォルトグループではなく現在アクティブなグループに割り当てられる

## 確認内容

- `./gradlew :app:assembleDebug` ✅
- `./gradlew detekt` ✅ (指摘なし)
- `./gradlew test` ✅
- Paparazzi スナップショット撮影済み (DownloadItemRow の Preview 2件)

https://claude.ai/code/session_01TRjKnqKuQJfpNVwdgh7Tch