### PR TITLE
コンテキストメニューを片手操作に対応させる

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -403,7 +403,8 @@ private fun ContextMenuDialog(
         // ボタンを縦に並べたいので confirm は空にして dismissButton スロットに集約する
         confirmButton = {},
         dismissButton = {
-            Column {
+            // 片手で持っていても押しやすいように全幅にし、テキストを中央寄せにする
+            Column(modifier = Modifier.fillMaxWidth()) {
                 when (menu) {
                     is BrowserTabScreenState.ContextMenuState.Link -> {
                         LinkActionButtons(
@@ -432,20 +433,32 @@ private fun ContextMenuDialog(
                             onCopyLink = onCopyLink,
                         )
                         if (enableTabUi) {
-                            TextButton(onClick = { onOpenNewTab(menu.imageSrcUrl) }) {
+                            TextButton(
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = { onOpenNewTab(menu.imageSrcUrl) },
+                            ) {
                                 Text(text = "画像を新しいタブで開く")
                             }
                         } else {
-                            TextButton(onClick = { onOpenUrl(menu.imageSrcUrl) }) {
+                            TextButton(
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = { onOpenUrl(menu.imageSrcUrl) },
+                            ) {
                                 Text(text = "画像を開く")
                             }
                         }
-                        TextButton(onClick = { onDownloadImage(menu.imageSrcUrl) }) {
+                        TextButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = { onDownloadImage(menu.imageSrcUrl) },
+                        ) {
                             Text(text = "画像をダウンロード")
                         }
                     }
                 }
-                TextButton(onClick = onDismiss) {
+                TextButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onDismiss,
+                ) {
                     Text(text = "キャンセル")
                 }
             }
@@ -461,17 +474,26 @@ private fun ImageActionButtons(
     onOpenUrl: (String) -> Unit,
     onDownloadImage: (String) -> Unit,
 ) {
-    Column {
+    Column(modifier = Modifier.fillMaxWidth()) {
         if (enableTabUi) {
-            TextButton(onClick = { onOpenNewTab(srcUrl) }) {
+            TextButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onOpenNewTab(srcUrl) },
+            ) {
                 Text(text = "新しいタブで開く")
             }
         } else {
-            TextButton(onClick = { onOpenUrl(srcUrl) }) {
+            TextButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onOpenUrl(srcUrl) },
+            ) {
                 Text(text = "開く")
             }
         }
-        TextButton(onClick = { onDownloadImage(srcUrl) }) {
+        TextButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { onDownloadImage(srcUrl) },
+        ) {
             Text(text = "ダウンロード")
         }
     }
@@ -485,17 +507,26 @@ private fun LinkActionButtons(
     onOpenUrl: (String) -> Unit,
     onCopyLink: (String) -> Unit,
 ) {
-    Column {
+    Column(modifier = Modifier.fillMaxWidth()) {
         if (enableTabUi) {
-            TextButton(onClick = { onOpenNewTab(url) }) {
+            TextButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onOpenNewTab(url) },
+            ) {
                 Text(text = "新しいタブで開く")
             }
         } else {
-            TextButton(onClick = { onOpenUrl(url) }) {
+            TextButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onOpenUrl(url) },
+            ) {
                 Text(text = "開く")
             }
         }
-        TextButton(onClick = { onCopyLink(url) }) {
+        TextButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { onCopyLink(url) },
+        ) {
             Text(text = "URLをコピー")
         }
     }
@@ -867,6 +898,25 @@ private fun flattenChoices(
         } else {
             listOf(choice)
         }
+    }
+}
+
+@Preview(name = "ContextMenuDialog")
+@Composable
+private fun PreviewContextMenuDialog() {
+    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_SYSTEM) {
+        ContextMenuDialog(
+            menu = BrowserTabScreenState.ContextMenuState.LinkWithImage(
+                url = "https://example.com/very/long/link/path/page.html",
+                imageSrcUrl = "https://example.com/image.png",
+            ),
+            enableTabUi = true,
+            onOpenNewTab = {},
+            onOpenUrl = {},
+            onCopyLink = {},
+            onDownloadImage = {},
+            onDismiss = {},
+        )
     }
 }
 

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/MoveTabToGroupDialog.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/MoveTabToGroupDialog.kt
@@ -10,8 +10,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import net.matsudamper.browser.data.TabGroupData
+import net.matsudamper.browser.data.TabGroupId
 
 /**
  * タブの移動先グループを選択するダイアログ。
@@ -34,9 +37,11 @@ internal fun MoveTabToGroupDialog(
             Column {
                 groups.forEachIndexed { index, group ->
                     if (index == currentGroupIndex) return@forEachIndexed
+                    // 片手で持っていても押しやすいように全幅・中央寄せにする
                     Text(
                         text = group.name,
                         style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { onGroupSelected(index) }
@@ -47,9 +52,27 @@ internal fun MoveTabToGroupDialog(
         },
         confirmButton = {},
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onDismiss,
+            ) {
                 Text("キャンセル")
             }
         },
+    )
+}
+
+@Composable
+@Preview
+private fun PreviewMoveTabToGroupDialog() {
+    MoveTabToGroupDialog(
+        groups = listOf(
+            TabGroupData(TabGroupId("g1"), "デフォルト"),
+            TabGroupData(TabGroupId("g2"), "開発"),
+            TabGroupData(TabGroupId("g3"), "調べ物"),
+        ),
+        currentGroupIndex = 0,
+        onGroupSelected = {},
+        onDismiss = {},
     )
 }


### PR DESCRIPTION
## 概要
コンテキストメニューのボタンを全幅に拡大し、テキストを中央寄せにすることで、片手で持っている状態でも押しやすくしました。

## 主な変更

### BrowserTabDialogLayer.kt
- `ContextMenuDialog` の dismissButton 内の `Column` に `Modifier.fillMaxWidth()` を追加
- `LinkActionButtons` と `ImageActionButtons` の `Column` に `Modifier.fillMaxWidth()` を追加
- 各 `TextButton` に `Modifier.fillMaxWidth()` を追加して全幅化
- `ContextMenuDialog` の Preview を追加

### MoveTabToGroupDialog.kt
- グループ選択テキストに `textAlign = TextAlign.Center` を追加して中央寄せ化
- キャンセルボタンの `TextButton` に `Modifier.fillMaxWidth()` を追加
- `MoveTabToGroupDialog` の Preview を追加

## 実装の詳細
- すべてのボタンを全幅にすることで、片手操作時のタップ領域を拡大
- テキストの中央寄せにより、視覚的なバランスを改善
- Preview を追加して、UI の見た目を確認可能に

https://claude.ai/code/session_01DCCKT3y2QZaep5qine7aqc