### PR TITLE
iframe からの位置情報要求をトップレベルサイト基準で制御する

### DIFF
--- a/app/src/main/assets/web_extensions/mock_location_bridge/manifest.json
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mock Location Bridge",
-  "version": "1.0",
+  "version": "1.1",
   "browser_specific_settings": {
     "gecko": {
       "id": "mock-location-bridge@browsem"
@@ -18,7 +18,8 @@
       "js": [
         "content.js"
       ],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "permissions": [

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -1215,8 +1215,10 @@ internal class BrowserTabScreenState(
         val completed = AtomicBoolean(false)
         val job = coroutineScope.launch {
             // モック/拒否はコンテンツスクリプトが処理するため、Gecko 本体の位置情報は
-            // サイトごとの設定が「実際の位置情報」の場合のみ許可する
-            val host = uri?.let { extractSiteHost(it) } ?: extractSiteHost(currentPageUrl)
+            // サイトごとの設定が「実際の位置情報」の場合のみ許可する。
+            // 許可は標準ブラウザと同様にトップレベルサイト基準のため、iframe からの
+            // 要求（uri が iframe のオリジン）も表示中ページのホストで判定する
+            val host = extractSiteHost(currentPageUrl) ?: uri?.let { extractSiteHost(it) }
             val allow = host != null &&
                 runCatching { siteSettingsRepository.getGeolocationState(host) }.getOrNull() ==
                 SiteGeolocationState.SITE_GEOLOCATION_REAL

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -492,8 +492,9 @@ internal fun GeckoBrowserTab(
     }
 
     val mockLocationWebExtension: MockLocationWebExtension = koinInject()
-    DisposableEffect(session, mockLocationWebExtension) {
-        mockLocationWebExtension.registerSession(session)
+    DisposableEffect(session, state, mockLocationWebExtension) {
+        // iframe からの位置情報要求をトップレベルサイトの設定で制御するため、現在ページ URL を渡す
+        mockLocationWebExtension.registerSession(session) { state.currentPageUrl }
         onDispose {
             mockLocationWebExtension.unregisterSession(session)
         }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
@@ -32,6 +32,10 @@ class MockLocationWebExtension {
     // セッションごとの接続ポート。iframe を含む各フレームから個別に接続されるため複数保持する
     private val sessionPorts = ConcurrentHashMap<GeckoSession, MutableSet<WebExtension.Port>>()
 
+    // セッションごとのトップレベルページ URL プロバイダ。
+    // iframe からの要求をトップレベルサイトの設定で制御するために使う
+    private val sessionTopUrlProviders = ConcurrentHashMap<GeckoSession, () -> String?>()
+
     // デリゲートを設定済みのセッションを追跡（二重設定を防ぐ）
     private val attachedSessions: MutableSet<GeckoSession> =
         Collections.newSetFromMap(ConcurrentHashMap())
@@ -55,7 +59,8 @@ class MockLocationWebExtension {
             )
     }
 
-    fun registerSession(session: GeckoSession) {
+    fun registerSession(session: GeckoSession, topUrlProvider: () -> String?) {
+        sessionTopUrlProviders[session] = topUrlProvider
         attachedSessions.add(session)
         extension?.also { ext ->
             attachSessionDelegate(session, ext)
@@ -65,6 +70,7 @@ class MockLocationWebExtension {
     fun unregisterSession(session: GeckoSession) {
         attachedSessions.remove(session)
         sessionPorts.remove(session)
+        sessionTopUrlProviders.remove(session)
         extension?.let { ext ->
             session.webExtensionController.setMessageDelegate(ext, null, NATIVE_APP_ID)
         }
@@ -73,12 +79,14 @@ class MockLocationWebExtension {
     /** 位置情報設定を更新し、接続済みの全セッションへ各ホストに応じたモードを通知する */
     fun updateConfig(config: GeolocationConfig) {
         currentConfig = config
-        sessionPorts.values.flatten().forEach { port ->
-            val message = buildConfigMessage(portHost(port), action = "update")
-            try {
-                port.postMessage(message)
-            } catch (e: Exception) {
-                Log.w(TAG, "updateConfig: ポートへの送信に失敗", e)
+        sessionPorts.forEach { (session, ports) ->
+            ports.forEach { port ->
+                val message = buildConfigMessage(resolveHost(session, port), action = "update")
+                try {
+                    port.postMessage(message)
+                } catch (e: Exception) {
+                    Log.w(TAG, "updateConfig: ポートへの送信に失敗", e)
+                }
             }
         }
     }
@@ -86,6 +94,19 @@ class MockLocationWebExtension {
     /** 接続元ページの URL からホスト名を取り出す */
     private fun portHost(port: WebExtension.Port): String? {
         return runCatching { URI(port.sender.url) }.getOrNull()?.host
+    }
+
+    /**
+     * ポートに適用するホストを返す。
+     * 標準ブラウザの位置情報許可と同様にトップレベルサイト基準で制御するため、
+     * iframe からの接続にはトップレベルページのホストを使う。
+     */
+    private fun resolveHost(session: GeckoSession, port: WebExtension.Port): String? {
+        val senderHost = portHost(port)
+        if (port.sender.isTopLevel) return senderHost
+        val topUrl = sessionTopUrlProviders[session]?.invoke()
+        val topHost = topUrl?.let { runCatching { URI(it) }.getOrNull()?.host }
+        return topHost ?: senderHost
     }
 
     /** ホストに応じた設定メッセージを構築する */
@@ -121,7 +142,8 @@ class MockLocationWebExtension {
                             val json = message as? JSONObject ?: return
                             when (json.optString("action")) {
                                 "getConfig" -> {
-                                    val response = buildConfigMessage(portHost(port), action = "config")
+                                    val response =
+                                        buildConfigMessage(resolveHost(session, port), action = "config")
                                     try {
                                         port.postMessage(response)
                                     } catch (e: Exception) {
@@ -131,7 +153,7 @@ class MockLocationWebExtension {
                                 // ページが位置情報を要求したことの通知。
                                 // 「サイトの設定」画面に位置情報の項目を表示するために記録する
                                 "geolocationRequested" -> {
-                                    val host = portHost(port) ?: return
+                                    val host = resolveHost(session, port) ?: return
                                     onGeolocationRequested?.invoke(host)
                                 }
                             }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/MockLocationWebExtension.kt
@@ -29,8 +29,8 @@ class MockLocationWebExtension {
     /** ページが位置情報を要求した際にホスト名を通知するコールバック */
     @Volatile var onGeolocationRequested: ((host: String) -> Unit)? = null
 
-    // セッションごとの接続ポート
-    private val sessionPorts = ConcurrentHashMap<GeckoSession, WebExtension.Port>()
+    // セッションごとの接続ポート。iframe を含む各フレームから個別に接続されるため複数保持する
+    private val sessionPorts = ConcurrentHashMap<GeckoSession, MutableSet<WebExtension.Port>>()
 
     // デリゲートを設定済みのセッションを追跡（二重設定を防ぐ）
     private val attachedSessions: MutableSet<GeckoSession> =
@@ -73,7 +73,7 @@ class MockLocationWebExtension {
     /** 位置情報設定を更新し、接続済みの全セッションへ各ホストに応じたモードを通知する */
     fun updateConfig(config: GeolocationConfig) {
         currentConfig = config
-        sessionPorts.values.forEach { port ->
+        sessionPorts.values.flatten().forEach { port ->
             val message = buildConfigMessage(portHost(port), action = "update")
             try {
                 port.postMessage(message)
@@ -112,9 +112,9 @@ class MockLocationWebExtension {
 
                 override fun onConnect(port: WebExtension.Port) {
                     Log.d(TAG, "onConnect: ポート接続")
-                    sessionPorts[session] = port
-                    // ナビゲーション/リロード時に新しいポートが先に sessionPorts に書き込まれた後で
-                    // 古いポートの onDisconnect が発火する場合があるため、自分のポートのみ削除する。
+                    sessionPorts
+                        .getOrPut(session) { Collections.newSetFromMap(ConcurrentHashMap()) }
+                        .add(port)
                     val connectedPort = port
                     port.setDelegate(object : WebExtension.PortDelegate {
                         override fun onPortMessage(message: Any, port: WebExtension.Port) {
@@ -139,7 +139,7 @@ class MockLocationWebExtension {
 
                         override fun onDisconnect(port: WebExtension.Port) {
                             Log.d(TAG, "onDisconnect: ポート切断")
-                            sessionPorts.remove(session, connectedPort)
+                            sessionPorts[session]?.remove(connectedPort)
                         }
                     })
                 }


### PR DESCRIPTION
## 概要

https://www.au.com/mobile/area/map/ のように、地図本体をクロスオリジン iframe（`https://area.uqcom.jp/v3/`、`allow="geolocation"` 付き）で埋め込んでいるサイトで、位置情報が取得できず「権限要求も出ない・サイトの設定にも出ない」問題を修正しました。

## 原因

- `mock_location_bridge` のコンテンツスクリプトがトップフレームにしか注入されず（`all_frames` 未指定）、iframe 内の `navigator.geolocation` は差し替えられないまま Gecko 本体の位置情報パスに到達していた
- Gecko 本体パスはサイト設定が「実際の位置情報」のときのみ許可する設計のため、未設定サイトはプロンプトなしで拒否され、サイト側に「位置情報が取得できなかった」と表示されていた
- 要求の記録（サイトの設定への表示）もコンテンツスクリプト経由のため発火しなかった

## 主な変更

### iframe へのコンテンツスクリプト注入
- manifest に `all_frames: true` を追加（バージョン 1.0 → 1.1）
- 各フレームから個別にポート接続されるため、`sessionPorts` をセッションごとに複数ポート保持できる構造（`ConcurrentHashMap<GeckoSession, MutableSet<Port>>`）に変更

### トップレベルサイト基準の制御
標準ブラウザ（Chrome / Firefox）の位置情報許可と同様に、iframe からの要求は埋め込み元（トップレベルサイト）の設定で制御する方式に変更。

- `MockLocationWebExtension.registerSession` にトップレベルページ URL のプロバイダを追加し、iframe からの接続（`sender.isTopLevel == false`）はモード解決（mock/deny/real）・要求記録・設定更新の再配信のすべてでトップレベルページのホストを使用
- Gecko 本体へ到達するパス（「実際の位置情報」設定時）の REAL 判定も、要求元 URI より表示中ページのホストを優先

## 動作

au のエリアマップを開いて地図が位置情報を要求すると、`www.au.com` のサイト設定に位置情報の項目が表示され、モック / ブロック / 実際の位置情報を切り替えると iframe 内の地図にも反映されます。

https://claude.ai/code/session_01QbUiQ9yDSTSJGEZTSNemuC