### PR TITLE
ダウンロード管理を設定画面からタブメニューに移動

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -343,6 +343,11 @@ private fun BrowserAppContent(
                                     onInstallExtensionRequest = onInstallExtensionRequest,
                                     onRequestDownloadNotificationPermission = onRequestDownloadNotificationPermission,
                                     onOpenSettings = { backStack.add(AppDestination.Settings) },
+                                    onOpenDownloads = {
+                                        if (backStack.none { it is AppDestination.Downloads }) {
+                                            backStack.add(AppDestination.Downloads)
+                                        }
+                                    },
                                     onOpenSiteSettings = { currentUrl ->
                                         val host = extractSiteHost(currentUrl)
                                         if (host != null) {
@@ -435,7 +440,6 @@ private fun BrowserAppContent(
                                 uiState = uiState,
                                 onOpenExtensions = { backStack.add(AppDestination.Extensions) },
                                 onOpenHistory = { backStack.add(AppDestination.History) },
-                                onOpenDownloads = { backStack.add(AppDestination.Downloads) },
                                 onBack = { backStack.removeLastOrNull() },
                             )
                         }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -115,6 +115,7 @@ internal fun BrowserToolBar(
     onHorizontalDrag: (Float) -> Unit = {},
     onHorizontalDragEnd: () -> Unit = {},
     onOpenSiteSettings: (() -> Unit)? = null,
+    onOpenDownloads: (() -> Unit)? = null,
 ) {
     var visibleMenu by remember { mutableStateOf(false) }
     BrowserToolbar(
@@ -179,6 +180,7 @@ internal fun BrowserToolBar(
                 onPageZoomOut = onPageZoomOut,
                 onResetPageZoom = onResetPageZoom,
                 onOpenSiteSettings = onOpenSiteSettings,
+                onOpenDownloads = onOpenDownloads,
             )
         }
     )

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
@@ -67,6 +67,7 @@ internal fun ToolbarMenu(
     showHome: Boolean = true,
     onOpenInBrowser: (() -> Unit)? = null,
     onOpenSiteSettings: (() -> Unit)? = null,
+    onOpenDownloads: (() -> Unit)? = null,
 ) {
     DropdownMenu(
         expanded = visibleMenu,
@@ -100,6 +101,7 @@ internal fun ToolbarMenu(
             showHome = showHome,
             onOpenInBrowser = onOpenInBrowser,
             onOpenSiteSettings = onOpenSiteSettings,
+            onOpenDownloads = onOpenDownloads,
         )
     }
 }
@@ -134,6 +136,7 @@ private fun ToolbarMenuContent(
     showHome: Boolean,
     onOpenInBrowser: (() -> Unit)?,
     onOpenSiteSettings: (() -> Unit)?,
+    onOpenDownloads: (() -> Unit)?,
 ) {
     Column {
         Row(
@@ -260,8 +263,8 @@ private fun ToolbarMenuContent(
                 )
             }
         }
-        // 二段目: ホームとサイトの設定を中央寄せで表示
-        if (showHome || onOpenSiteSettings != null) {
+        // 二段目: ホーム・ダウンロード・サイトの設定を中央寄せで表示
+        if (showHome || onOpenDownloads != null || onOpenSiteSettings != null) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -285,6 +288,27 @@ private fun ToolbarMenuContent(
                         }
                         Text(
                             text = "ホーム",
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
+                }
+                if (onOpenDownloads != null) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        IconButton(
+                            modifier = Modifier
+                                .testTag(BrowserToolbarMenuTestTags.DownloadsButton.testTag),
+                            onClick = {
+                                onDismissRequest()
+                                onOpenDownloads()
+                            },
+                        ) {
+                            Icon(
+                                painter = painterResource(ResourcesR.drawable.ic_download_24dp),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = "ダウンロード",
                             style = MaterialTheme.typography.labelSmall,
                         )
                     }
@@ -523,6 +547,7 @@ private fun PreviewToolbarMenuContent() {
                 showHome = true,
                 onOpenInBrowser = null,
                 onOpenSiteSettings = {},
+                onOpenDownloads = {},
             )
         }
     }
@@ -537,5 +562,6 @@ sealed interface BrowserToolbarMenuTestTags {
     object RefreshButton : BrowserToolbarMenuTestTags { override val id = "refresh_button" }
     object FindInPageButton : BrowserToolbarMenuTestTags { override val id = "find_in_page_button" }
     object SiteSettingsButton : BrowserToolbarMenuTestTags { override val id = "site_settings_button" }
+    object DownloadsButton : BrowserToolbarMenuTestTags { override val id = "downloads_button" }
     object HomeButton : BrowserToolbarMenuTestTags { override val id = "home_button" }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -271,6 +271,7 @@ private fun CustomTabScreen(
         onOpenSettings = {},
         // カスタムタブは設定画面のナビゲーションスタックを持たないため非表示
         onOpenSiteSettings = null,
+        onOpenDownloads = null,
         onOpenTabs = {},
         enableTabUi = false,
         showInstallExtensionItem = false,

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -96,6 +96,7 @@ internal fun GeckoBrowserTab(
     onInstallExtensionRequest: (String) -> Unit,
     onOpenSettings: () -> Unit,
     onOpenSiteSettings: ((currentUrl: String) -> Unit)?,
+    onOpenDownloads: (() -> Unit)?,
     onOpenTabs: () -> Unit,
     onOpenNewSessionRequest: (String) -> GeckoSession?,
     onOpenNewTabRequest: (url: String, referrerUrl: String?) -> Unit,
@@ -786,6 +787,7 @@ internal fun GeckoBrowserTab(
                     onOpenSiteSettings = onOpenSiteSettings?.let { callback ->
                         { callback(state.currentPageUrl) }
                     },
+                    onOpenDownloads = onOpenDownloads,
                     onShare = state::sharePage,
                     tabCount = tabCount,
                     showTabActions = enableTabUi,

--- a/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
@@ -128,6 +128,7 @@ class WebAppActivity : ComponentActivity() {
                         onOpenSettings = {},
                         // ウェブアプリモードは設定画面のナビゲーションスタックを持たないため非表示
                         onOpenSiteSettings = null,
+                        onOpenDownloads = null,
                         onOpenTabs = {},
                         enableTabUi = false,
                         showInstallExtensionItem = false,

--- a/resources/src/main/res/drawable/ic_download_24dp.xml
+++ b/resources/src/main/res/drawable/ic_download_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M480,640L280,440L336,382L440,486L440,160L520,160L520,486L624,382L680,440L480,640ZM240,800Q207,800 183.5,776.5Q160,753 160,720L160,600L240,600L240,720Q240,720 240,720Q240,720 240,720L720,720Q720,720 720,720Q720,720 720,720L720,600L800,600L800,720Q800,753 776.5,776.5Q753,800 720,800L240,800Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -52,7 +52,6 @@ fun SettingsScreen(
     uiState: SettingsScreenUiState,
     onOpenExtensions: () -> Unit,
     onOpenHistory: () -> Unit,
-    onOpenDownloads: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -310,17 +309,6 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(betweenPadding))
 
-            SettingSection(title = "ダウンロード") {
-                TextButton(
-                    onClick = onOpenDownloads,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text("ダウンロード管理")
-                }
-            }
-
-            Spacer(Modifier.height(betweenPadding))
-
             SettingSection(title = "バックアップ") {
                 Column {
                     Text(
@@ -465,7 +453,6 @@ private fun SettingsScreenPreview() {
             ),
             onOpenExtensions = {},
             onOpenHistory = {},
-            onOpenDownloads = {},
             onBack = {},
         )
     }

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -417,7 +417,8 @@ internal fun SettingSection(
     }
 }
 
-@Preview(showBackground = true)
+// 設定項目が縦に長いため、全体が見えるように高さを広げて Preview する
+@Preview(showBackground = true, heightDp = 2400)
 @Composable
 private fun SettingsScreenPreview() {
     MaterialTheme {


### PR DESCRIPTION
## 概要

ダウンロード管理画面への導線を設定画面から削除し、タブのツールバーメニュー二段目の「ホーム」と「サイトの設定」の間に移動しました。

## 変更内容

- `ToolbarMenu` の二段目（ホーム/サイトの設定の行）にダウンロードボタンを追加
  - アイコンは Google Fonts (Material Symbols) の `download` を Vector Drawable として `ic_download_24dp.xml` に追加（Compose Material Icons Extended は不使用）
  - `BrowserApp` から `GeckoBrowserTab` → `BrowserToolBar` → `ToolbarMenu` へ `onOpenDownloads` を配線し、タップで `AppDestination.Downloads` へ遷移
  - カスタムタブ・ウェブアプリモードでは `null` を渡して非表示
- 設定画面の「ダウンロード」セクション（ダウンロード管理ボタン）を削除

## スクリーンショット (Paparazzi)

| ツールバーメニュー |
|---|
| ホームとサイトの設定の間にダウンロードが表示されます |

## 確認

- `./gradlew :app:assembleDebug` ✅
- `./gradlew detekt` ✅
- `./gradlew test` ✅
- Paparazzi スナップショットで表示確認 ✅

https://claude.ai/code/session_01Mg2tosmoXuAuczLuVos5dL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg2tosmoXuAuczLuVos5dL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Downloads button to the toolbar menu with a dedicated icon.

* **Bug Fixes**
  * Fixed duplicate navigation entries when repeatedly accessing the Downloads section.

* **Changes**
  * Removed Downloads option from the Settings screen and relocated it to the toolbar menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->