### PR TITLE
画像を新しいタブで開いた際に小さく低解像度で表示される問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -558,6 +558,34 @@ internal fun GeckoBrowserTab(
         }
     }
 
+    // 新規タブの初回ロードは GeckoView のサイズ確定後に実行する。
+    // setSession 直後の未確定 viewport でロードすると、画像単体表示 (ImageDocument) の
+    // shrink-to-fit スケールが誤計算され、画像が小さく低解像度で表示されるため。
+    // geckoView は AndroidView factory で後から確定するので key にして再起動させる。
+    LaunchedEffect(session, browserTab, geckoView) {
+        val gv = geckoView ?: return@LaunchedEffect
+        if (!browserSessionLifecycleController.hasPendingInitialLoad(browserTab)) {
+            return@LaunchedEffect
+        }
+        val startTimeMs = SystemClock.elapsedRealtime()
+        fun scheduleInitialLoad() {
+            gv.postOnAnimation {
+                if (!browserSessionLifecycleController.hasPendingInitialLoad(browserTab)) {
+                    return@postOnAnimation
+                }
+                val elapsed = SystemClock.elapsedRealtime() - startTimeMs
+                // サイズ未確定の間は次フレームへ持ち越す。レイアウトが進まない異常系で
+                // 白画面のままにならないよう STABLE_TIMEOUT_MS 経過後は強制ロードする
+                if ((gv.width == 0 || gv.height == 0) && elapsed < STABLE_TIMEOUT_MS) {
+                    scheduleInitialLoad()
+                    return@postOnAnimation
+                }
+                browserSessionLifecycleController.performInitialLoadIfPending(browserTab)
+            }
+        }
+        scheduleInitialLoad()
+    }
+
     // テキスト選択メニューにカスタムアクション（検索/開く）を追加
     DisposableEffect(session, enableTabUi, searchTemplate) {
         val activity = context as Activity

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserSessionController.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserSessionController.kt
@@ -79,6 +79,27 @@ class BrowserSessionLifecycleController(
                 return
             }
         }
