### PR TITLE
プレビューキャプチャを毎回更新するよう改善

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -272,9 +272,10 @@ internal class BrowserTabScreenState(
 
     var renderReady by mutableStateOf(false)
 
-    // プレビュー画像が未取得の状態でページロードが完了した際にインクリメントされるカウンター。
-    // GeckoBrowserTab がこの値を監視してキャプチャをトリガーする。
-    var captureOnPageLoadRequestCount by mutableIntStateOf(0)
+    // ページの初回描画・ロード完了の度にインクリメントされるカウンター。
+    // GeckoBrowserTab がこの値を監視してプレビューキャプチャをトリガーする。
+    // ドメイン遷移後も古いプレビューが残らないよう、プレビュー取得済みでも毎回更新する。
+    var capturePreviewRequestCount by mutableIntStateOf(0)
         private set
 
     // プレビューキャプチャの可否を表すフラグ。
@@ -1029,6 +1030,10 @@ internal class BrowserTabScreenState(
     override fun onPreviewCaptureReady() {
         renderReady = true
         previewCaptureReady = true
+        // 新ページの初回描画 (onFirstContentfulPaint) 時点でキャプチャを更新する。
+        // ロード完了 (onPageStop) まで待つと、ロードの長いページでタブ切替した際に
+        // 前のページ（別ドメイン）のプレビューが表示され続けるため。
+        capturePreviewRequestCount++
     }
 
     override fun onExternalResponse(response: WebResponse) {
@@ -1061,10 +1066,10 @@ internal class BrowserTabScreenState(
         // ページロード完了時点でキャプチャを許可する。これがないと previewCaptureReady が
         // false のまま戻らず、以降のタブのキャプチャが全て拒否される。
         previewCaptureReady = true
-        // プレビュー画像がまだない場合はページロード完了時にキャプチャをリクエストする
-        if (browserTab.previewBitmap == null || browserTab.previewBitmap!!.isEmpty()) {
-            captureOnPageLoadRequestCount++
-        }
+        // ページロード完了時に毎回キャプチャをリクエストする。
+        // 「プレビュー未取得時のみ」に絞ると、別ドメインへ遷移しても古いプレビューが
+        // 残り続けるため、取得済みでも常に最新の表示内容で上書きする。
+        capturePreviewRequestCount++
         if (success) {
             fetchFavicon(currentPageUrl)
             // ページ遷移後もズームを維持する

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -241,9 +241,9 @@ internal fun GeckoBrowserTab(
         geckoView?.requestFocus()
     }
 
-    // プレビュー画像未取得時にページロードが完了したらキャプチャを実行する
+    // ページの初回描画・ロード完了の度にプレビューキャプチャを実行する
     LaunchedEffect(state) {
-        snapshotFlow { state.captureOnPageLoadRequestCount }
+        snapshotFlow { state.capturePreviewRequestCount }
             .collectLatest { count ->
                 if (count == 0) return@collectLatest
                 /**


### PR DESCRIPTION
## 概要
ページロード時のプレビューキャプチャ戦略を変更し、ドメイン遷移後に古いプレビューが残る問題を解決しました。

## 主な変更

- **変数名の変更**: `captureOnPageLoadRequestCount` → `capturePreviewRequestCount`
  - 変数の役割をより正確に反映するため、「ページロード完了時のみ」から「初回描画・ロード完了の度に」実行するよう意味を拡張

- **キャプチャタイミングの追加**: `onPreviewCaptureReady()` で初回描画時にもキャプチャをリクエスト
  - 従来はページロード完了(`onPageStop`)まで待っていたが、ロード時間が長いページでタブ切替した際に前ページのプレビューが表示され続ける問題が発生
  - 初回描画(`onFirstContentfulPaint`)時点で即座にキャプチャを更新することで、より迅速にプレビューを反映

- **条件判定の削除**: `onPageStop()` でプレビュー未取得時のみという条件を廃止
  - 別ドメインへ遷移しても古いプレビューが残り続ける問題を解決するため、取得済みでも常に最新の表示内容で上書きするよう変更

- **コメント更新**: 各処理の意図をより詳細に説明するコメントに更新

## 実装の詳細
- `BrowserTabScreenState.kt`: キャプチャリクエストカウンターの管理ロジックを更新
- `GeckoBrowserTab.kt`: 監視対象の状態変数を新しい名前に変更

https://claude.ai/code/session_01KhqGhjmArf4UbwnKrVDHcx