### PR TITLE
画像長押しメニューに「新しいタブで開く」を追加し、referrer 欠落による 403 を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -364,7 +364,7 @@ private fun BrowserAppContent(
                                         selectTab(newTab.tabId, key)
                                         newTab.session
                                     },
-                                    onOpenNewTabRequest = { uri ->
+                                    onOpenNewTabRequest = { uri, referrerUrl ->
                                         scope.launch {
                                             val tabId = UUID.randomUUID().toString()
                                             assignTabToOpenerGroup(tabId, key.tabId)
@@ -372,6 +372,7 @@ private fun BrowserAppContent(
                                                 tabId = tabId,
                                                 initialUrl = uri,
                                                 openerTabId = key.tabId,
+                                                initialReferrerUrl = referrerUrl,
                                             )
                                             selectTab(newTab.tabId, key)
                                         }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -51,18 +51,19 @@ internal fun BrowserTabDialogLayer(
     state: BrowserTabScreenState,
     dialogState: PromptDialogState,
     enableTabUi: Boolean,
-    onOpenNewTabRequest: (String) -> Unit,
+    onOpenNewTabRequest: (url: String, referrerUrl: String?) -> Unit,
 ) {
     state.contextMenuState?.let { menu ->
         ContextMenuDialog(
             menu = menu,
             enableTabUi = enableTabUi,
+            // ホットリンク保護のあるサーバーで 403 にならないよう、元ページを referrer に付ける
             onOpenNewTab = { url ->
-                onOpenNewTabRequest(url)
+                onOpenNewTabRequest(url, state.currentPageUrl)
                 state.dismissContextMenu()
             },
             onOpenUrl = { url ->
-                state.onUrlSubmit(url)
+                state.openUrlWithReferrer(url)
                 state.dismissContextMenu()
             },
             onCopyLink = { url -> state.copyLinkUrl(url) },

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -386,7 +386,7 @@ private fun ContextMenuDialog(
     }
     val bodyText = when (menu) {
         is BrowserTabScreenState.ContextMenuState.Link -> menu.url
-        is BrowserTabScreenState.ContextMenuState.Image -> "この画像をダウンロードしますか？"
+        is BrowserTabScreenState.ContextMenuState.Image -> menu.srcUrl
         is BrowserTabScreenState.ContextMenuState.LinkWithImage -> menu.url
     }
     AlertDialog(
@@ -414,9 +414,13 @@ private fun ContextMenuDialog(
                         )
                     }
                     is BrowserTabScreenState.ContextMenuState.Image -> {
-                        TextButton(onClick = { onDownloadImage(menu.srcUrl) }) {
-                            Text(text = "ダウンロード")
-                        }
+                        ImageActionButtons(
+                            srcUrl = menu.srcUrl,
+                            enableTabUi = enableTabUi,
+                            onOpenNewTab = onOpenNewTab,
+                            onOpenUrl = onOpenUrl,
+                            onDownloadImage = onDownloadImage,
+                        )
                     }
                     is BrowserTabScreenState.ContextMenuState.LinkWithImage -> {
                         LinkActionButtons(
@@ -426,6 +430,11 @@ private fun ContextMenuDialog(
                             onOpenUrl = onOpenUrl,
                             onCopyLink = onCopyLink,
                         )
+                        if (enableTabUi) {
+                            TextButton(onClick = { onOpenNewTab(menu.imageSrcUrl) }) {
+                                Text(text = "画像を新しいタブで開く")
+                            }
+                        }
                         TextButton(onClick = { onDownloadImage(menu.imageSrcUrl) }) {
                             Text(text = "画像をダウンロード")
                         }
@@ -437,6 +446,30 @@ private fun ContextMenuDialog(
             }
         },
     )
+}
+
+@Composable
+private fun ImageActionButtons(
+    srcUrl: String,
+    enableTabUi: Boolean,
+    onOpenNewTab: (String) -> Unit,
+    onOpenUrl: (String) -> Unit,
+    onDownloadImage: (String) -> Unit,
+) {
+    Column {
+        if (enableTabUi) {
+            TextButton(onClick = { onOpenNewTab(srcUrl) }) {
+                Text(text = "新しいタブで開く")
+            }
+        } else {
+            TextButton(onClick = { onOpenUrl(srcUrl) }) {
+                Text(text = "開く")
+            }
+        }
+        TextButton(onClick = { onDownloadImage(srcUrl) }) {
+            Text(text = "ダウンロード")
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -434,6 +434,10 @@ private fun ContextMenuDialog(
                             TextButton(onClick = { onOpenNewTab(menu.imageSrcUrl) }) {
                                 Text(text = "画像を新しいタブで開く")
                             }
+                        } else {
+                            TextButton(onClick = { onOpenUrl(menu.imageSrcUrl) }) {
+                                Text(text = "画像を開く")
+                            }
                         }
                         TextButton(onClick = { onDownloadImage(menu.imageSrcUrl) }) {
                             Text(text = "画像をダウンロード")

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -344,6 +344,24 @@ internal class BrowserTabScreenState(
         session.loadUri(resolved)
     }
 
+    /**
+     * 現在のページを referrer に付けて URL を読み込む。
+     * コンテキストメニューの「開く」「画像を開く」から使用し、
+     * ホットリンク保護のあるサーバーで 403 にならないようにする。
+     */
+    fun openUrlWithReferrer(url: String) {
+        val referrerUrl = currentPageUrl
+        urlInput = url
+        maybeResetToolbarColor(currentPageUrl, url)
+        currentPageUrl = url
+        clearPageLoadError()
+        session.load(
+            GeckoSession.Loader()
+                .uri(url)
+                .referrer(referrerUrl),
+        )
+    }
+
     fun onHome() {
         urlInput = homepageUrl
         maybeResetToolbarColor(currentPageUrl, homepageUrl)

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -45,6 +45,7 @@ import net.matsudamper.browser.screen.browser.CustomTabScreenViewModel
 import net.matsudamper.browser.ui.common.BrowserTheme
 import org.koin.android.ext.android.inject
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoSession
 import java.util.concurrent.CancellationException
 
 class CustomTabActivity : ComponentActivity() {
@@ -279,8 +280,14 @@ private fun CustomTabScreen(
         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
         onOpenNewSessionRequest = { null },
-        onOpenNewTabRequest = { uri ->
-            activeTab.session.loadUri(uri)
+        onOpenNewTabRequest = { uri, referrerUrl ->
+            if (referrerUrl != null) {
+                activeTab.session.load(
+                    GeckoSession.Loader().uri(uri).referrer(referrerUrl),
+                )
+            } else {
+                activeTab.session.loadUri(uri)
+            }
         },
         onCloseTab = onClose,
         onHistoryRecord = uiState.callbacks::onHistoryRecord,

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -98,7 +98,7 @@ internal fun GeckoBrowserTab(
     onOpenSiteSettings: ((currentUrl: String) -> Unit)?,
     onOpenTabs: () -> Unit,
     onOpenNewSessionRequest: (String) -> GeckoSession?,
-    onOpenNewTabRequest: (String) -> Unit,
+    onOpenNewTabRequest: (url: String, referrerUrl: String?) -> Unit,
     modifier: Modifier = Modifier,
     onRequestDownloadNotificationPermission: suspend () -> Unit = {},
     enableTabUi: Boolean = true,
@@ -591,7 +591,7 @@ internal fun GeckoBrowserTab(
                             URLEncoder.encode(text, "UTF-8"),
                         )
                         if (enableTabUi) {
-                            currentOnOpenNewTabRequest(url)
+                            currentOnOpenNewTabRequest(url, null)
                         } else {
                             state.onUrlSubmit(url)
                         }
@@ -605,7 +605,7 @@ internal fun GeckoBrowserTab(
                             "https://$text"
                         }
                         if (enableTabUi) {
-                            currentOnOpenNewTabRequest(url)
+                            currentOnOpenNewTabRequest(url, null)
                         } else {
                             state.onUrlSubmit(url)
                         }

--- a/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
@@ -28,6 +28,7 @@ import net.matsudamper.browser.ui.common.BrowserTheme
 import net.matsudamper.browser.ui.browser.WebAppScreen
 import org.koin.android.ext.android.inject
 import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoSession
 import java.util.concurrent.CancellationException
 
 /**
@@ -135,8 +136,14 @@ class WebAppActivity : ComponentActivity() {
                         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
                         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
                         onOpenNewSessionRequest = { null },
-                        onOpenNewTabRequest = { uri ->
-                            browserTab.session.loadUri(uri)
+                        onOpenNewTabRequest = { uri, referrerUrl ->
+                            if (referrerUrl != null) {
+                                browserTab.session.load(
+                                    GeckoSession.Loader().uri(uri).referrer(referrerUrl),
+                                )
+                            } else {
+                                browserTab.session.loadUri(uri)
+                            }
                         },
                         onHistoryRecord = webAppUiState.callbacks::onHistoryRecord,
                         onHistoryTitleUpdate = webAppUiState.callbacks::onHistoryTitleUpdate,

--- a/app/src/main/kotlin/net/matsudamper/browser/download/GeckoDownloadHttpClient.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/download/GeckoDownloadHttpClient.kt
@@ -36,7 +36,9 @@ class GeckoDownloadHttpClient(
         val executor = GeckoWebExecutor(geckoRuntime)
         val request = WebRequest.Builder(url)
             .apply {
-                if (referrerUrl.isNotBlank()) addHeader("Referer", referrerUrl)
+                // Referer は forbidden header のため addHeader では Gecko に除去される。
+                // 専用の referrer API を使わないとホットリンク保護のあるサーバーで 403 になる
+                if (referrerUrl.isNotBlank()) referrer(referrerUrl)
                 if (rangeStart > 0) addHeader("Range", "bytes=$rangeStart-")
             }
             .build()

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserSessionController.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserSessionController.kt
@@ -79,7 +79,19 @@ class BrowserSessionLifecycleController(
                 return
             }
         }
-        tab.session.loadUri(tab.currentUrl.ifBlank { "about:blank" })
+        val referrerUrl = tab.pendingReferrerUrl
+        tab.pendingReferrerUrl = null
+        if (referrerUrl != null) {
+            // コンテキストメニューの「新しいタブで開く」由来のタブは元ページを referrer に
+            // 付けて読み込む。ホットリンク保護のあるサーバーで 403 にならないようにするため
+            tab.session.load(
+                GeckoSession.Loader()
+                    .uri(tab.currentUrl.ifBlank { "about:blank" })
+                    .referrer(referrerUrl),
+            )
+        } else {
+            tab.session.loadUri(tab.currentUrl.ifBlank { "about:blank" })
+        }
         tab.session.setActive(true)
         markActiveForExtensions(tab.session)
     }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
@@ -97,6 +97,11 @@ class BrowserTab(
     // ガードとして使い、実 URL への onLocationChange 発火でクリアされる。
     internal var pendingInitialUrl: String? by mutableStateOf(null)
 
+    // 初回読み込み時に referrer として送信する URL。コンテキストメニューの
+    // 「新しいタブで開く」で、ホットリンク保護のあるサーバーが 403 を返さないように
+    // 元ページの URL を引き継ぐために使用する。初回読み込みで消費される。
+    internal var pendingReferrerUrl: String? = null
+
     private val sessionDelegateHost = BrowserTabSessionDelegateHost(this)
 
     internal fun bindSessionDelegates() {

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
@@ -191,6 +191,7 @@ class BrowserTabController(
         restoredPreviewImage: ByteArray = byteArrayOf(),
         restoredThemeColor: Int? = null,
         openerTabId: String? = null,
+        initialReferrerUrl: String? = null,
     ): BrowserTab {
         if (!isSinglePage && restoreState != RestoreState.COMPLETED) {
             Log.w(TAG, "タブ復元完了前に createAndAppendTab が呼ばれました (状態: $restoreState)")
@@ -210,6 +211,7 @@ class BrowserTabController(
                 insertIndex = insertIndex,
             )
             tab.pendingSessionState = restoredSessionState?.takeIf { it.isNotBlank() }
+            tab.pendingReferrerUrl = initialReferrerUrl?.takeIf { it.isNotBlank() }
             val shouldSelect = selectedTabId == null
             val nextSelectedTabId = if (shouldSelect) tab.tabId else selectedTabId
             publishRuntimeState(nextSelectedTabId)


### PR DESCRIPTION
## 概要

画像を長押しした際のコンテキストメニューが「ダウンロード」のみだったため、画像を新しいタブで開くオプションを追加しました。

また、ホットリンク保護のあるサーバーで「新しいタブで開く」と「ダウンロード」が 403 で失敗する問題を修正しました（本家 Firefox では成功するケース）。

## 変更内容

### コンテキストメニューの拡充 (`BrowserTabDialogLayer.kt`)

- **画像メニュー (`ContextMenuState.Image`)**
  - 「新しいタブで開く」を先頭に追加（タブUIが無効な場合は「開く」として現在のタブで開く）
  - 「ダウンロード」は従来通り
  - 本文を「この画像をダウンロードしますか？」から画像URLの表示に変更し、リンクメニューと体裁を統一
- **リンク+画像メニュー (`ContextMenuState.LinkWithImage`)**
  - 「画像を新しいタブで開く」（タブUI無効時は「画像を開く」）を追加
  - 画像用のボタン群を `ImageActionButtons` として切り出し（`LinkActionButtons` と同じパターン）

### 403 の修正（referrer の付与）

原因は 2 つとも「Referer なしのリクエストになっていた」ことです。

| 経路 | 原因 | 修正 |
|---|---|---|
| ダウンロード | `Referer` は forbidden header のため、`WebRequest.Builder.addHeader("Referer", ...)` では Gecko (necko) に除去されて送信されない | 専用 API の `WebRequest.Builder.referrer()` に変更 (`GeckoDownloadHttpClient`) |
| 新しいタブで開く | 新規タブの初回ロードが referrer なしの `loadUri` だった | `onOpenNewTabRequest` に `referrerUrl` を追加し、`BrowserTab.pendingReferrerUrl` 経由で初回ロード時に `GeckoSession.Loader.referrer()` を付与 |
| タブUI無効時の「開く」「画像を開く」 | `onUrlSubmit` 経由で referrer なしの `loadUri` だった | referrer 付きでロードする `BrowserTabScreenState.openUrlWithReferrer()` を追加 |

referrer には元ページの URL を渡します（本家 Firefox の「画像を表示」と同じ挙動）。テキスト選択からの検索など、元ページと無関係な新規タブは従来通り referrer なしです。

## 確認

- [x] `./gradlew :app:assembleDebug` ビルド成功
- [x] `./gradlew detekt` 指摘 0 件
- [x] `./gradlew test` 全件通過

https://claude.ai/code/session_017SwQ3XK5hsoC7WbAwkqEFi

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image context menu now displays the source URL for better clarity
  * Added &#34;open in a new tab&#34; action for images when tab UI is enabled
  * Reorganized image action buttons for improved context menu usability