+        // 初回ロードは GeckoView の Surface サイズ確定後まで遅延する。
+        // 未確定 viewport でロードすると ImageDocument (画像単体表示) の
+        // shrink-to-fit スケールが誤計算され、画像が小さく低解像度で表示されるため。
+        // performInitialLoadIfPending がサイズ確定検知後に呼ばれてロードを実行する。
+        tab.pendingInitialLoad = true
+        tab.session.setActive(true)
+        markActiveForExtensions(tab.session)
+    }
+
+    /** restoreSession で遅延された初回ロードが未実行かどうかを返す */
+    fun hasPendingInitialLoad(tab: BrowserTab): Boolean = tab.pendingInitialLoad
+
+    /**
+     * restoreSession で遅延された初回ロードを実行する。
+     * GeckoView のサイズ確定後（width/height > 0）に app 層から呼ばれることを想定。
+     */
+    fun performInitialLoadIfPending(tab: BrowserTab) {
+        if (!tab.pendingInitialLoad) return
+        // サイズ確定待ちの間にタブが閉じられた場合は何もしない
+        if (!tab.session.isOpen) return
+        tab.pendingInitialLoad = false
         val referrerUrl = tab.pendingReferrerUrl
         tab.pendingReferrerUrl = null
         if (referrerUrl != null) {
@@ -92,8 +113,6 @@ class BrowserSessionLifecycleController(
         } else {
             tab.session.loadUri(tab.currentUrl.ifBlank { "about:blank" })
         }
-        tab.session.setActive(true)
-        markActiveForExtensions(tab.session)
     }
 
     /**

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
@@ -112,6 +112,12 @@ class BrowserTab(
     // 元ページの URL を引き継ぐために使用する。初回読み込みで消費される。
     internal var pendingReferrerUrl: String? = null
 
+    // 初回ロードを GeckoView の Surface サイズ確定後まで遅延するための目印。
+    // 未確定 viewport でロードすると ImageDocument の shrink-to-fit スケールが
+    // 誤計算され、画像が小さく低解像度で表示されるのを回避する。
+    // restoreSession で立ち、performInitialLoadIfPending で消費される。
+    internal var pendingInitialLoad: Boolean = false
+
     private val sessionDelegateHost = BrowserTabSessionDelegateHost(this)
 
     internal fun bindSessionDelegates() {

--- a/browser-engine-gecko/src/test/kotlin/net/matsudamper/browser/BrowserSessionLifecycleControllerTest.kt
+++ b/browser-engine-gecko/src/test/kotlin/net/matsudamper/browser/BrowserSessionLifecycleControllerTest.kt
@@ -54,17 +54,82 @@ class BrowserSessionLifecycleControllerTest {
         verify(exactly = 0) { session.loadUri(any<String>()) }
     }
 
+    /**
+     * 初回ロードは GeckoView のサイズ確定後まで遅延する。
+     * 未確定 viewport でロードすると ImageDocument の shrink-to-fit スケールが
+     * 誤計算され、画像が小さく低解像度で表示されるため。
+     */
     @Test
-    fun `未オープンの通常タブは open して currentUrl を読み込む`() {
+    fun `未オープンの通常タブは open するが初回ロードはサイズ確定まで遅延する`() {
         val runtime = mockk<GeckoRuntime>(relaxed = true)
         val session = mockk<GeckoSession>(relaxed = true)
         every { session.isOpen } returns false
         val tab = createTab(session)
         tab.currentUrl = "https://example.com/"
+        val controller = BrowserSessionLifecycleController(runtime)
 
-        BrowserSessionLifecycleController(runtime).restoreSession(tab)
+        controller.restoreSession(tab)
 
         verify { session.open(runtime) }
+        verify(exactly = 0) { session.loadUri(any<String>()) }
+        verify { session.setActive(true) }
+
+        // サイズ確定後に performInitialLoadIfPending で currentUrl が読み込まれる
+        every { session.isOpen } returns true
+        controller.performInitialLoadIfPending(tab)
+
         verify { session.loadUri("https://example.com/") }
+    }
+
+    @Test
+    fun `referrer 付きの遅延初回ロードは load(Loader) で読み込まれる`() {
+        val runtime = mockk<GeckoRuntime>(relaxed = true)
+        val session = mockk<GeckoSession>(relaxed = true)
+        every { session.isOpen } returns false
+        val tab = createTab(session)
+        tab.currentUrl = "https://example.com/image.png"
+        tab.pendingReferrerUrl = "https://example.com/page"
+        val controller = BrowserSessionLifecycleController(runtime)
+
+        controller.restoreSession(tab)
+        every { session.isOpen } returns true
+        controller.performInitialLoadIfPending(tab)
+
+        verify { session.load(any()) }
+        verify(exactly = 0) { session.loadUri(any<String>()) }
+    }
+
+    @Test
+    fun `初回ロードは一度しか実行されない`() {
+        val runtime = mockk<GeckoRuntime>(relaxed = true)
+        val session = mockk<GeckoSession>(relaxed = true)
+        every { session.isOpen } returns false
+        val tab = createTab(session)
+        tab.currentUrl = "https://example.com/"
+        val controller = BrowserSessionLifecycleController(runtime)
+
+        controller.restoreSession(tab)
+        every { session.isOpen } returns true
+        controller.performInitialLoadIfPending(tab)
+        controller.performInitialLoadIfPending(tab)
+
+        verify(exactly = 1) { session.loadUri("https://example.com/") }
+    }
+
+    @Test
+    fun `サイズ確定待ち中にタブが閉じられた場合はロードしない`() {
+        val runtime = mockk<GeckoRuntime>(relaxed = true)
+        val session = mockk<GeckoSession>(relaxed = true)
+        every { session.isOpen } returns false
+        val tab = createTab(session)
+        tab.currentUrl = "https://example.com/"
+        val controller = BrowserSessionLifecycleController(runtime)
+
+        controller.restoreSession(tab)
+        // session.isOpen が false のまま（閉じられた状態）
+        controller.performInitialLoadIfPending(tab)
+
+        verify(exactly = 0) { session.loadUri(any<String>()) }
+        verify(exactly = 0) { session.load(any()) }
     }
 }


### PR DESCRIPTION
## 概要

#432 で追加した「新しいタブで開く」で画像 URL を開くと、黒背景の中央に画像が小さく低解像度（ガビガビ）で表示され、リロードすると正しく表示される問題を修正します。

## 原因

新規タブの初回ロードは `GeckoView.setSession()` 直後の `restoreSession` で実行されますが、この時点では GeckoView の Surface サイズが未確定です。Gecko の画像単体表示（ImageDocument）はロード時に一度だけ shrink-to-fit スケールを計算するため、未確定 viewport を基準にスケールが誤計算され、その後正しいサイズになっても再レイアウトされません。リロードはサイズ確定後の再ロードなので直ります。

## 変更内容

初回ロードを GeckoView のサイズ確定（width/height > 0）後まで遅延します。

- `BrowserSessionController` (browser-engine-gecko)
  - `restoreSession` は `open` + `setActive` までにとどめ、`BrowserTab.pendingInitialLoad` を立てる
  - ロード本体（referrer 付き `load` / `loadUri`）は新メソッド `performInitialLoadIfPending` に分離。サイズ確定待ち中にタブが閉じられた場合はロードしない
- `GeckoBrowserTab` (app)
  - `LaunchedEffect(session, browserTab, geckoView)` で、既存の `scheduleStableSizeAttach` と同じ `postOnAnimation` パターンによりサイズ確定を待ってから `performInitialLoadIfPending` を呼ぶ
  - レイアウトが進まない異常系で白画面にならないよう `STABLE_TIMEOUT_MS`（1000ms）経過後は強制ロード

## デグレ防止

| 経路 | 影響 |
|---|---|
| タブ復元（pendingSessionState） | `restoreState` 経路は従来どおり即実行 |
| target=_blank / window.open（pendingInitialUrl） | 早期 return のまま。Google Pay 等のポップアップ決済に影響なし |
| 既存タブ表示・切替（session.isOpen） | 早期 return のまま |

`BrowserSessionLifecycleControllerTest` に遅延ロードの状態遷移（遅延・referrer 付きロード・二重実行防止・クローズ時スキップ）のテストを追加しています。

## 確認

- [x] `./gradlew :app:assembleDebug` ビルド成功
- [x] `./gradlew detekt` 指摘 0 件
- [x] `./gradlew test` 全件通過（追加テスト含む）
- [ ] 実機確認: 画像を「新しいタブで開く」で初回から正しいスケール・解像度で表示されること

https://claude.ai/code/session_017SwQ3XK5hsoC7WbAwkqEFi

---
_Generated by [Claude Code](https://claude.ai/code/session_017SwQ3XK5hsoC7WbAwkqEFi)_