### PR TITLE
InputResultDetail の全情報で PullToRefresh の発動可否を判定する

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -318,10 +318,6 @@ internal class BrowserTabScreenState(
 
     // --- Scroll / Refresh state ---
     var visualViewportScale by mutableFloatStateOf(1f)
-    // ピンチジェスチャー検出フラグ。JS管理のズーム（Xの画像ビューアー等）では
-    // visualViewport.scaleが1.0のままなので、ピンチ操作自体を記録して
-    // 後続のパンジェスチャーでPullToRefreshが誤発動しないようにする。
-    var hadPinchGesture by mutableStateOf(false)
     var isRefreshing by mutableStateOf(false)
     // BrowserTab.scrollY に委譲することで、タブ切替で State が再生成されても
     // スクロール位置を保持し、復元タブでの PullToRefresh 誤発動を防ぐ。
@@ -929,8 +925,10 @@ internal class BrowserTabScreenState(
             return
         }
         if (url.startsWith("javascript:")) return
-        hadPinchGesture = false
-        visualViewportScale = 1f
+        // visualViewportScale はここではリセットしない。SPA の pushState 遷移
+        // （X のタブ内遷移等）ではピンチズームが維持されたまま onLocationChange が
+        // 発火するため、リセットすると拡大中なのに PullToRefresh が許可されてしまう。
+        // フルページロードでは onPageStart でリセットされる。
         if (pageLoadError?.failingUrl != url) {
             clearPageLoadError()
         }
@@ -1045,7 +1043,6 @@ internal class BrowserTabScreenState(
 
     override fun onPageStart(url: String) {
         clearPageLoadError()
-        hadPinchGesture = false
         visualViewportScale = 1f
         // previewCaptureReady は false に戻さない。
         // GeckoView は新ページの描画が始まるまで古いページを表示し続けるため、

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
@@ -49,7 +49,6 @@ import net.matsudamper.browser.ui.browser.UrlBarSuggestionsUiState
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoView
-import org.mozilla.geckoview.PanZoomController
 
 @Composable
 internal fun BrowserContentHost(
@@ -69,6 +68,10 @@ internal fun BrowserContentHost(
             factory = { context ->
                 GeckoSwipeRefreshLayout(context).also { swipeRefreshLayout ->
                     var swipeRefreshScrollEnabled = false
+                    // ピンチ等のマルチタッチジェスチャー中は PTR を発動させないための
+                    // ジェスチャー単位のフラグ。ACTION_DOWN の非同期判定結果が
+                    // ACTION_POINTER_DOWN より後に届いても上書きされないようにする。
+                    var gestureHadMultiTouch = false
                     val gecko = GeckoView(context).also { geckoView ->
                         geckoView.id = id
                         geckoView.isNestedScrollingEnabled = true
@@ -84,19 +87,22 @@ internal fun BrowserContentHost(
                             when (event.actionMasked) {
                                 MotionEvent.ACTION_DOWN -> {
                                     swipeRefreshScrollEnabled = false
+                                    gestureHadMultiTouch = false
                                     (view as GeckoView).onTouchEventForDetailResult(event).then { detail ->
-                                        if (detail != null) {
-                                            val handledResult = detail.handledResult()
-                                            val isUnhandled = handledResult == PanZoomController.INPUT_RESULT_UNHANDLED
-                                            val isHandled = handledResult == PanZoomController.INPUT_RESULT_HANDLED
-                                            swipeRefreshScrollEnabled = isHandled || isUnhandled
+                                        if (detail != null && !gestureHadMultiTouch) {
+                                            swipeRefreshScrollEnabled = canTriggerPullToRefresh(
+                                                handledResult = detail.handledResult(),
+                                                scrollableDirections = detail.scrollableDirections(),
+                                                overscrollDirections = detail.overscrollDirections(),
+                                            )
                                         }
                                         GeckoResult.fromValue<Void>(null)
                                     }
                                     true
                                 }
                                 MotionEvent.ACTION_POINTER_DOWN -> {
-                                    state.hadPinchGesture = true
+                                    gestureHadMultiTouch = true
+                                    swipeRefreshScrollEnabled = false
                                     false
                                 }
                                 else -> false
@@ -114,7 +120,6 @@ internal fun BrowserContentHost(
                     swipeRefreshLayout.setOnChildScrollUpCallback { _, _ ->
                         !swipeRefreshScrollEnabled || state.scrollY > 0
                             || state.visualViewportScale > 1.05f
-                            || state.hadPinchGesture
                     }
                     swipeRefreshLayout.setOnRefreshListener {
                         state.isRefreshing = true

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -505,9 +505,6 @@ internal fun GeckoBrowserTab(
     DisposableEffect(session, state, viewportScaleWebExtension) {
         viewportScaleWebExtension.registerSession(session) { scale ->
             state.visualViewportScale = scale
-            if (scale <= 1.05f) {
-                state.hadPinchGesture = false
-            }
         }
         onDispose {
             viewportScaleWebExtension.unregisterSession(session)

--- a/app/src/main/kotlin/net/matsudamper/browser/PullToRefreshPolicy.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/PullToRefreshPolicy.kt
@@ -1,0 +1,33 @@
+package net.matsudamper.browser
+
+import org.mozilla.geckoview.PanZoomController
+
+/**
+ * ACTION_DOWN 時の [PanZoomController.InputResultDetail] から
+ * PullToRefresh を発動させてよいタッチかを判定する。
+ *
+ * Fenix (android-components) の InputResultDetail.canOverscrollTop() と同等のロジック。
+ * https://github.com/mozilla-firefox/firefox/blob/main/mobile/android/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/InputResultDetail.kt
+ *
+ * - コンテンツ (JS) がタッチを消費する場合 (preventDefault / touch-action) は発動させない。
+ *   X の画像ビューアー等、JS 管理ズーム中のパン操作がこれに該当する。
+ * - 上方向にまだスクロールできる場合は発動させない。scrollableDirections は
+ *   visual viewport 基準のため、ピンチズーム中で上端に達していない場合も TOP フラグが立つ。
+ * - タッチ対象のスクロールフレームが縦方向にオーバースクロールできない場合は発動させない。
+ *   ライトボックス表示中の overflow: hidden な body や overscroll-behavior: none が該当する
+ *   (https://bugzilla.mozilla.org/show_bug.cgi?id=1902313 で Chrome 互換にされた挙動)。
+ *   短い（スクロール不能な）ページは UNHANDLED + 縦オーバースクロール可で返るため発動できる。
+ */
+internal fun canTriggerPullToRefresh(
+    handledResult: Int,
+    scrollableDirections: Int,
+    overscrollDirections: Int,
+): Boolean {
+    // HANDLED_CONTENT はコンテンツがタッチを消費。IGNORED は「ブラウザは何もすべきでない」
+    val isEligibleResult = handledResult == PanZoomController.INPUT_RESULT_HANDLED ||
+        handledResult == PanZoomController.INPUT_RESULT_UNHANDLED
+    if (!isEligibleResult) return false
+    if (scrollableDirections and PanZoomController.SCROLLABLE_FLAG_TOP != 0) return false
+    if (overscrollDirections and PanZoomController.OVERSCROLL_FLAG_VERTICAL == 0) return false
+    return true
+}

--- a/app/src/test/kotlin/net/matsudamper/browser/PullToRefreshPolicyTest.kt
+++ b/app/src/test/kotlin/net/matsudamper/browser/PullToRefreshPolicyTest.kt
@@ -1,0 +1,83 @@
+package net.matsudamper.browser
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mozilla.geckoview.PanZoomController
+
+class PullToRefreshPolicyTest {
+
+    @Test
+    fun `ページ最上部のスクロール可能ページでは発動できる`() {
+        // 最上部では下方向のみスクロール可能で、縦オーバースクロールが許可される
+        assertTrue(
+            canTriggerPullToRefresh(
+                handledResult = PanZoomController.INPUT_RESULT_HANDLED,
+                scrollableDirections = PanZoomController.SCROLLABLE_FLAG_BOTTOM,
+                overscrollDirections = PanZoomController.OVERSCROLL_FLAG_VERTICAL,
+            )
+        )
+    }
+
+    @Test
+    fun `スクロール不能な短いページでは発動できる`() {
+        // 短いページは UNHANDLED + 方向なし + 縦横オーバースクロール可で返る
+        assertTrue(
+            canTriggerPullToRefresh(
+                handledResult = PanZoomController.INPUT_RESULT_UNHANDLED,
+                scrollableDirections = PanZoomController.SCROLLABLE_FLAG_NONE,
+                overscrollDirections = PanZoomController.OVERSCROLL_FLAG_VERTICAL or
+                    PanZoomController.OVERSCROLL_FLAG_HORIZONTAL,
+            )
+        )
+    }
+
+    @Test
+    fun `上方向にスクロールできる場合は発動できない`() {
+        // ページ途中、またはピンチズーム中で visual viewport が上端より下にある場合
+        assertFalse(
+            canTriggerPullToRefresh(
+                handledResult = PanZoomController.INPUT_RESULT_HANDLED,
+                scrollableDirections = PanZoomController.SCROLLABLE_FLAG_TOP or
+                    PanZoomController.SCROLLABLE_FLAG_BOTTOM,
+                overscrollDirections = PanZoomController.OVERSCROLL_FLAG_VERTICAL,
+            )
+        )
+    }
+
+    @Test
+    fun `コンテンツがタッチを消費する場合は発動できない`() {
+        // preventDefault / touch-action: none (X の画像ビューアー等の JS 管理ズーム)
+        assertFalse(
+            canTriggerPullToRefresh(
+                handledResult = PanZoomController.INPUT_RESULT_HANDLED_CONTENT,
+                scrollableDirections = PanZoomController.SCROLLABLE_FLAG_NONE,
+                overscrollDirections = PanZoomController.OVERSCROLL_FLAG_VERTICAL,
+            )
+        )
+    }
+
+    @Test
+    fun `縦オーバースクロール不可の場合は発動できない`() {
+        // overflow-y: hidden な body (ライトボックス表示中) や overscroll-behavior: none
+        assertFalse(
+            canTriggerPullToRefresh(
+                handledResult = PanZoomController.INPUT_RESULT_UNHANDLED,
+                scrollableDirections = PanZoomController.SCROLLABLE_FLAG_NONE,
+                overscrollDirections = PanZoomController.OVERSCROLL_FLAG_NONE,
+            )
+        )
+    }
+
+    @Test
+    fun `IGNORED の場合は発動できない`() {
+        // APZ が内部で消費しブラウザは何もすべきでないケース
+        assertFalse(
+            canTriggerPullToRefresh(
+                handledResult = PanZoomController.INPUT_RESULT_IGNORED,
+                scrollableDirections = PanZoomController.SCROLLABLE_FLAG_NONE,
+                overscrollDirections = PanZoomController.OVERSCROLL_FLAG_VERTICAL,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 概要

ピンチズーム中に下に引っ張ると PullToRefresh が誤発動する問題の修正のみを切り出した PR です（#439 から分離。ズーム周りの修正は別途継続）。

## 問題

従来は `onTouchEventForDetailResult` の `handledResult` (HANDLED/UNHANDLED) のみで PTR を許可し、visualViewport.scale 監視とピンチ検出フラグで穴埋めしていたが、以下のケースで誤発動が残っていた。

- **SPA 遷移でガード消失**: X は pushState 遷移のため `onLocationChange` が発火し、そこで scale をリセットしていた。ネイティブピンチズームは SPA 遷移後も維持されるため「拡大中なのに scale=1 扱い」になり PTR が許可されていた
- **ダブルタップ拡大後の単指パン**: scale は 1.0 のまま・マルチタッチも発生しないため、どのガードにも掛からなかった

## 修正

Fenix (android-components) の [InputResultDetail.canOverscrollTop()](``https://github.com/mozilla-firefox/firefox/blob/main/mobile/android/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/InputResultDetail.kt)`` と同等の判定に変更する。

- `scrollableDirections`: **visual viewport 基準**で計算されるため、ズーム中で上が見える状態は毎ジェスチャー正しく抑止される（状態リセット漏れの影響を受けない）
- `overscrollDirections`: overflow-y: hidden（ライトボックス表示中の body 等）では縦オーバースクロールが落とされ抑止される（[Bug 1902313](https://bugzilla.mozilla.org/show_bug.cgi?id=1902313)、Chrome 互換挙動）
- 短い（スクロール不能な）ページは UNHANDLED + 縦オーバースクロール可で返るため従来どおり PTR 可能

あわせて役目を終えた `hadPinchGesture` フラグ（ピンチ後にページ遷移までPTRが無効化される副作用があった）を削除し、マルチタッチ中の抑止はジェスチャー単位のローカル判定に変更。`visualViewportScale` のリセットはフルページロード (`onPageStart`) のみとし、SPA 遷移ではズーム状態を維持する。

## テスト

- `PullToRefreshPolicyTest` を追加（6 ケース）
- `assembleDebug` / `detekt` / `test` 通過
- 実機確認済み（#439 上で PTR 誤発動の解消を確認）

https://claude.ai/code/session_018qDxh8f8SSxm3XtzZgTiK8

---
_Generated by [Claude Code](https://claude.ai/code/session_018qDxh8f8SSxm3XtzZgTiK8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull-to-refresh gesture detection to properly handle multi-touch interactions, preventing unintended triggers.

* **Improvements**
  * Viewport zoom level is now preserved when navigating within pages using browser history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->