### PR TITLE
ダウンロード一時停止機能を追加

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
@@ -102,24 +102,30 @@ internal class DownloadWorker(
             // CancellationException を投げて DB 更新・ファイル削除がスキップされるため、
             // NonCancellable で囲んで確実に実行する
             withContext(NonCancellable) {
+                val workerId = id.toString()
                 val savedUri = partialResultUri
-                if (repository.isPaused(id.toString())) {
+                if (repository.isPaused(workerId)) {
                     if (savedUri != null && partialResultTotalRead > 0 && !usedPendingBody) {
                         // 一時停止: 部分ファイルを保持して再開（HTTP Range）に備える
                         repository.updatePausedPartial(
-                            workerId = id.toString(),
+                            workerId = workerId,
                             partialFileUri = savedUri.toString(),
                             fileName = partialResultFileName,
                             totalRead = partialResultTotalRead,
                             contentLength = partialResultContentLength,
                         )
+                        // isPaused 判定→保存の間に CANCELLED へ遷移すると updatePausedPartial が
+                        // no-op になり部分ファイルが孤立するため、再確認して削除する
+                        if (repository.isCancelled(workerId)) {
+                            context.contentResolver.delete(savedUri, null, null)
+                        }
                     } else {
                         // 部分ファイルが再開に使えない場合は削除する。
                         // PAUSED 状態は維持され、再開時は URL を再取得してダウンロードし直す
                         savedUri?.let { context.contentResolver.delete(it, null, null) }
                     }
                 } else {
-                    repository.updateCancelled(id.toString())
+                    repository.updateCancelled(workerId)
                     // キャンセル時は部分ファイルを削除する
                     savedUri?.let { context.contentResolver.delete(it, null, null) }
                 }

--- a/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
@@ -108,7 +108,7 @@ internal class DownloadWorker(
                     if (savedUri != null && partialResultTotalRead > 0 && !usedPendingBody) {
                         // 一時停止: 部分ファイルを保持して再開（HTTP Range）に備える
                         repository.updatePausedPartial(
-                            workerId = workerId,
+                            currentWorkerId = workerId,
                             partialFileUri = savedUri.toString(),
                             fileName = partialResultFileName,
                             totalRead = partialResultTotalRead,
@@ -137,7 +137,7 @@ internal class DownloadWorker(
             if (savedUri != null && partialResultTotalRead > 0 && !usedPendingBody) {
                 // 部分ファイルが存在する場合は再開可能として保存する
                 repository.updatePartialFailed(
-                    workerId = id.toString(),
+                    currentWorkerId = id.toString(),
                     partialFileUri = savedUri.toString(),
                     fileName = partialResultFileName,
                     totalRead = partialResultTotalRead,
@@ -203,7 +203,7 @@ internal class DownloadWorker(
             openDownloadsIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        val fileName = repository.get(id).fileName
+        val fileName = repository.getByCurrentWorkerId(id)?.fileName.orEmpty()
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_notify_error)

--- a/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/DownloadWorker.kt
@@ -102,9 +102,27 @@ internal class DownloadWorker(
             // CancellationException を投げて DB 更新・ファイル削除がスキップされるため、
             // NonCancellable で囲んで確実に実行する
             withContext(NonCancellable) {
-                repository.updateCancelled(id.toString())
-                // キャンセル時は部分ファイルを削除する
-                partialResultUri?.let { context.contentResolver.delete(it, null, null) }
+                val savedUri = partialResultUri
+                if (repository.isPaused(id.toString())) {
+                    if (savedUri != null && partialResultTotalRead > 0 && !usedPendingBody) {
+                        // 一時停止: 部分ファイルを保持して再開（HTTP Range）に備える
+                        repository.updatePausedPartial(
+                            workerId = id.toString(),
+                            partialFileUri = savedUri.toString(),
+                            fileName = partialResultFileName,
+                            totalRead = partialResultTotalRead,
+                            contentLength = partialResultContentLength,
+                        )
+                    } else {
+                        // 部分ファイルが再開に使えない場合は削除する。
+                        // PAUSED 状態は維持され、再開時は URL を再取得してダウンロードし直す
+                        savedUri?.let { context.contentResolver.delete(it, null, null) }
+                    }
+                } else {
+                    repository.updateCancelled(id.toString())
+                    // キャンセル時は部分ファイルを削除する
+                    savedUri?.let { context.contentResolver.delete(it, null, null) }
+                }
             }
             throw e
         } catch (e: Exception) {
@@ -135,8 +153,8 @@ internal class DownloadWorker(
      * Worker がこのチェックによって自力で停止できる
      */
     private suspend fun throwIfCancelledOnRecord() {
-        if (repository.isCancelled(id.toString())) {
-            throw CancellationException("ダウンロードがキャンセルされました")
+        if (repository.isStopRequested(id.toString())) {
+            throw CancellationException("ダウンロードがキャンセルまたは一時停止されました")
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoDownloadManager.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoDownloadManager.kt
@@ -94,44 +94,42 @@ internal class GeckoDownloadManager(
     }
 
     /**
-     * 失敗したダウンロードを部分ファイルから再開する。
-     * 古いレコードを削除して新しいワーカーをエンキューする。
-     * HTTPサーバーがRangeリクエストをサポートしている場合のみ実際の再開が行われ、
-     * サポートしていない場合は最初からダウンロードし直す。
+     * 失敗・一時停止したダウンロードを再開する。
+     * レコードは削除せず、既存レコードを新しいワーカーIDへ付け替えてENQUEUEDに戻す。
+     * これによりリスト上の位置（enqueuedAt）とUIのアイテム同一性（workerId）が維持され、
+     * 再開時に項目がリスト先頭へ飛んだりちらついたりしない。
+     * 部分ファイルがある場合はHTTP Rangeリクエストで続きから、
+     * 無い場合はURLを再取得して最初からダウンロードする。
      */
     fun resumeDownload(
-        oldWorkerId: String,
+        workerId: String,
         url: String,
         referrerUrl: String,
-        partialFileUri: String,
+        partialFileUri: String?,
         totalRead: Long,
         coroutineScope: CoroutineScope,
     ) {
         DownloadWorker.ensureNotificationChannel(context)
-        val workId = UUID.randomUUID()
-        val notificationId = workId.hashCode() and 0x7fffffff
+        val newWorkId = UUID.randomUUID()
+        val notificationId = newWorkId.hashCode() and 0x7fffffff
+        val inputData = buildMap<String, Any> {
+            put(DownloadWorker.KEY_URL, url)
+            put(DownloadWorker.KEY_REFERRER_URL, referrerUrl)
+            put(DownloadWorker.KEY_NOTIFICATION_ID, notificationId)
+            // 部分ファイルがある場合のみRange再開モードで起動する
+            if (partialFileUri != null) {
+                put(DownloadWorker.KEY_PARTIAL_FILE_URI, partialFileUri)
+                put(DownloadWorker.KEY_RESUME_FROM_BYTES, totalRead)
+            }
+        }
         val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-            .setId(workId)
-            .setInputData(
-                workDataOf(
-                    DownloadWorker.KEY_URL to url,
-                    DownloadWorker.KEY_REFERRER_URL to referrerUrl,
-                    DownloadWorker.KEY_NOTIFICATION_ID to notificationId,
-                    DownloadWorker.KEY_PARTIAL_FILE_URI to partialFileUri,
-                    DownloadWorker.KEY_RESUME_FROM_BYTES to totalRead,
-                )
-            )
+            .setId(newWorkId)
+            .setInputData(workDataOf(*inputData.toList().toTypedArray()))
             .addTag(DownloadWorker.TAG_DOWNLOAD)
             .build()
         coroutineScope.launch {
-            // 古いFAILEDレコードを削除してから新しいENQUEUEDレコードを挿入する
-            downloadRepository.deleteById(oldWorkerId)
-            downloadRepository.insertEnqueued(
-                workerId = workRequest.id.toString(),
-                url = url,
-                referrerUrl = referrerUrl,
-                enqueuedAt = System.currentTimeMillis(),
-            )
+            // 既存レコードを新しいワーカーIDへ付け替えてENQUEUEDに戻す（削除・再作成しない）
+            downloadRepository.updateResumed(workerId = workerId, newWorkerId = newWorkId.toString())
             WorkManager.getInstance(context).enqueue(workRequest)
             val notification = NotificationCompat.Builder(context, DownloadWorker.CHANNEL_ID)
                 .setSmallIcon(android.R.drawable.stat_sys_download)

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -98,6 +98,7 @@ internal class DownloadManagementScreenViewModel(
 
     private fun buildCallbacks() = DownloadManagementScreenUiState.Callbacks(
         onCancel = { id -> cancelDownload(id) },
+        onPause = { id -> pauseDownload(id) },
         onOpenFile = { fileUri -> openFile(fileUri) },
         onOpenDownloadsFolder = { openDownloadsFolder() },
         onResume = { id -> resumeDownload(id) },
@@ -141,6 +142,13 @@ internal class DownloadManagementScreenViewModel(
                 )
             }
             DownloadRecordStatus.CANCELLED -> DownloadManagementScreenUiState.DownloadStatus.Cancelled
+            DownloadRecordStatus.PAUSED -> {
+                DownloadManagementScreenUiState.DownloadStatus.Paused(
+                    progress = progress,
+                    totalRead = totalRead,
+                    contentLength = contentLength,
+                )
+            }
         }
         return DownloadManagementScreenUiState.DownloadItem(
             id = workerId,
@@ -155,6 +163,10 @@ internal class DownloadManagementScreenViewModel(
     }
 
     private fun cancelDownload(id: UUID) {
+        // 一時停止中のレコードは Worker が存在しないため、残った部分ファイルをここで削除する
+        val pausedPartialFileUri = currentRecords
+            .find { it.workerId == id && it.status == DownloadRecordStatus.PAUSED }
+            ?.partialFileUri
         // suspend を挟むと viewModelScope の破棄でキャンセル要求自体が消えるため、即時に発行する
         workManager.cancelWorkById(id)
         // Worker 起動前に GeckoDownloadManager が直接表示した通知は誰も消さないため、
@@ -169,17 +181,44 @@ internal class DownloadManagementScreenViewModel(
             // WorkManager の割り込みが届かない場合でも、Worker が進捗更新時に
             // この CANCELLED 状態を検知して自力で停止する
             downloadRepository.updateCancelled(id.toString())
+            pausedPartialFileUri?.let { uri ->
+                runCatching {
+                    getApplication<Application>().contentResolver.delete(uri.toUri(), null, null)
+                }
+            }
         }
     }
 
     /**
-     * 失敗したダウンロードを再開する。
+     * 実行中のダウンロードを一時停止する。
+     * 先に DB を PAUSED に更新してから WorkManager に割り込みを発行することで、
+     * Worker の CancellationException ハンドラが一時停止を検知して部分ファイルを保持する
+     */
+    private fun pauseDownload(id: UUID) {
+        viewModelScope.launch {
+            downloadRepository.updatePaused(id.toString())
+            workManager.cancelWorkById(id)
+            // Worker 起動前に GeckoDownloadManager が直接表示した通知は誰も消さないため、
+            // 同じ導出式（workId の hashCode）で通知 ID を求めて明示的に消す
+            val notificationId = id.hashCode() and 0x7fffffff
+            getApplication<Application>()
+                .getSystemService(NotificationManager::class.java)
+                ?.cancel(notificationId)
+        }
+    }
+
+    /**
+     * 失敗または一時停止したダウンロードを再開する。
      * 部分ファイルが残っている場合はRangeリクエストで再開し、
      * そうでない場合は同じURLを再度エンキューする。
      */
     private fun resumeDownload(id: UUID) {
         val record = currentRecords.find { it.workerId == id } ?: return
-        if (record.status != DownloadRecordStatus.FAILED) return
+        if (record.status != DownloadRecordStatus.FAILED &&
+            record.status != DownloadRecordStatus.PAUSED
+        ) {
+            return
+        }
 
         val partialFileUri = record.partialFileUri
         if (partialFileUri != null) {

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -163,15 +163,16 @@ internal class DownloadManagementScreenViewModel(
     }
 
     private fun cancelDownload(id: UUID) {
+        val record = currentRecords.find { it.workerId == id } ?: return
+        // WorkManager・通知・DB はいずれも現在のワーカーID（currentWorkerId）で識別する
+        val currentWorkerId = record.currentWorkerId
         // 一時停止中のレコードは Worker が存在しないため、残った部分ファイルをここで削除する
-        val pausedPartialFileUri = currentRecords
-            .find { it.workerId == id && it.status == DownloadRecordStatus.PAUSED }
-            ?.partialFileUri
+        val pausedPartialFileUri = record.partialFileUri.takeIf { record.status == DownloadRecordStatus.PAUSED }
         // suspend を挟むと viewModelScope の破棄でキャンセル要求自体が消えるため、即時に発行する
-        workManager.cancelWorkById(id)
+        workManager.cancelWorkById(currentWorkerId)
         // Worker 起動前に GeckoDownloadManager が直接表示した通知は誰も消さないため、
         // 同じ導出式（workId の hashCode）で通知 ID を求めて明示的に消す
-        val notificationId = id.hashCode() and 0x7fffffff
+        val notificationId = currentWorkerId.hashCode() and 0x7fffffff
         getApplication<Application>()
             .getSystemService(NotificationManager::class.java)
             ?.cancel(notificationId)
@@ -180,7 +181,7 @@ internal class DownloadManagementScreenViewModel(
             // SUCCEEDED/FAILED の上書きは DAO 側のガードで防がれる。
             // WorkManager の割り込みが届かない場合でも、Worker が進捗更新時に
             // この CANCELLED 状態を検知して自力で停止する
-            downloadRepository.updateCancelled(id.toString())
+            downloadRepository.updateCancelled(currentWorkerId.toString())
             pausedPartialFileUri?.let { uri ->
                 runCatching {
                     getApplication<Application>().contentResolver.delete(uri.toUri(), null, null)
@@ -195,12 +196,14 @@ internal class DownloadManagementScreenViewModel(
      * Worker の CancellationException ハンドラが一時停止を検知して部分ファイルを保持する
      */
     private fun pauseDownload(id: UUID) {
+        val record = currentRecords.find { it.workerId == id } ?: return
+        val currentWorkerId = record.currentWorkerId
         viewModelScope.launch {
-            downloadRepository.updatePaused(id.toString())
-            workManager.cancelWorkById(id)
+            downloadRepository.updatePaused(currentWorkerId.toString())
+            workManager.cancelWorkById(currentWorkerId)
             // Worker 起動前に GeckoDownloadManager が直接表示した通知は誰も消さないため、
             // 同じ導出式（workId の hashCode）で通知 ID を求めて明示的に消す
-            val notificationId = id.hashCode() and 0x7fffffff
+            val notificationId = currentWorkerId.hashCode() and 0x7fffffff
             getApplication<Application>()
                 .getSystemService(NotificationManager::class.java)
                 ?.cancel(notificationId)
@@ -209,8 +212,9 @@ internal class DownloadManagementScreenViewModel(
 
     /**
      * 失敗または一時停止したダウンロードを再開する。
-     * 部分ファイルが残っている場合はRangeリクエストで再開し、
-     * そうでない場合は同じURLを再度エンキューする。
+     * 既存レコードを付け替えるため、リスト上の位置とアイテム同一性は維持される。
+     * 部分ファイルが残っている場合はRangeリクエストで続きから、
+     * 無い場合はURLを再取得して最初からダウンロードする。
      */
     private fun resumeDownload(id: UUID) {
         val record = currentRecords.find { it.workerId == id } ?: return
@@ -219,26 +223,12 @@ internal class DownloadManagementScreenViewModel(
         ) {
             return
         }
-
-        val partialFileUri = record.partialFileUri
-        if (partialFileUri != null) {
-            geckoDownloadManager.resumeDownload(
-                oldWorkerId = record.workerId.toString(),
-                url = record.url,
-                referrerUrl = record.referrerUrl,
-                partialFileUri = partialFileUri,
-                totalRead = record.totalRead,
-                coroutineScope = viewModelScope,
-            )
-            return
-        }
-
-        viewModelScope.launch {
-            downloadRepository.deleteById(record.workerId.toString())
-        }
-        geckoDownloadManager.enqueueDownload(
+        geckoDownloadManager.resumeDownload(
+            workerId = record.workerId.toString(),
             url = record.url,
             referrerUrl = record.referrerUrl,
+            partialFileUri = record.partialFileUri,
+            totalRead = record.totalRead,
             coroutineScope = viewModelScope,
         )
     }

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.matsudamper.browser.GeckoDownloadManager
@@ -49,6 +50,13 @@ internal class DownloadManagementScreenViewModel(
     /** サムネイル読み込み要求済みの fileUri */
     private val requestedThumbnailUris = mutableSetOf<String>()
 
+    /**
+     * 一時停止を要求したがワーカーがまだ停止処理中のダウンロードID（安定 workerId）。
+     * DB 上は即座に PAUSED になるが、ワーカーが部分ファイルを保存し終えるまでは
+     * UI 上「停止処理中（グレーアウト + 円形インジケーター）」として表示する。
+     */
+    private val pausingIds = MutableStateFlow<Set<UUID>>(emptySet())
+
     val uiState: StateFlow<DownloadManagementScreenUiState> = MutableStateFlow(
         DownloadManagementScreenUiState(
             downloads = emptyList(),
@@ -59,15 +67,16 @@ internal class DownloadManagementScreenViewModel(
             combine(
                 downloadRepository.observeDownloads(),
                 thumbnailFlow,
-            ) { records, thumbnails -> records to thumbnails }
-                .collectLatest { (records, thumbnails) ->
+                pausingIds,
+            ) { records, thumbnails, pausing -> Triple(records, thumbnails, pausing) }
+                .collectLatest { (records, thumbnails, pausing) ->
                     currentRecords = records
                     records.forEach { record ->
                         if (record.status == DownloadRecordStatus.SUCCEEDED) {
                             record.fileUri?.let { requestThumbnail(it) }
                         }
                     }
-                    val items = records.map { record -> record.toDownloadItem(thumbnails) }
+                    val items = records.map { record -> record.toDownloadItem(thumbnails, pausing) }
                     uiStateFlow.update {
                         DownloadManagementScreenUiState(
                             downloads = items,
@@ -107,6 +116,7 @@ internal class DownloadManagementScreenViewModel(
 
     private fun DownloadRecord.toDownloadItem(
         thumbnails: Map<String, ImageBitmap?>,
+        pausingIds: Set<UUID>,
     ): DownloadManagementScreenUiState.DownloadItem {
         val uiStatus = when (status) {
             DownloadRecordStatus.SUCCEEDED -> {
@@ -143,11 +153,20 @@ internal class DownloadManagementScreenViewModel(
             }
             DownloadRecordStatus.CANCELLED -> DownloadManagementScreenUiState.DownloadStatus.Cancelled
             DownloadRecordStatus.PAUSED -> {
-                DownloadManagementScreenUiState.DownloadStatus.Paused(
-                    progress = progress,
-                    totalRead = totalRead,
-                    contentLength = contentLength,
-                )
+                if (workerId in pausingIds) {
+                    // ワーカーがまだ停止処理中: グレーアウト + 円形インジケーターを表示する
+                    DownloadManagementScreenUiState.DownloadStatus.Pausing(
+                        progress = progress,
+                        totalRead = totalRead,
+                        contentLength = contentLength,
+                    )
+                } else {
+                    DownloadManagementScreenUiState.DownloadStatus.Paused(
+                        progress = progress,
+                        totalRead = totalRead,
+                        contentLength = contentLength,
+                    )
+                }
             }
         }
         return DownloadManagementScreenUiState.DownloadItem(
@@ -168,6 +187,8 @@ internal class DownloadManagementScreenViewModel(
         val currentWorkerId = record.currentWorkerId
         // 一時停止中のレコードは Worker が存在しないため、残った部分ファイルをここで削除する
         val pausedPartialFileUri = record.partialFileUri.takeIf { record.status == DownloadRecordStatus.PAUSED }
+        // 停止処理中にキャンセルされた場合はフラグを解除する
+        pausingIds.update { it - id }
         // suspend を挟むと viewModelScope の破棄でキャンセル要求自体が消えるため、即時に発行する
         workManager.cancelWorkById(currentWorkerId)
         // Worker 起動前に GeckoDownloadManager が直接表示した通知は誰も消さないため、
@@ -198,6 +219,8 @@ internal class DownloadManagementScreenViewModel(
     private fun pauseDownload(id: UUID) {
         val record = currentRecords.find { it.workerId == id } ?: return
         val currentWorkerId = record.currentWorkerId
+        // 停止処理中フラグを立てる（UI 上はグレーアウト + 円形インジケーター）
+        pausingIds.update { it + id }
         viewModelScope.launch {
             downloadRepository.updatePaused(currentWorkerId.toString())
             workManager.cancelWorkById(currentWorkerId)
@@ -207,6 +230,11 @@ internal class DownloadManagementScreenViewModel(
             getApplication<Application>()
                 .getSystemService(NotificationManager::class.java)
                 ?.cancel(notificationId)
+            // ワーカーが実際に停止（部分ファイル保存）し終えるまで待ってからフラグを解除する。
+            // WorkInfo が終端状態になった時点でワーカーの後処理は完了している
+            workManager.getWorkInfoByIdFlow(currentWorkerId)
+                .first { it == null || it.state.isFinished }
+            pausingIds.update { it - id }
         }
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.matsudamper.browser.GeckoDownloadManager
@@ -50,13 +49,6 @@ internal class DownloadManagementScreenViewModel(
     /** サムネイル読み込み要求済みの fileUri */
     private val requestedThumbnailUris = mutableSetOf<String>()
 
-    /**
-     * 一時停止を要求したがワーカーがまだ停止処理中のダウンロードID（安定 workerId）。
-     * DB 上は即座に PAUSED になるが、ワーカーが部分ファイルを保存し終えるまでは
-     * UI 上「停止処理中（グレーアウト + 円形インジケーター）」として表示する。
-     */
-    private val pausingIds = MutableStateFlow<Set<UUID>>(emptySet())
-
     val uiState: StateFlow<DownloadManagementScreenUiState> = MutableStateFlow(
         DownloadManagementScreenUiState(
             downloads = emptyList(),
@@ -67,16 +59,15 @@ internal class DownloadManagementScreenViewModel(
             combine(
                 downloadRepository.observeDownloads(),
                 thumbnailFlow,
-                pausingIds,
-            ) { records, thumbnails, pausing -> Triple(records, thumbnails, pausing) }
-                .collectLatest { (records, thumbnails, pausing) ->
+            ) { records, thumbnails -> records to thumbnails }
+                .collectLatest { (records, thumbnails) ->
                     currentRecords = records
                     records.forEach { record ->
                         if (record.status == DownloadRecordStatus.SUCCEEDED) {
                             record.fileUri?.let { requestThumbnail(it) }
                         }
                     }
-                    val items = records.map { record -> record.toDownloadItem(thumbnails, pausing) }
+                    val items = records.map { record -> record.toDownloadItem(thumbnails) }
                     uiStateFlow.update {
                         DownloadManagementScreenUiState(
                             downloads = items,
@@ -116,7 +107,6 @@ internal class DownloadManagementScreenViewModel(
 
     private fun DownloadRecord.toDownloadItem(
         thumbnails: Map<String, ImageBitmap?>,
-        pausingIds: Set<UUID>,
     ): DownloadManagementScreenUiState.DownloadItem {
         val uiStatus = when (status) {
             DownloadRecordStatus.SUCCEEDED -> {
@@ -153,20 +143,11 @@ internal class DownloadManagementScreenViewModel(
             }
             DownloadRecordStatus.CANCELLED -> DownloadManagementScreenUiState.DownloadStatus.Cancelled
             DownloadRecordStatus.PAUSED -> {
-                if (workerId in pausingIds) {
-                    // ワーカーがまだ停止処理中: グレーアウト + 円形インジケーターを表示する
-                    DownloadManagementScreenUiState.DownloadStatus.Pausing(
-                        progress = progress,
-                        totalRead = totalRead,
-                        contentLength = contentLength,
-                    )
-                } else {
-                    DownloadManagementScreenUiState.DownloadStatus.Paused(
-                        progress = progress,
-                        totalRead = totalRead,
-                        contentLength = contentLength,
-                    )
-                }
+                DownloadManagementScreenUiState.DownloadStatus.Paused(
+                    progress = progress,
+                    totalRead = totalRead,
+                    contentLength = contentLength,
+                )
             }
         }
         return DownloadManagementScreenUiState.DownloadItem(
@@ -187,8 +168,6 @@ internal class DownloadManagementScreenViewModel(
         val currentWorkerId = record.currentWorkerId
         // 一時停止中のレコードは Worker が存在しないため、残った部分ファイルをここで削除する
         val pausedPartialFileUri = record.partialFileUri.takeIf { record.status == DownloadRecordStatus.PAUSED }
-        // 停止処理中にキャンセルされた場合はフラグを解除する
-        pausingIds.update { it - id }
         // suspend を挟むと viewModelScope の破棄でキャンセル要求自体が消えるため、即時に発行する
         workManager.cancelWorkById(currentWorkerId)
         // Worker 起動前に GeckoDownloadManager が直接表示した通知は誰も消さないため、
@@ -219,8 +198,6 @@ internal class DownloadManagementScreenViewModel(
     private fun pauseDownload(id: UUID) {
         val record = currentRecords.find { it.workerId == id } ?: return
         val currentWorkerId = record.currentWorkerId
-        // 停止処理中フラグを立てる（UI 上はグレーアウト + 円形インジケーター）
-        pausingIds.update { it + id }
         viewModelScope.launch {
             downloadRepository.updatePaused(currentWorkerId.toString())
             workManager.cancelWorkById(currentWorkerId)
@@ -230,11 +207,6 @@ internal class DownloadManagementScreenViewModel(
             getApplication<Application>()
                 .getSystemService(NotificationManager::class.java)
                 ?.cancel(notificationId)
-            // ワーカーが実際に停止（部分ファイル保存）し終えるまで待ってからフラグを解除する。
-            // WorkInfo が終端状態になった時点でワーカーの後処理は完了している
-            workManager.getWorkInfoByIdFlow(currentWorkerId)
-                .first { it == null || it.state.isFinished }
-            pausingIds.update { it - id }
         }
     }
 

--- a/data/schemas/net.matsudamper.browser.data.tab.TabDatabase/4.json
+++ b/data/schemas/net.matsudamper.browser.data.tab.TabDatabase/4.json
@@ -1,0 +1,108 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "09d958584be119a427cfb83d7cb87bc7",
+    "entities": [
+      {
+        "tableName": "tab_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tabId` TEXT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `openerTabId` TEXT NOT NULL, `themeColor` INTEGER, `sortOrder` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `groupId` TEXT NOT NULL, PRIMARY KEY(`tabId`))",
+        "fields": [
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openerTabId",
+            "columnName": "openerTabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tabId"
+          ]
+        }
+      },
+      {
+        "tableName": "tab_group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` TEXT NOT NULL, `name` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, `isDefault` INTEGER NOT NULL, PRIMARY KEY(`groupId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '09d958584be119a427cfb83d7cb87bc7')"
+    ]
+  }
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -7,15 +7,78 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.matsudamper.browser.data.tab.TabDatabase
 import net.matsudamper.browser.data.tab.TabStateEntity
+import net.matsudamper.browser.data.tab.TabStateRow
 
 class TabRepository(context: Context) {
     private val db = TabDatabase.getInstance(context)
     private val dao = db.tabDao()
     private val thumbnailDir = File(context.cacheDir, "tab_thumbnails").apply { mkdirs() }
 
+    // sessionState は GeckoView のセッション状態(履歴・フォーム・スクロール等)を直列化した
+    // 実質 blob で、ヘビーに使われたタブでは Android の CursorWindow 上限(約2MB)を超え、
+    // tab_state の取得時に SQLiteBlobTooBigException でクラッシュする原因になる。
+    // そのため DB には保持せず、tabId をファイル名としてファイルへ保存する。
+    // 履歴等を含む永続データなので、消えうる cacheDir ではなく filesDir に置く。
+    private val sessionStateDir = File(context.filesDir, "tab_session_states").apply { mkdirs() }
+
+    private fun sessionStateFile(tabId: String) = File(sessionStateDir, tabId)
+
+    /** sessionState をファイルへ保存する。空の場合はファイルを削除する */
+    private fun writeSessionState(tabId: String, sessionState: String) {
+        val file = sessionStateFile(tabId)
+        if (sessionState.isBlank()) {
+            file.delete()
+            return
+        }
+        if (!sessionStateDir.exists()) {
+            sessionStateDir.mkdirs()
+        }
+        file.writeText(sessionState)
+    }
+
+    private fun deleteSessionStateFile(tabId: String) {
+        sessionStateFile(tabId).delete()
+    }
+
+    /**
+     * 指定タブの sessionState を解決する。
+     * ファイルがあればそれを返す。無い場合は旧バージョンで DB 列に保存された
+     * sessionState をファイルへ移行してから返す（移行後は DB 列を空にする）。
+     */
+    private suspend fun resolveSessionState(tabId: String): String {
+        val file = sessionStateFile(tabId)
+        if (file.exists()) {
+            return file.readText()
+        }
+        val fromDb = readSessionStateFromDb(tabId)
+        if (fromDb.isNotEmpty()) {
+            writeSessionState(tabId, fromDb)
+            dao.clearSessionState(tabId)
+        }
+        return fromDb
+    }
+
+    /**
+     * 旧バージョンで tab_state.sessionState に保存された文字列を読み出す。
+     * 巨大セルでも CursorWindow 上限(約2MB)を超えないよう substr で分割して読む。
+     */
+    private suspend fun readSessionStateFromDb(tabId: String): String {
+        val length = dao.getSessionStateLength(tabId) ?: return ""
+        if (length <= 0) return ""
+        val builder = StringBuilder(length)
+        var offset = 1 // SQLite の substr は 1 始まり
+        while (offset <= length) {
+            val chunk = dao.getSessionStateChunk(tabId, offset, SESSION_STATE_CHUNK_CHARS)
+            if (chunk.isNullOrEmpty()) break
+            builder.append(chunk)
+            offset += SESSION_STATE_CHUNK_CHARS
+        }
+        return builder.toString()
+    }
+
     fun observeTabs(): Flow<PersistedTabStateContainer> {
-        return dao.observeAllTabs().map { entities ->
-            entities.toPersistedTabStateContainer()
+        return dao.observeAllTabs().map { rows ->
+            rows.toPersistedTabStateContainer()
         }
     }
 
@@ -29,16 +92,17 @@ class TabRepository(context: Context) {
         selected: Boolean,
     ) {
         db.withTransaction {
-            val currentEntities = dao.getAllTabs()
-            val existing = currentEntities.firstOrNull { it.tabId == tab.tabId }
-            val visibleTabs = currentEntities.filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+            val currentRows = dao.getAllTabs()
+            val existing = currentRows.firstOrNull { it.tabId == tab.tabId }
+            val visibleTabs = currentRows.filterNot(TabStateRow::isPlaceholderForPreAssignment)
             val targetIndex = insertIndex.coerceIn(0, visibleTabs.size)
 
             dao.upsertTab(
                 TabStateEntity(
                     tabId = tab.tabId,
                     url = tab.url,
-                    sessionState = tab.sessionState,
+                    // sessionState はファイルへ保存するため DB 列は常に空にする
+                    sessionState = "",
                     title = tab.title,
                     openerTabId = tab.openerTabId,
                     themeColor = tab.themeColor,
@@ -58,6 +122,8 @@ class TabRepository(context: Context) {
                 dao.setSelectedTab(tab.tabId)
             }
         }
+        // sessionState はファイルへ保存する（DB トランザクション外で I/O を行う）
+        writeSessionState(tab.tabId, tab.sessionState)
     }
 
     suspend fun updateUrl(tabId: String, url: String) {
@@ -69,7 +135,8 @@ class TabRepository(context: Context) {
     }
 
     suspend fun updateSessionState(tabId: String, sessionState: String) {
-        dao.updateSessionState(tabId, sessionState)
+        // sessionState は DB ではなくファイルに保存する
+        writeSessionState(tabId, sessionState)
     }
 
     suspend fun updateThemeColor(tabId: String, themeColor: Int?) {
@@ -89,15 +156,15 @@ class TabRepository(context: Context) {
     suspend fun moveTab(fromIndex: Int, toIndex: Int) {
         db.withTransaction {
             val visibleTabs = dao.getAllTabs()
-                .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+                .filterNot(TabStateRow::isPlaceholderForPreAssignment)
                 .toMutableList()
             if (fromIndex !in visibleTabs.indices || toIndex !in visibleTabs.indices) {
                 return@withTransaction
             }
             visibleTabs.add(toIndex, visibleTabs.removeAt(fromIndex))
-            visibleTabs.forEachIndexed { index, entity ->
-                if (entity.sortOrder != index) {
-                    dao.updateSortOrder(entity.tabId, index)
+            visibleTabs.forEachIndexed { index, row ->
+                if (row.sortOrder != index) {
+                    dao.updateSortOrder(row.tabId, index)
                 }
             }
         }
@@ -114,6 +181,7 @@ class TabRepository(context: Context) {
             reorderVisibleTabs()
         }
         deleteTabThumbnail(tabId)
+        deleteSessionStateFile(tabId)
     }
 
     /** サムネイル画像をキャッシュファイルに保存する */
@@ -140,42 +208,50 @@ class TabRepository(context: Context) {
         targetIndex: Int? = null,
     ) {
         val visibleTabs = dao.getAllTabs()
-            .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+            .filterNot(TabStateRow::isPlaceholderForPreAssignment)
             .toMutableList()
 
         if (moveTabId != null && targetIndex != null) {
             val currentIndex = visibleTabs.indexOfFirst { it.tabId == moveTabId }
             if (currentIndex >= 0) {
-                val entity = visibleTabs.removeAt(currentIndex)
-                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), entity)
+                val row = visibleTabs.removeAt(currentIndex)
+                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), row)
             }
         }
 
-        visibleTabs.forEachIndexed { index, entity ->
-            if (entity.sortOrder != index) {
-                dao.updateSortOrder(entity.tabId, index)
+        visibleTabs.forEachIndexed { index, row ->
+            if (row.sortOrder != index) {
+                dao.updateSortOrder(row.tabId, index)
             }
         }
     }
 
-    private fun List<TabStateEntity>.toPersistedTabStateContainer(): PersistedTabStateContainer {
-        val visibleEntities = filterNot(TabStateEntity::isPlaceholderForPreAssignment)
-        val selectedTabId = visibleEntities.firstOrNull { it.isSelected == 1 }?.tabId
-            ?: visibleEntities.lastOrNull()?.tabId
+    private suspend fun List<TabStateRow>.toPersistedTabStateContainer(): PersistedTabStateContainer {
+        val visibleRows = filterNot(TabStateRow::isPlaceholderForPreAssignment)
+        val selectedTabId = visibleRows.firstOrNull { it.isSelected == 1 }?.tabId
+            ?: visibleRows.lastOrNull()?.tabId
         return PersistedTabStateContainer(
-            tabs = visibleEntities.map { it.toPersistedTabState() },
+            tabs = visibleRows.map { it.toPersistedTabState() },
             selectedTabId = selectedTabId,
         )
     }
 
-    private fun TabStateEntity.toPersistedTabState() = PersistedTabState(
+    private suspend fun TabStateRow.toPersistedTabState() = PersistedTabState(
         url = url,
-        sessionState = sessionState,
+        sessionState = resolveSessionState(tabId),
         title = title,
         tabId = tabId,
         openerTabId = openerTabId,
         themeColor = themeColor,
     )
+
+    private companion object {
+        /**
+         * 旧 DB から sessionState を分割読みする際の 1 チャンクの文字数。
+         * 最悪 4byte/文字でも約 1MB に収まり、CursorWindow 上限(約2MB)を超えない。
+         */
+        private const val SESSION_STATE_CHUNK_CHARS = 256 * 1024
+    }
 }
 
 data class PersistedTabStateContainer(
@@ -192,10 +268,12 @@ data class PersistedTabState(
     val themeColor: Int? = null,
 )
 
-private fun TabStateEntity.isPlaceholderForPreAssignment(): Boolean {
+private fun TabStateRow.isPlaceholderForPreAssignment(): Boolean {
+    // グループ先行割り当てのプレースホルダ行は全フィールドが空。
+    // sessionState はファイルへ移行したため、ここでは射影に含まれるフィールドのみで判定する。
+    // 実タブは必ず非空の url を持つため、これで一意に識別できる。
     return url.isBlank() &&
         title.isBlank() &&
-        sessionState.isBlank() &&
         openerTabId.isBlank() &&
         themeColor == null
 }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.matsudamper.browser.data.tab.TabDatabase
 import net.matsudamper.browser.data.tab.TabStateEntity
-import net.matsudamper.browser.data.tab.TabStateRow
 
 class TabRepository(context: Context) {
     private val db = TabDatabase.getInstance(context)
@@ -16,7 +15,7 @@ class TabRepository(context: Context) {
 
     // sessionState は GeckoView のセッション状態(履歴・フォーム・スクロール等)を直列化した
     // 実質 blob で、ヘビーに使われたタブでは Android の CursorWindow 上限(約2MB)を超え、
-    // tab_state の取得時に SQLiteBlobTooBigException でクラッシュする原因になる。
+    // tab_state の取得時に SQLiteBlobTooBigException でクラッシュする原因になっていた。
     // そのため DB には保持せず、tabId をファイル名としてファイルへ保存する。
     // 履歴等を含む永続データなので、消えうる cacheDir ではなく filesDir に置く。
     private val sessionStateDir = File(context.filesDir, "tab_session_states").apply { mkdirs() }
@@ -36,51 +35,19 @@ class TabRepository(context: Context) {
         file.writeText(sessionState)
     }
 
+    /** 指定タブの sessionState をファイルから読み出す。無ければ空文字。 */
+    private fun readSessionState(tabId: String): String {
+        val file = sessionStateFile(tabId)
+        return if (file.exists()) file.readText() else ""
+    }
+
     private fun deleteSessionStateFile(tabId: String) {
         sessionStateFile(tabId).delete()
     }
 
-    /**
-     * 指定タブの sessionState を解決する。
-     * ファイルがあればそれを返す。無い場合は旧バージョンで DB 列に保存された
-     * sessionState をファイルへコピーしてから返す。
-     * ファイル移行が正しく動くと確認できるまでは、安全のため DB 列のデータは消さずに残す。
-     * （DB 列データの削除と移行コードの撤去は別 Issue で対応する）
-     */
-    private suspend fun resolveSessionState(tabId: String): String {
-        val file = sessionStateFile(tabId)
-        if (file.exists()) {
-            return file.readText()
-        }
-        val fromDb = readSessionStateFromDb(tabId)
-        if (fromDb.isNotEmpty()) {
-            // DB のデータはバックアップとして温存し、ファイルへコピーするだけに留める
-            writeSessionState(tabId, fromDb)
-        }
-        return fromDb
-    }
-
-    /**
-     * 旧バージョンで tab_state.sessionState に保存された文字列を読み出す。
-     * 巨大セルでも CursorWindow 上限(約2MB)を超えないよう substr で分割して読む。
-     */
-    private suspend fun readSessionStateFromDb(tabId: String): String {
-        val length = dao.getSessionStateLength(tabId) ?: return ""
-        if (length <= 0) return ""
-        val builder = StringBuilder(length)
-        var offset = 1 // SQLite の substr は 1 始まり
-        while (offset <= length) {
-            val chunk = dao.getSessionStateChunk(tabId, offset, SESSION_STATE_CHUNK_CHARS)
-            if (chunk.isNullOrEmpty()) break
-            builder.append(chunk)
-            offset += SESSION_STATE_CHUNK_CHARS
-        }
-        return builder.toString()
-    }
-
     fun observeTabs(): Flow<PersistedTabStateContainer> {
-        return dao.observeAllTabs().map { rows ->
-            rows.toPersistedTabStateContainer()
+        return dao.observeAllTabs().map { entities ->
+            entities.toPersistedTabStateContainer()
         }
     }
 
@@ -94,17 +61,15 @@ class TabRepository(context: Context) {
         selected: Boolean,
     ) {
         db.withTransaction {
-            val currentRows = dao.getAllTabs()
-            val existing = currentRows.firstOrNull { it.tabId == tab.tabId }
-            val visibleTabs = currentRows.filterNot(TabStateRow::isPlaceholderForPreAssignment)
+            val currentEntities = dao.getAllTabs()
+            val existing = currentEntities.firstOrNull { it.tabId == tab.tabId }
+            val visibleTabs = currentEntities.filterNot(TabStateEntity::isPlaceholderForPreAssignment)
             val targetIndex = insertIndex.coerceIn(0, visibleTabs.size)
 
             dao.upsertTab(
                 TabStateEntity(
                     tabId = tab.tabId,
                     url = tab.url,
-                    // sessionState はファイルへ保存するため DB 列は常に空にする
-                    sessionState = "",
                     title = tab.title,
                     openerTabId = tab.openerTabId,
                     themeColor = tab.themeColor,
@@ -158,15 +123,15 @@ class TabRepository(context: Context) {
     suspend fun moveTab(fromIndex: Int, toIndex: Int) {
         db.withTransaction {
             val visibleTabs = dao.getAllTabs()
-                .filterNot(TabStateRow::isPlaceholderForPreAssignment)
+                .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
                 .toMutableList()
             if (fromIndex !in visibleTabs.indices || toIndex !in visibleTabs.indices) {
                 return@withTransaction
             }
             visibleTabs.add(toIndex, visibleTabs.removeAt(fromIndex))
-            visibleTabs.forEachIndexed { index, row ->
-                if (row.sortOrder != index) {
-                    dao.updateSortOrder(row.tabId, index)
+            visibleTabs.forEachIndexed { index, entity ->
+                if (entity.sortOrder != index) {
+                    dao.updateSortOrder(entity.tabId, index)
                 }
             }
         }
@@ -210,50 +175,42 @@ class TabRepository(context: Context) {
         targetIndex: Int? = null,
     ) {
         val visibleTabs = dao.getAllTabs()
-            .filterNot(TabStateRow::isPlaceholderForPreAssignment)
+            .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
             .toMutableList()
 
         if (moveTabId != null && targetIndex != null) {
             val currentIndex = visibleTabs.indexOfFirst { it.tabId == moveTabId }
             if (currentIndex >= 0) {
-                val row = visibleTabs.removeAt(currentIndex)
-                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), row)
+                val entity = visibleTabs.removeAt(currentIndex)
+                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), entity)
             }
         }
 
-        visibleTabs.forEachIndexed { index, row ->
-            if (row.sortOrder != index) {
-                dao.updateSortOrder(row.tabId, index)
+        visibleTabs.forEachIndexed { index, entity ->
+            if (entity.sortOrder != index) {
+                dao.updateSortOrder(entity.tabId, index)
             }
         }
     }
 
-    private suspend fun List<TabStateRow>.toPersistedTabStateContainer(): PersistedTabStateContainer {
-        val visibleRows = filterNot(TabStateRow::isPlaceholderForPreAssignment)
-        val selectedTabId = visibleRows.firstOrNull { it.isSelected == 1 }?.tabId
-            ?: visibleRows.lastOrNull()?.tabId
+    private fun List<TabStateEntity>.toPersistedTabStateContainer(): PersistedTabStateContainer {
+        val visibleEntities = filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+        val selectedTabId = visibleEntities.firstOrNull { it.isSelected == 1 }?.tabId
+            ?: visibleEntities.lastOrNull()?.tabId
         return PersistedTabStateContainer(
-            tabs = visibleRows.map { it.toPersistedTabState() },
+            tabs = visibleEntities.map { it.toPersistedTabState() },
             selectedTabId = selectedTabId,
         )
     }
 
-    private suspend fun TabStateRow.toPersistedTabState() = PersistedTabState(
+    private fun TabStateEntity.toPersistedTabState() = PersistedTabState(
         url = url,
-        sessionState = resolveSessionState(tabId),
+        sessionState = readSessionState(tabId),
         title = title,
         tabId = tabId,
         openerTabId = openerTabId,
         themeColor = themeColor,
     )
-
-    private companion object {
-        /**
-         * 旧 DB から sessionState を分割読みする際の 1 チャンクの文字数。
-         * 最悪 4byte/文字でも約 1MB に収まり、CursorWindow 上限(約2MB)を超えない。
-         */
-        private const val SESSION_STATE_CHUNK_CHARS = 256 * 1024
-    }
 }
 
 data class PersistedTabStateContainer(
@@ -270,9 +227,8 @@ data class PersistedTabState(
     val themeColor: Int? = null,
 )
 
-private fun TabStateRow.isPlaceholderForPreAssignment(): Boolean {
+private fun TabStateEntity.isPlaceholderForPreAssignment(): Boolean {
     // グループ先行割り当てのプレースホルダ行は全フィールドが空。
-    // sessionState はファイルへ移行したため、ここでは射影に含まれるフィールドのみで判定する。
     // 実タブは必ず非空の url を持つため、これで一意に識別できる。
     return url.isBlank() &&
         title.isBlank() &&

--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -43,7 +43,9 @@ class TabRepository(context: Context) {
     /**
      * 指定タブの sessionState を解決する。
      * ファイルがあればそれを返す。無い場合は旧バージョンで DB 列に保存された
-     * sessionState をファイルへ移行してから返す（移行後は DB 列を空にする）。
+     * sessionState をファイルへコピーしてから返す。
+     * ファイル移行が正しく動くと確認できるまでは、安全のため DB 列のデータは消さずに残す。
+     * （DB 列データの削除と移行コードの撤去は別 Issue で対応する）
      */
     private suspend fun resolveSessionState(tabId: String): String {
         val file = sessionStateFile(tabId)
@@ -52,8 +54,8 @@ class TabRepository(context: Context) {
         }
         val fromDb = readSessionStateFromDb(tabId)
         if (fromDb.isNotEmpty()) {
+            // DB のデータはバックアップとして温存し、ファイルへコピーするだけに留める
             writeSessionState(tabId, fromDb)
-            dao.clearSessionState(tabId)
         }
         return fromDb
     }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
@@ -23,7 +23,8 @@ interface DownloadDao {
     @Query("UPDATE download SET status = :status WHERE workerId = :workerId")
     suspend fun updateStatus(workerId: String, status: String)
 
-    @Query("UPDATE download SET status = 'FAILED' WHERE currentWorkerId = :currentWorkerId")
+    /** 実行中（ENQUEUED/RUNNING）のときのみ失敗にする。PAUSED/CANCELLED の上書きを防ぐ */
+    @Query("UPDATE download SET status = 'FAILED' WHERE currentWorkerId = :currentWorkerId AND status IN ('ENQUEUED', 'RUNNING')")
     suspend fun updateFailed(currentWorkerId: String)
 
     /** SUCCEEDED/FAILED 以外の状態のときのみキャンセルする。完了済みの上書きを防ぐ */

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
@@ -30,6 +30,10 @@ interface DownloadDao {
     @Query("UPDATE download SET status = 'CANCELLED' WHERE workerId = :workerId AND status NOT IN ('SUCCEEDED', 'FAILED', 'CANCELLED')")
     suspend fun cancelIfActive(workerId: String)
 
+    /** 実行中（ENQUEUED/RUNNING）のときのみ一時停止する。完了・失敗・キャンセル済みの上書きを防ぐ */
+    @Query("UPDATE download SET status = 'PAUSED' WHERE workerId = :workerId AND status IN ('ENQUEUED', 'RUNNING')")
+    suspend fun pauseIfActive(workerId: String)
+
     /** 指定ワーカーの現在のステータスを取得する。レコードが無い場合は null */
     @Query("SELECT status FROM download WHERE workerId = :workerId")
     suspend fun getStatus(workerId: String): String?
@@ -70,6 +74,23 @@ interface DownloadDao {
             "WHERE workerId = :workerId AND status = 'RUNNING'",
     )
     suspend fun updatePartialFailed(
+        workerId: String,
+        partialFileUri: String,
+        fileName: String,
+        totalRead: Long,
+        contentLength: Long,
+    )
+
+    /**
+     * 一時停止時に部分ファイルURIを保存する。
+     * 再開可能なダウンロードとしてPAUSEDステータスで記録する
+     */
+    @Query(
+        "UPDATE download SET partialFileUri = :partialFileUri, " +
+            "fileName = :fileName, totalRead = :totalRead, contentLength = :contentLength " +
+            "WHERE workerId = :workerId AND status = 'PAUSED'",
+    )
+    suspend fun updatePausedPartial(
         workerId: String,
         partialFileUri: String,
         fileName: String,

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
@@ -17,34 +17,34 @@ interface DownloadDao {
     suspend fun insertIgnoreConflict(entity: DownloadEntity)
 
     /** ENQUEUEDからRUNNINGへの状態遷移。ENQUEUED以外は変更しない */
-    @Query("UPDATE download SET status = 'RUNNING' WHERE workerId = :workerId AND status = 'ENQUEUED'")
-    suspend fun updateEnqueuedToRunning(workerId: String)
+    @Query("UPDATE download SET status = 'RUNNING' WHERE currentWorkerId = :currentWorkerId AND status = 'ENQUEUED'")
+    suspend fun updateEnqueuedToRunning(currentWorkerId: String)
 
     @Query("UPDATE download SET status = :status WHERE workerId = :workerId")
     suspend fun updateStatus(workerId: String, status: String)
 
-    @Query("UPDATE download SET status = 'FAILED' WHERE workerId = :workerId")
-    suspend fun updateFailed(workerId: String)
+    @Query("UPDATE download SET status = 'FAILED' WHERE currentWorkerId = :currentWorkerId")
+    suspend fun updateFailed(currentWorkerId: String)
 
     /** SUCCEEDED/FAILED 以外の状態のときのみキャンセルする。完了済みの上書きを防ぐ */
-    @Query("UPDATE download SET status = 'CANCELLED' WHERE workerId = :workerId AND status NOT IN ('SUCCEEDED', 'FAILED', 'CANCELLED')")
-    suspend fun cancelIfActive(workerId: String)
+    @Query("UPDATE download SET status = 'CANCELLED' WHERE currentWorkerId = :currentWorkerId AND status NOT IN ('SUCCEEDED', 'FAILED', 'CANCELLED')")
+    suspend fun cancelIfActive(currentWorkerId: String)
 
     /** 実行中（ENQUEUED/RUNNING）のときのみ一時停止する。完了・失敗・キャンセル済みの上書きを防ぐ */
-    @Query("UPDATE download SET status = 'PAUSED' WHERE workerId = :workerId AND status IN ('ENQUEUED', 'RUNNING')")
-    suspend fun pauseIfActive(workerId: String)
+    @Query("UPDATE download SET status = 'PAUSED' WHERE currentWorkerId = :currentWorkerId AND status IN ('ENQUEUED', 'RUNNING')")
+    suspend fun pauseIfActive(currentWorkerId: String)
 
     /** 指定ワーカーの現在のステータスを取得する。レコードが無い場合は null */
-    @Query("SELECT status FROM download WHERE workerId = :workerId")
-    suspend fun getStatus(workerId: String): String?
+    @Query("SELECT status FROM download WHERE currentWorkerId = :currentWorkerId")
+    suspend fun getStatus(currentWorkerId: String): String?
 
     @Query(
         "UPDATE download SET fileName = :fileName, status = 'RUNNING', " +
             "progress = :progress, totalRead = :totalRead, contentLength = :contentLength " +
-            "WHERE workerId = :workerId AND status = 'RUNNING'",
+            "WHERE currentWorkerId = :currentWorkerId AND status = 'RUNNING'",
     )
     suspend fun updateProgress(
-        workerId: String,
+        currentWorkerId: String,
         fileName: String,
         progress: Int,
         totalRead: Long,
@@ -54,15 +54,15 @@ interface DownloadDao {
     /** キャンセル済みレコードを完了で上書きしない（キャンセルとWorker完了の競合対策） */
     @Query(
         "UPDATE download SET fileName = :fileName, fileUri = :fileUri, status = 'SUCCEEDED' " +
-            "WHERE workerId = :workerId AND status != 'CANCELLED'",
+            "WHERE currentWorkerId = :currentWorkerId AND status != 'CANCELLED'",
     )
-    suspend fun updateCompleted(workerId: String, fileName: String, fileUri: String)
+    suspend fun updateCompleted(currentWorkerId: String, fileName: String, fileUri: String)
 
     @Query("SELECT * FROM download ORDER BY enqueuedAt DESC")
     fun observeAll(): Flow<List<DownloadEntity>>
 
-    @Query("SELECT * FROM download WHERE workerId = :workerId")
-    suspend fun get(workerId: String): DownloadEntity
+    @Query("SELECT * FROM download WHERE currentWorkerId = :currentWorkerId")
+    suspend fun getByCurrentWorkerId(currentWorkerId: String): DownloadEntity?
 
     /**
      * ダウンロード失敗時に部分ファイルURIを保存する。
@@ -71,10 +71,10 @@ interface DownloadDao {
     @Query(
         "UPDATE download SET status = 'FAILED', partialFileUri = :partialFileUri, " +
             "fileName = :fileName, totalRead = :totalRead, contentLength = :contentLength " +
-            "WHERE workerId = :workerId AND status = 'RUNNING'",
+            "WHERE currentWorkerId = :currentWorkerId AND status = 'RUNNING'",
     )
     suspend fun updatePartialFailed(
-        workerId: String,
+        currentWorkerId: String,
         partialFileUri: String,
         fileName: String,
         totalRead: Long,
@@ -88,16 +88,21 @@ interface DownloadDao {
     @Query(
         "UPDATE download SET partialFileUri = :partialFileUri, " +
             "fileName = :fileName, totalRead = :totalRead, contentLength = :contentLength " +
-            "WHERE workerId = :workerId AND status = 'PAUSED'",
+            "WHERE currentWorkerId = :currentWorkerId AND status = 'PAUSED'",
     )
     suspend fun updatePausedPartial(
-        workerId: String,
+        currentWorkerId: String,
         partialFileUri: String,
         fileName: String,
         totalRead: Long,
         contentLength: Long,
     )
 
-    @Query("DELETE FROM download WHERE workerId = :workerId")
-    suspend fun deleteById(workerId: String)
+    /**
+     * 再開時に既存レコードを新しいワーカーIDへ付け替えてENQUEUEDに戻す。
+     * レコードを削除・再作成しないため、enqueuedAt（リスト上の位置）と
+     * UIのアイテム同一性（workerId）が維持される
+     */
+    @Query("UPDATE download SET currentWorkerId = :newWorkerId, status = 'ENQUEUED' WHERE workerId = :workerId")
+    suspend fun updateResumed(workerId: String, newWorkerId: String)
 }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDao.kt
@@ -52,10 +52,10 @@ interface DownloadDao {
         contentLength: Long,
     )
 
-    /** キャンセル済みレコードを完了で上書きしない（キャンセルとWorker完了の競合対策） */
+    /** キャンセル/一時停止済みレコードを完了で上書きしない（停止要求とWorker完了の競合対策） */
     @Query(
         "UPDATE download SET fileName = :fileName, fileUri = :fileUri, status = 'SUCCEEDED' " +
-            "WHERE currentWorkerId = :currentWorkerId AND status != 'CANCELLED'",
+            "WHERE currentWorkerId = :currentWorkerId AND status NOT IN ('CANCELLED', 'PAUSED')",
     )
     suspend fun updateCompleted(currentWorkerId: String, fileName: String, fileUri: String)
 

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDatabase.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [DownloadEntity::class], version = 3, exportSchema = false)
+@Database(entities = [DownloadEntity::class], version = 4, exportSchema = false)
 abstract class DownloadDatabase : RoomDatabase() {
 
     abstract fun downloadDao(): DownloadDao
@@ -32,13 +32,22 @@ abstract class DownloadDatabase : RoomDatabase() {
             }
         }
 
+        /** バージョン3→4: currentWorkerId にインデックスを追加し、状態判定・進捗更新クエリを高速化する */
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_download_currentWorkerId ON download(currentWorkerId)",
+                )
+            }
+        }
+
         fun getInstance(context: Context): DownloadDatabase {
             return instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
                     context.applicationContext,
                     DownloadDatabase::class.java,
                     "download.db",
-                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build().also { instance = it }
+                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4).build().also { instance = it }
             }
         }
     }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDatabase.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [DownloadEntity::class], version = 2, exportSchema = false)
+@Database(entities = [DownloadEntity::class], version = 3, exportSchema = false)
 abstract class DownloadDatabase : RoomDatabase() {
 
     abstract fun downloadDao(): DownloadDao
@@ -24,13 +24,21 @@ abstract class DownloadDatabase : RoomDatabase() {
             }
         }
 
+        /** バージョン2→3: currentWorkerId カラムを追加（既存レコードは workerId と同値で埋める） */
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE download ADD COLUMN currentWorkerId TEXT NOT NULL DEFAULT ''")
+                db.execSQL("UPDATE download SET currentWorkerId = workerId")
+            }
+        }
+
         fun getInstance(context: Context): DownloadDatabase {
             return instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
                     context.applicationContext,
                     DownloadDatabase::class.java,
                     "download.db",
-                ).addMigrations(MIGRATION_1_2).build().also { instance = it }
+                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build().also { instance = it }
             }
         }
     }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadEntity.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadEntity.kt
@@ -1,9 +1,13 @@
 package net.matsudamper.browser.data.download
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "download")
+@Entity(
+    tableName = "download",
+    indices = [Index(value = ["currentWorkerId"])],
+)
 data class DownloadEntity(
     /** レコードの安定ID。初回ダウンロード時のワーカーIDで、再開してもこの値は変わらない */
     @PrimaryKey val workerId: String,

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadEntity.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadEntity.kt
@@ -5,7 +5,10 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "download")
 data class DownloadEntity(
+    /** レコードの安定ID。初回ダウンロード時のワーカーIDで、再開してもこの値は変わらない */
     @PrimaryKey val workerId: String,
+    /** 現在実行中（または最後に実行した）WorkManagerワーカーのID。再開のたびに更新される */
+    val currentWorkerId: String,
     val url: String,
     val fileName: String,
     val fileUri: String?,

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.UUID
 
-enum class DownloadRecordStatus { ENQUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED }
+enum class DownloadRecordStatus { ENQUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED, PAUSED }
 
 data class DownloadRecord(
     val workerId: UUID,
@@ -18,7 +18,7 @@ data class DownloadRecord(
     val contentLength: Long,
     val enqueuedAt: Long,
     val referrerUrl: String,
-    /** 失敗時に保存した部分ファイルURI。非nullの場合は再開可能 */
+    /** 失敗・一時停止時に保存した部分ファイルURI。非nullの場合は再開可能 */
     val partialFileUri: String?,
 )
 
@@ -120,6 +120,36 @@ class DownloadRepository(context: Context) {
         dao.cancelIfActive(workerId)
     }
 
+    /** ENQUEUED/RUNNING のときのみ一時停止状態に更新する */
+    suspend fun updatePaused(workerId: String) {
+        dao.pauseIfActive(workerId)
+    }
+
+    /** 指定したワーカーのレコードが一時停止済みかどうかを返す */
+    suspend fun isPaused(workerId: String): Boolean {
+        return dao.getStatus(workerId) == DownloadRecordStatus.PAUSED.name
+    }
+
+    /**
+     * 一時停止時に部分ファイルURIを保存する。
+     * 再開可能なPAUSEDレコードとして記録する
+     */
+    suspend fun updatePausedPartial(
+        workerId: String,
+        partialFileUri: String,
+        fileName: String,
+        totalRead: Long,
+        contentLength: Long,
+    ) {
+        dao.updatePausedPartial(
+            workerId = workerId,
+            partialFileUri = partialFileUri,
+            fileName = fileName,
+            totalRead = totalRead,
+            contentLength = contentLength,
+        )
+    }
+
     /**
      * 指定したワーカーのレコードがキャンセル済みかどうかを返す。
      * WorkManager の割り込みが取りこぼされた場合でも Worker が自力で停止できるよう、
@@ -127,6 +157,18 @@ class DownloadRepository(context: Context) {
      */
     suspend fun isCancelled(workerId: String): Boolean {
         return dao.getStatus(workerId) == DownloadRecordStatus.CANCELLED.name
+    }
+
+    /**
+     * 指定したワーカーのレコードがキャンセルまたは一時停止済みかどうかを返す。
+     * WorkManager の割り込みが取りこぼされた場合でも Worker が自力で停止できるよう、
+     * Worker の進捗更新時にポーリングして確認するために使用する
+     */
+    suspend fun isStopRequested(workerId: String): Boolean {
+        return dao.getStatus(workerId) in listOf(
+            DownloadRecordStatus.CANCELLED.name,
+            DownloadRecordStatus.PAUSED.name,
+        )
     }
 
     suspend fun get(workerId: UUID): DownloadEntity {

--- a/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/download/DownloadRepository.kt
@@ -8,7 +8,10 @@ import java.util.UUID
 enum class DownloadRecordStatus { ENQUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED, PAUSED }
 
 data class DownloadRecord(
+    /** レコードの安定ID。再開してもこの値は変わらない */
     val workerId: UUID,
+    /** 現在のWorkManagerワーカーのID。再開のたびに更新される */
+    val currentWorkerId: UUID,
     val url: String,
     val fileName: String,
     val fileUri: String?,
@@ -35,6 +38,7 @@ class DownloadRepository(context: Context) {
         dao.insertIgnoreConflict(
             DownloadEntity(
                 workerId = workerId,
+                currentWorkerId = workerId,
                 url = url,
                 fileName = "",
                 fileUri = null,
@@ -49,37 +53,41 @@ class DownloadRepository(context: Context) {
         )
     }
 
-    /** Worker 開始時に RUNNING 状態に遷移する。ENQUEUED レコードがあれば遷移、なければ新規挿入する */
+    /** Worker 開始時に RUNNING 状態に遷移する。レコードがあれば遷移、なければ新規挿入する */
     suspend fun insertDownload(workerId: String, url: String, referrerUrl: String, enqueuedAt: Long) {
-        // ENQUEUEDレコードがない場合に備えてRUNNINGで新規挿入（競合時は無視）
-        dao.insertIgnoreConflict(
-            DownloadEntity(
-                workerId = workerId,
-                url = url,
-                fileName = "",
-                fileUri = null,
-                status = DownloadRecordStatus.RUNNING.name,
-                progress = 0,
-                totalRead = 0L,
-                contentLength = -1L,
-                enqueuedAt = enqueuedAt,
-                referrerUrl = referrerUrl,
-                partialFileUri = null,
-            ),
-        )
+        // 再開時はエンキュー済みレコードが currentWorkerId で紐付いているため、
+        // 存在しない場合（エンキュー前にWorkerが起動したケース）のみ新規挿入する
+        if (dao.getByCurrentWorkerId(workerId) == null) {
+            dao.insertIgnoreConflict(
+                DownloadEntity(
+                    workerId = workerId,
+                    currentWorkerId = workerId,
+                    url = url,
+                    fileName = "",
+                    fileUri = null,
+                    status = DownloadRecordStatus.RUNNING.name,
+                    progress = 0,
+                    totalRead = 0L,
+                    contentLength = -1L,
+                    enqueuedAt = enqueuedAt,
+                    referrerUrl = referrerUrl,
+                    partialFileUri = null,
+                ),
+            )
+        }
         // ENQUEUEDからRUNNINGへの状態遷移（既にRUNNINGの場合は何もしない）
         dao.updateEnqueuedToRunning(workerId)
     }
 
     suspend fun updateProgress(
-        workerId: String,
+        currentWorkerId: String,
         fileName: String,
         progress: Int,
         totalRead: Long,
         contentLength: Long,
     ) {
         dao.updateProgress(
-            workerId = workerId,
+            currentWorkerId = currentWorkerId,
             fileName = fileName,
             progress = progress,
             totalRead = totalRead,
@@ -87,12 +95,12 @@ class DownloadRepository(context: Context) {
         )
     }
 
-    suspend fun updateCompleted(workerId: String, fileName: String, fileUri: String) {
-        dao.updateCompleted(workerId = workerId, fileName = fileName, fileUri = fileUri)
+    suspend fun updateCompleted(currentWorkerId: String, fileName: String, fileUri: String) {
+        dao.updateCompleted(currentWorkerId = currentWorkerId, fileName = fileName, fileUri = fileUri)
     }
 
-    suspend fun updateFailed(workerId: String) {
-        dao.updateFailed(workerId = workerId)
+    suspend fun updateFailed(currentWorkerId: String) {
+        dao.updateFailed(currentWorkerId = currentWorkerId)
     }
 
     /**
@@ -100,14 +108,14 @@ class DownloadRepository(context: Context) {
      * 再開可能なFAILEDレコードとして記録する
      */
     suspend fun updatePartialFailed(
-        workerId: String,
+        currentWorkerId: String,
         partialFileUri: String,
         fileName: String,
         totalRead: Long,
         contentLength: Long,
     ) {
         dao.updatePartialFailed(
-            workerId = workerId,
+            currentWorkerId = currentWorkerId,
             partialFileUri = partialFileUri,
             fileName = fileName,
             totalRead = totalRead,
@@ -116,18 +124,18 @@ class DownloadRepository(context: Context) {
     }
 
     /** SUCCEEDED/FAILED 以外の状態のときのみキャンセル状態に更新する */
-    suspend fun updateCancelled(workerId: String) {
-        dao.cancelIfActive(workerId)
+    suspend fun updateCancelled(currentWorkerId: String) {
+        dao.cancelIfActive(currentWorkerId)
     }
 
     /** ENQUEUED/RUNNING のときのみ一時停止状態に更新する */
-    suspend fun updatePaused(workerId: String) {
-        dao.pauseIfActive(workerId)
+    suspend fun updatePaused(currentWorkerId: String) {
+        dao.pauseIfActive(currentWorkerId)
     }
 
     /** 指定したワーカーのレコードが一時停止済みかどうかを返す */
-    suspend fun isPaused(workerId: String): Boolean {
-        return dao.getStatus(workerId) == DownloadRecordStatus.PAUSED.name
+    suspend fun isPaused(currentWorkerId: String): Boolean {
+        return dao.getStatus(currentWorkerId) == DownloadRecordStatus.PAUSED.name
     }
 
     /**
@@ -135,14 +143,14 @@ class DownloadRepository(context: Context) {
      * 再開可能なPAUSEDレコードとして記録する
      */
     suspend fun updatePausedPartial(
-        workerId: String,
+        currentWorkerId: String,
         partialFileUri: String,
         fileName: String,
         totalRead: Long,
         contentLength: Long,
     ) {
         dao.updatePausedPartial(
-            workerId = workerId,
+            currentWorkerId = currentWorkerId,
             partialFileUri = partialFileUri,
             fileName = fileName,
             totalRead = totalRead,
@@ -150,13 +158,8 @@ class DownloadRepository(context: Context) {
         )
     }
 
-    /**
-     * 指定したワーカーのレコードがキャンセル済みかどうかを返す。
-     * WorkManager の割り込みが取りこぼされた場合でも Worker が自力で停止できるよう、
-     * Worker の進捗更新時にポーリングして確認するために使用する
-     */
-    suspend fun isCancelled(workerId: String): Boolean {
-        return dao.getStatus(workerId) == DownloadRecordStatus.CANCELLED.name
+    suspend fun isCancelled(currentWorkerId: String): Boolean {
+        return dao.getStatus(currentWorkerId) == DownloadRecordStatus.CANCELLED.name
     }
 
     /**
@@ -164,20 +167,23 @@ class DownloadRepository(context: Context) {
      * WorkManager の割り込みが取りこぼされた場合でも Worker が自力で停止できるよう、
      * Worker の進捗更新時にポーリングして確認するために使用する
      */
-    suspend fun isStopRequested(workerId: String): Boolean {
-        return dao.getStatus(workerId) in listOf(
+    suspend fun isStopRequested(currentWorkerId: String): Boolean {
+        return dao.getStatus(currentWorkerId) in listOf(
             DownloadRecordStatus.CANCELLED.name,
             DownloadRecordStatus.PAUSED.name,
         )
     }
 
-    suspend fun get(workerId: UUID): DownloadEntity {
-        return dao.get(workerId = workerId.toString())
+    suspend fun getByCurrentWorkerId(currentWorkerId: UUID): DownloadEntity? {
+        return dao.getByCurrentWorkerId(currentWorkerId = currentWorkerId.toString())
     }
 
-    /** 指定したワーカーIDのレコードを削除する（再開時に古いレコードを削除するために使用） */
-    suspend fun deleteById(workerId: String) {
-        dao.deleteById(workerId)
+    /**
+     * 再開時に既存レコードを新しいワーカーIDへ付け替えてENQUEUEDに戻す。
+     * レコードを削除・再作成しないため、リスト上の位置とUIのアイテム同一性が維持される
+     */
+    suspend fun updateResumed(workerId: String, newWorkerId: String) {
+        dao.updateResumed(workerId = workerId, newWorkerId = newWorkerId)
     }
 
     private fun DownloadEntity.toRecord(): DownloadRecord {
@@ -188,6 +194,7 @@ class DownloadRepository(context: Context) {
         }
         return DownloadRecord(
             workerId = UUID.fromString(workerId),
+            currentWorkerId = UUID.fromString(currentWorkerId),
             url = url,
             fileName = fileName,
             fileUri = fileUri,

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
@@ -47,7 +47,8 @@ interface TabDao {
     @Query("UPDATE tab_state SET isSelected = 0")
     suspend fun clearSelectedTab()
 
-    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへ移行するための補助クエリ ---
+    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへコピーするための補助クエリ ---
+    // 移行が正しく動くと確認できるまでは DB 列のデータは消さず、バックアップとして残す。
 
     /** sessionState の文字数を取得する。セルの中身は CursorWindow に載らないため安全 */
     @Query("SELECT length(sessionState) FROM tab_state WHERE tabId = :tabId")
@@ -59,10 +60,6 @@ interface TabDao {
      */
     @Query("SELECT substr(sessionState, :start, :count) FROM tab_state WHERE tabId = :tabId")
     suspend fun getSessionStateChunk(tabId: String, start: Int, count: Int): String?
-
-    /** ファイルへ移行済みの sessionState を DB から空にする */
-    @Query("UPDATE tab_state SET sessionState = '' WHERE tabId = :tabId")
-    suspend fun clearSessionState(tabId: String)
 }
 
 /**

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
@@ -11,14 +11,19 @@ interface TabDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertTab(tab: TabStateEntity)
 
-    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
-    suspend fun getAllTabs(): List<TabStateEntity>
+    // sessionState は CursorWindow 上限(約2MB)を超え得るため一覧取得では読まない。
+    // SELECT * を避け、sessionState 以外のメタデータのみを射影して取得する。
+    @Query(
+        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
+            "FROM tab_state ORDER BY sortOrder ASC",
+    )
+    suspend fun getAllTabs(): List<TabStateRow>
 
-    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
-    fun observeAllTabs(): Flow<List<TabStateEntity>>
-
-    @Query("SELECT * FROM tab_state WHERE tabId = :tabId LIMIT 1")
-    suspend fun getTab(tabId: String): TabStateEntity?
+    @Query(
+        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
+            "FROM tab_state ORDER BY sortOrder ASC",
+    )
+    fun observeAllTabs(): Flow<List<TabStateRow>>
 
     @Query("DELETE FROM tab_state WHERE tabId = :tabId")
     suspend fun deleteTab(tabId: String)
@@ -28,9 +33,6 @@ interface TabDao {
 
     @Query("UPDATE tab_state SET title = :title WHERE tabId = :tabId")
     suspend fun updateTitle(tabId: String, title: String)
-
-    @Query("UPDATE tab_state SET sessionState = :sessionState WHERE tabId = :tabId")
-    suspend fun updateSessionState(tabId: String, sessionState: String)
 
     @Query("UPDATE tab_state SET themeColor = :themeColor WHERE tabId = :tabId")
     suspend fun updateThemeColor(tabId: String, themeColor: Int?)
@@ -44,4 +46,36 @@ interface TabDao {
 
     @Query("UPDATE tab_state SET isSelected = 0")
     suspend fun clearSelectedTab()
+
+    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへ移行するための補助クエリ ---
+
+    /** sessionState の文字数を取得する。セルの中身は CursorWindow に載らないため安全 */
+    @Query("SELECT length(sessionState) FROM tab_state WHERE tabId = :tabId")
+    suspend fun getSessionStateLength(tabId: String): Int?
+
+    /**
+     * sessionState を substr で部分取得する（1始まり）。
+     * 巨大セルでも 1 チャンクずつなら CursorWindow 上限に収まるため、分割して読み出せる。
+     */
+    @Query("SELECT substr(sessionState, :start, :count) FROM tab_state WHERE tabId = :tabId")
+    suspend fun getSessionStateChunk(tabId: String, start: Int, count: Int): String?
+
+    /** ファイルへ移行済みの sessionState を DB から空にする */
+    @Query("UPDATE tab_state SET sessionState = '' WHERE tabId = :tabId")
+    suspend fun clearSessionState(tabId: String)
 }
+
+/**
+ * tab_state からセッション状態(sessionState)を除いたメタデータ射影。
+ * sessionState は肥大化して CursorWindow 上限を超え得るため一覧取得には含めない。
+ */
+data class TabStateRow(
+    val tabId: String,
+    val url: String,
+    val title: String,
+    val openerTabId: String,
+    val themeColor: Int?,
+    val sortOrder: Int,
+    val isSelected: Int,
+    val groupId: String,
+)

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
@@ -11,19 +11,11 @@ interface TabDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertTab(tab: TabStateEntity)
 
-    // sessionState は CursorWindow 上限(約2MB)を超え得るため一覧取得では読まない。
-    // SELECT * を避け、sessionState 以外のメタデータのみを射影して取得する。
-    @Query(
-        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
-            "FROM tab_state ORDER BY sortOrder ASC",
-    )
-    suspend fun getAllTabs(): List<TabStateRow>
+    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
+    suspend fun getAllTabs(): List<TabStateEntity>
 
-    @Query(
-        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
-            "FROM tab_state ORDER BY sortOrder ASC",
-    )
-    fun observeAllTabs(): Flow<List<TabStateRow>>
+    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
+    fun observeAllTabs(): Flow<List<TabStateEntity>>
 
     @Query("DELETE FROM tab_state WHERE tabId = :tabId")
     suspend fun deleteTab(tabId: String)
@@ -46,33 +38,4 @@ interface TabDao {
 
     @Query("UPDATE tab_state SET isSelected = 0")
     suspend fun clearSelectedTab()
-
-    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへコピーするための補助クエリ ---
-    // 移行が正しく動くと確認できるまでは DB 列のデータは消さず、バックアップとして残す。
-
-    /** sessionState の文字数を取得する。セルの中身は CursorWindow に載らないため安全 */
-    @Query("SELECT length(sessionState) FROM tab_state WHERE tabId = :tabId")
-    suspend fun getSessionStateLength(tabId: String): Int?
-
-    /**
-     * sessionState を substr で部分取得する（1始まり）。
-     * 巨大セルでも 1 チャンクずつなら CursorWindow 上限に収まるため、分割して読み出せる。
-     */
-    @Query("SELECT substr(sessionState, :start, :count) FROM tab_state WHERE tabId = :tabId")
-    suspend fun getSessionStateChunk(tabId: String, start: Int, count: Int): String?
 }
-
-/**
- * tab_state からセッション状態(sessionState)を除いたメタデータ射影。
- * sessionState は肥大化して CursorWindow 上限を超え得るため一覧取得には含めない。
- */
-data class TabStateRow(
-    val tabId: String,
-    val url: String,
-    val title: String,
-    val openerTabId: String,
-    val themeColor: Int?,
-    val sortOrder: Int,
-    val isSelected: Int,
-    val groupId: String,
-)

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDatabase.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import java.io.File
 
 @Database(
     entities = [TabStateEntity::class, TabGroupEntity::class],
@@ -18,7 +19,7 @@ abstract class TabDatabase : RoomDatabase() {
 
     companion object {
         /** Room の @Database version と連動。バックアップ互換性チェックでも参照する */
-        const val SCHEMA_VERSION: Int = 3
+        const val SCHEMA_VERSION: Int = 4
 
         @Volatile
         private var instance: TabDatabase? = null
@@ -40,20 +41,86 @@ abstract class TabDatabase : RoomDatabase() {
             }
         }
 
+        private const val SESSION_STATE_CHUNK_CHARS = 256 * 1024
+
+        /**
+         * v3→v4: tab_state から sessionState カラムを削除する。
+         * 削除前に、まだファイルへ移行されていない sessionState をファイルへコピーする。
+         * CursorWindow 上限(約2MB)を超え得るため substr で分割読みする。
+         * 既にアプリ側で移行済み（ファイルが存在する）タブはスキップする。
+         */
+        internal fun createMigration3To4(sessionStateDir: File): Migration = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                migrateSessionStatesToFiles(db, sessionStateDir)
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `tab_state_new` (" +
+                        "`tabId` TEXT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, " +
+                        "`openerTabId` TEXT NOT NULL, `themeColor` INTEGER, `sortOrder` INTEGER NOT NULL, " +
+                        "`isSelected` INTEGER NOT NULL, `groupId` TEXT NOT NULL, PRIMARY KEY(`tabId`))",
+                )
+                db.execSQL(
+                    "INSERT INTO `tab_state_new` " +
+                        "(`tabId`, `url`, `title`, `openerTabId`, `themeColor`, `sortOrder`, `isSelected`, `groupId`) " +
+                        "SELECT `tabId`, `url`, `title`, `openerTabId`, `themeColor`, `sortOrder`, `isSelected`, `groupId` " +
+                        "FROM `tab_state`",
+                )
+                db.execSQL("DROP TABLE `tab_state`")
+                db.execSQL("ALTER TABLE `tab_state_new` RENAME TO `tab_state`")
+            }
+        }
+
+        private fun migrateSessionStatesToFiles(db: SupportSQLiteDatabase, sessionStateDir: File) {
+            if (!sessionStateDir.exists()) sessionStateDir.mkdirs()
+            db.query(
+                "SELECT tabId, length(sessionState) FROM tab_state " +
+                    "WHERE sessionState IS NOT NULL AND length(sessionState) > 0",
+            ).use { cursor ->
+                while (cursor.moveToNext()) {
+                    val tabId = cursor.getString(0)
+                    val length = cursor.getInt(1)
+                    if (File(sessionStateDir, tabId).exists()) continue
+                    try {
+                        val builder = StringBuilder(length)
+                        var offset = 1
+                        while (offset <= length) {
+                            db.query(
+                                "SELECT substr(sessionState, ?, ?) FROM tab_state WHERE tabId = ?",
+                                arrayOf<Any?>(offset, SESSION_STATE_CHUNK_CHARS, tabId),
+                            ).use { chunkCursor ->
+                                if (chunkCursor.moveToFirst()) {
+                                    chunkCursor.getString(0)?.let { builder.append(it) }
+                                }
+                            }
+                            offset += SESSION_STATE_CHUNK_CHARS
+                        }
+                        if (builder.isNotEmpty()) {
+                            File(sessionStateDir, tabId).writeText(builder.toString())
+                        }
+                    } catch (_: Exception) {
+                        // ファイル書き込み失敗時はスキップ（セッション状態は失われるがアプリは起動できる）
+                    }
+                }
+            }
+        }
+
         /** 全マイグレーション。getInstance とマイグレーションテストで共用する */
-        internal val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
+        internal fun allMigrations(sessionStateDir: File): Array<Migration> = arrayOf(
+            MIGRATION_1_2, MIGRATION_2_3, createMigration3To4(sessionStateDir),
+        )
 
         fun getInstance(context: Context): TabDatabase {
-            // closeInstance() 後の fast-path で閉じた DB を返さないよう isOpen を確認する
             instance?.takeIf { it.isOpen }?.let { return it }
             return synchronized(this) {
-                instance?.takeIf { it.isOpen } ?: Room.databaseBuilder(
-                    context.applicationContext,
-                    TabDatabase::class.java,
-                    "tab.db",
-                )
-                    .addMigrations(*ALL_MIGRATIONS)
-                    .build().also { instance = it }
+                instance?.takeIf { it.isOpen } ?: run {
+                    val sessionStateDir = File(context.filesDir, "tab_session_states")
+                    Room.databaseBuilder(
+                        context.applicationContext,
+                        TabDatabase::class.java,
+                        "tab.db",
+                    )
+                        .addMigrations(*allMigrations(sessionStateDir))
+                        .build().also { instance = it }
+                }
             }
         }
 
@@ -64,9 +131,6 @@ abstract class TabDatabase : RoomDatabase() {
          * 復元後のファイルを開くので、復元完了→プロセス終了の流れで使うこと。
          */
         fun closeInstance() {
-            // 参照を先に切ってから close する。ロック内で close まで行うと
-            // close 完了前に getInstance() を素通りした呼び出しが
-            // すでに閉じたインスタンスを掴む可能性があるため。
             val toClose = synchronized(this) {
                 val current = instance
                 instance = null

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabGroupDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabGroupDao.kt
@@ -52,7 +52,6 @@ abstract class TabGroupDao {
             TabStateEntity(
                 tabId = tabId,
                 url = "",
-                sessionState = "",
                 title = "",
                 openerTabId = "",
                 themeColor = null,
@@ -75,7 +74,6 @@ abstract class TabGroupDao {
             TabStateEntity(
                 tabId = tabId,
                 url = "",
-                sessionState = "",
                 title = "",
                 openerTabId = "",
                 themeColor = null,

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabStateEntity.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabStateEntity.kt
@@ -7,7 +7,6 @@ import androidx.room.PrimaryKey
 data class TabStateEntity(
     @PrimaryKey val tabId: String,
     val url: String,
-    val sessionState: String,
     val title: String,
     val openerTabId: String,
     val themeColor: Int?,

--- a/data/src/test/kotlin/net/matsudamper/browser/data/download/DownloadDatabaseMigrationTest.kt
+++ b/data/src/test/kotlin/net/matsudamper/browser/data/download/DownloadDatabaseMigrationTest.kt
@@ -37,18 +37,18 @@ class DownloadDatabaseMigrationTest {
             close()
         }
 
-        val db = helper.runMigrationsAndValidate(TEST_DB, 2, true, *DownloadDatabase.ALL_MIGRATIONS)
-
-        db.query(
-            "SELECT workerId, referrerUrl, partialFileUri FROM download WHERE workerId = 'w1'",
-        ).use { cursor ->
-            assertTrue(cursor.moveToFirst())
-            assertEquals("w1", cursor.getString(0))
-            // referrerUrl は NOT NULL DEFAULT '' のため空文字
-            assertEquals("", cursor.getString(1))
-            // partialFileUri は nullable のため NULL
-            assertTrue(cursor.isNull(2))
-            assertNull(cursor.getString(2))
+        helper.runMigrationsAndValidate(TEST_DB, 2, true, *DownloadDatabase.ALL_MIGRATIONS).use { db ->
+            db.query(
+                "SELECT workerId, referrerUrl, partialFileUri FROM download WHERE workerId = 'w1'",
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("w1", cursor.getString(0))
+                // referrerUrl は NOT NULL DEFAULT '' のため空文字
+                assertEquals("", cursor.getString(1))
+                // partialFileUri は nullable のため NULL
+                assertTrue(cursor.isNull(2))
+                assertNull(cursor.getString(2))
+            }
         }
     }
 
@@ -69,21 +69,21 @@ class DownloadDatabaseMigrationTest {
             close()
         }
 
-        val db = helper.runMigrationsAndValidate(TEST_DB, 4, true, *DownloadDatabase.ALL_MIGRATIONS)
-
-        db.query(
-            "SELECT workerId, currentWorkerId FROM download WHERE workerId = 'w2'",
-        ).use { cursor ->
-            assertTrue(cursor.moveToFirst())
-            assertEquals("w2", cursor.getString(0))
-            // currentWorkerId は workerId と同値でバックフィルされる
-            assertEquals("w2", cursor.getString(1))
-        }
-        // currentWorkerId にインデックスが作成されている
-        db.query(
-            "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'index_download_currentWorkerId'",
-        ).use { cursor ->
-            assertTrue(cursor.moveToFirst())
+        helper.runMigrationsAndValidate(TEST_DB, 4, true, *DownloadDatabase.ALL_MIGRATIONS).use { db ->
+            db.query(
+                "SELECT workerId, currentWorkerId FROM download WHERE workerId = 'w2'",
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("w2", cursor.getString(0))
+                // currentWorkerId は workerId と同値でバックフィルされる
+                assertEquals("w2", cursor.getString(1))
+            }
+            // currentWorkerId にインデックスが作成されている
+            db.query(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'index_download_currentWorkerId'",
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+            }
         }
     }
 

--- a/data/src/test/kotlin/net/matsudamper/browser/data/tab/TabDatabaseMigrationTest.kt
+++ b/data/src/test/kotlin/net/matsudamper/browser/data/tab/TabDatabaseMigrationTest.kt
@@ -2,11 +2,13 @@ package net.matsudamper.browser.data.tab
 
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -26,6 +28,9 @@ class TabDatabaseMigrationTest {
         TabDatabase::class.java,
     )
 
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
     /** v1→v2: tab_group テーブル追加と tab_state.groupId 追加。既存タブが保持されることを確認 */
     @Test
     fun migrate1To2() {
@@ -38,7 +43,9 @@ class TabDatabaseMigrationTest {
             close()
         }
 
-        val db = helper.runMigrationsAndValidate(TEST_DB, 2, true, *TabDatabase.ALL_MIGRATIONS)
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 2, true, *TabDatabase.allMigrations(sessionStateDir()),
+        )
 
         db.query("SELECT tabId, groupId FROM tab_state WHERE tabId = 't1'").use { cursor ->
             assertTrue(cursor.moveToFirst())
@@ -62,7 +69,9 @@ class TabDatabaseMigrationTest {
             close()
         }
 
-        val db = helper.runMigrationsAndValidate(TEST_DB, 3, true, *TabDatabase.ALL_MIGRATIONS)
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 3, true, *TabDatabase.allMigrations(sessionStateDir()),
+        )
 
         db.query("SELECT groupId, isDefault FROM tab_group WHERE groupId = 'g1'").use { cursor ->
             assertTrue(cursor.moveToFirst())
@@ -71,9 +80,74 @@ class TabDatabaseMigrationTest {
         }
     }
 
+    /** v3→v4: sessionState をファイルへ移行しカラム削除。既存タブのデータが保持されることを確認 */
+    @Test
+    fun migrate3To4() {
+        val sessionDir = sessionStateDir()
+
+        helper.createDatabase(TEST_DB, 3).apply {
+            execSQL(
+                "INSERT INTO tab_state " +
+                    "(tabId, url, sessionState, title, openerTabId, themeColor, sortOrder, isSelected, groupId) " +
+                    "VALUES ('t1', 'https://example.com', 'session_data', 'Example', '', NULL, 0, 1, '')",
+            )
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 4, true, *TabDatabase.allMigrations(sessionDir),
+        )
+
+        db.query("SELECT tabId, url, title FROM tab_state WHERE tabId = 't1'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("t1", cursor.getString(0))
+            assertEquals("https://example.com", cursor.getString(1))
+            assertEquals("Example", cursor.getString(2))
+        }
+        // sessionState カラムが削除されている
+        db.query("PRAGMA table_info(tab_state)").use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            val columnNames = buildList {
+                while (cursor.moveToNext()) {
+                    add(cursor.getString(nameIndex))
+                }
+            }
+            assertFalse(columnNames.contains("sessionState"))
+        }
+        // sessionState がファイルに移行されている
+        val sessionFile = File(sessionDir, "t1")
+        assertTrue(sessionFile.exists())
+        assertEquals("session_data", sessionFile.readText())
+    }
+
+    /** v3→v4: 既にファイルが存在する場合は上書きしない */
+    @Test
+    fun migrate3To4_existingFileNotOverwritten() {
+        val sessionDir = sessionStateDir()
+        File(sessionDir, "t1").writeText("already_migrated")
+
+        helper.createDatabase(TEST_DB, 3).apply {
+            execSQL(
+                "INSERT INTO tab_state " +
+                    "(tabId, url, sessionState, title, openerTabId, themeColor, sortOrder, isSelected, groupId) " +
+                    "VALUES ('t1', 'https://example.com', 'old_db_data', 'Example', '', NULL, 0, 1, '')",
+            )
+            close()
+        }
+
+        helper.runMigrationsAndValidate(
+            TEST_DB, 4, true, *TabDatabase.allMigrations(sessionDir),
+        )
+
+        // 既にファイルが存在する場合は上書きしない（アプリ側で既に移行済み）
+        assertEquals("already_migrated", File(sessionDir, "t1").readText())
+    }
+
     /** v1 から最新バージョンまで全マイグレーションを連続適用できることを確認 */
     @Test
     fun migrateAllFrom1() {
+        val sessionDir = sessionStateDir()
+
         helper.createDatabase(TEST_DB, 1).apply {
             execSQL(
                 "INSERT INTO tab_state " +
@@ -87,7 +161,7 @@ class TabDatabaseMigrationTest {
             TEST_DB,
             TabDatabase.SCHEMA_VERSION,
             true,
-            *TabDatabase.ALL_MIGRATIONS,
+            *TabDatabase.allMigrations(sessionDir),
         )
 
         db.query("SELECT count(*) FROM tab_state").use { cursor ->
@@ -95,7 +169,11 @@ class TabDatabaseMigrationTest {
             assertEquals(1, cursor.getInt(0))
         }
         assertFalse(db.isReadOnly)
+        // v1 から最新まで適用すると sessionState がファイルに移行されている
+        assertEquals("state", File(sessionDir, "t1").readText())
     }
+
+    private fun sessionStateDir(): File = File(tempFolder.root, "session_states").apply { mkdirs() }
 
     companion object {
         private const val TEST_DB = "migration-test-tab"

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -42,6 +43,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -182,24 +184,59 @@ private fun DownloadItemRow(
                     )
                     when (val status = item.status) {
                         is DownloadManagementScreenUiState.DownloadStatus.InProgress -> {
-                            Row {
-                                TextButton(onClick = onPause) {
-                                    Text("一時停止")
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                DownloadIconButton(
+                                    iconRes = R.drawable.ic_pause,
+                                    contentDescription = "一時停止",
+                                    onClick = onPause,
+                                )
+                                DownloadIconButton(
+                                    iconRes = R.drawable.ic_close,
+                                    contentDescription = "キャンセル",
+                                    onClick = onCancel,
+                                )
+                            }
+                        }
+
+                        is DownloadManagementScreenUiState.DownloadStatus.Pausing -> {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                // 停止処理中: 一時停止アイコンをグレーアウトし周囲を円形インジケーターで囲む
+                                Box(
+                                    modifier = Modifier.size(48.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(28.dp),
+                                        strokeWidth = 2.dp,
+                                    )
+                                    Icon(
+                                        painter = painterResource(R.drawable.ic_pause),
+                                        contentDescription = "一時停止中",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                            .copy(alpha = 0.38f),
+                                        modifier = Modifier.size(20.dp),
+                                    )
                                 }
-                                TextButton(onClick = onCancel) {
-                                    Text("キャンセル")
-                                }
+                                DownloadIconButton(
+                                    iconRes = R.drawable.ic_close,
+                                    contentDescription = "キャンセル",
+                                    onClick = onCancel,
+                                )
                             }
                         }
 
                         is DownloadManagementScreenUiState.DownloadStatus.Paused -> {
-                            Row {
-                                TextButton(onClick = onResume) {
-                                    Text("再開")
-                                }
-                                TextButton(onClick = onCancel) {
-                                    Text("キャンセル")
-                                }
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                DownloadIconButton(
+                                    iconRes = R.drawable.ic_play_arrow,
+                                    contentDescription = "再開",
+                                    onClick = onResume,
+                                )
+                                DownloadIconButton(
+                                    iconRes = R.drawable.ic_close,
+                                    contentDescription = "キャンセル",
+                                    onClick = onCancel,
+                                )
                             }
                         }
 
@@ -211,9 +248,11 @@ private fun DownloadItemRow(
 
                         is DownloadManagementScreenUiState.DownloadStatus.Failed -> {
                             if (status.canResume) {
-                                TextButton(onClick = onResume) {
-                                    Text("再開")
-                                }
+                                DownloadIconButton(
+                                    iconRes = R.drawable.ic_play_arrow,
+                                    contentDescription = "再開",
+                                    onClick = onResume,
+                                )
                             } else {
                                 Text(
                                     text = "失敗",
@@ -271,6 +310,21 @@ private fun DownloadItemRow(
                         )
                     }
 
+                    is DownloadManagementScreenUiState.DownloadStatus.Pausing -> {
+                        val sizeText = buildSizeText(status.totalRead, status.contentLength)
+                        Text(
+                            text = "一時停止しています… $sizeText",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        LinearProgressIndicator(
+                            progress = { status.progress / 100f },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp),
+                        )
+                    }
+
                     is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
                         Text(
                             text = "完了",
@@ -301,6 +355,21 @@ private fun DownloadItemRow(
     }
 }
 
+@Composable
+private fun DownloadIconButton(
+    iconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick = onClick) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
 private fun buildSizeText(totalRead: Long, contentLength: Long): String {
     return if (contentLength > 0) {
         "${formatBytes(totalRead)} / ${formatBytes(contentLength)}"
@@ -328,6 +397,31 @@ private fun PreviewInProgress() {
                     totalRead = 40L * 1024 * 1024,
                     contentLength = 100L * 1024 * 1024,
                     isIndeterminate = false,
+                ),
+                enqueuedAt = 0L,
+                originPageUrl = "https://example.com/page",
+            ),
+            onCancel = {},
+            onPause = {},
+            onOpenFile = {},
+            onResume = {},
+            onOpenOriginPage = {},
+        )
+    }
+}
+
+@Preview(name = "停止処理中")
+@Composable
+private fun PreviewPausing() {
+    MaterialTheme {
+        DownloadItemRow(
+            item = DownloadManagementScreenUiState.DownloadItem(
+                id = UUID.randomUUID(),
+                fileName = "example.zip",
+                status = DownloadManagementScreenUiState.DownloadStatus.Pausing(
+                    progress = 40,
+                    totalRead = 40L * 1024 * 1024,
+                    contentLength = 100L * 1024 * 1024,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = "https://example.com/page",

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FolderOpen
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -198,33 +197,6 @@ private fun DownloadItemRow(
                             }
                         }
 
-                        is DownloadManagementScreenUiState.DownloadStatus.Pausing -> {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                // 停止処理中: 一時停止アイコンをグレーアウトし周囲を円形インジケーターで囲む
-                                Box(
-                                    modifier = Modifier.size(48.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(28.dp),
-                                        strokeWidth = 2.dp,
-                                    )
-                                    Icon(
-                                        painter = painterResource(R.drawable.ic_pause),
-                                        contentDescription = "一時停止中",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                            .copy(alpha = 0.38f),
-                                        modifier = Modifier.size(20.dp),
-                                    )
-                                }
-                                DownloadIconButton(
-                                    iconRes = R.drawable.ic_close,
-                                    contentDescription = "キャンセル",
-                                    onClick = onCancel,
-                                )
-                            }
-                        }
-
                         is DownloadManagementScreenUiState.DownloadStatus.Paused -> {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 DownloadIconButton(
@@ -310,21 +282,6 @@ private fun DownloadItemRow(
                         )
                     }
 
-                    is DownloadManagementScreenUiState.DownloadStatus.Pausing -> {
-                        val sizeText = buildSizeText(status.totalRead, status.contentLength)
-                        Text(
-                            text = "一時停止しています… $sizeText",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        LinearProgressIndicator(
-                            progress = { status.progress / 100f },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 4.dp),
-                        )
-                    }
-
                     is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
                         Text(
                             text = "完了",
@@ -397,31 +354,6 @@ private fun PreviewInProgress() {
                     totalRead = 40L * 1024 * 1024,
                     contentLength = 100L * 1024 * 1024,
                     isIndeterminate = false,
-                ),
-                enqueuedAt = 0L,
-                originPageUrl = "https://example.com/page",
-            ),
-            onCancel = {},
-            onPause = {},
-            onOpenFile = {},
-            onResume = {},
-            onOpenOriginPage = {},
-        )
-    }
-}
-
-@Preview(name = "停止処理中")
-@Composable
-private fun PreviewPausing() {
-    MaterialTheme {
-        DownloadItemRow(
-            item = DownloadManagementScreenUiState.DownloadItem(
-                id = UUID.randomUUID(),
-                fileName = "example.zip",
-                status = DownloadManagementScreenUiState.DownloadStatus.Pausing(
-                    progress = 40,
-                    totalRead = 40L * 1024 * 1024,
-                    contentLength = 100L * 1024 * 1024,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = "https://example.com/page",

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -104,6 +104,7 @@ fun DownloadManagementScreen(
                     DownloadItemRow(
                         item = item,
                         onCancel = { uiState.callbacks.onCancel(item.id) },
+                        onPause = { uiState.callbacks.onPause(item.id) },
                         onOpenFile = { fileUri -> uiState.callbacks.onOpenFile(fileUri) },
                         onResume = { uiState.callbacks.onResume(item.id) },
                         onOpenOriginPage = { url -> uiState.callbacks.onOpenOriginPage(url) },
@@ -119,6 +120,7 @@ fun DownloadManagementScreen(
 private fun DownloadItemRow(
     item: DownloadManagementScreenUiState.DownloadItem,
     onCancel: () -> Unit,
+    onPause: () -> Unit,
     onOpenFile: (String) -> Unit,
     onResume: () -> Unit,
     onOpenOriginPage: (url: String) -> Unit,
@@ -180,8 +182,24 @@ private fun DownloadItemRow(
                     )
                     when (val status = item.status) {
                         is DownloadManagementScreenUiState.DownloadStatus.InProgress -> {
-                            TextButton(onClick = onCancel) {
-                                Text("キャンセル")
+                            Row {
+                                TextButton(onClick = onPause) {
+                                    Text("一時停止")
+                                }
+                                TextButton(onClick = onCancel) {
+                                    Text("キャンセル")
+                                }
+                            }
+                        }
+
+                        is DownloadManagementScreenUiState.DownloadStatus.Paused -> {
+                            Row {
+                                TextButton(onClick = onResume) {
+                                    Text("再開")
+                                }
+                                TextButton(onClick = onCancel) {
+                                    Text("キャンセル")
+                                }
                             }
                         }
 
@@ -238,6 +256,21 @@ private fun DownloadItemRow(
                         }
                     }
 
+                    is DownloadManagementScreenUiState.DownloadStatus.Paused -> {
+                        val sizeText = buildSizeText(status.totalRead, status.contentLength)
+                        Text(
+                            text = "一時停止中 $sizeText",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        LinearProgressIndicator(
+                            progress = { status.progress / 100f },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp),
+                        )
+                    }
+
                     is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
                         Text(
                             text = "完了",
@@ -282,6 +315,57 @@ private fun formatBytes(bytes: Long): String = when {
     else -> "$bytes B"
 }
 
+@Preview(name = "ダウンロード中")
+@Composable
+private fun PreviewInProgress() {
+    MaterialTheme {
+        DownloadItemRow(
+            item = DownloadManagementScreenUiState.DownloadItem(
+                id = UUID.randomUUID(),
+                fileName = "example.zip",
+                status = DownloadManagementScreenUiState.DownloadStatus.InProgress(
+                    progress = 40,
+                    totalRead = 40L * 1024 * 1024,
+                    contentLength = 100L * 1024 * 1024,
+                    isIndeterminate = false,
+                ),
+                enqueuedAt = 0L,
+                originPageUrl = "https://example.com/page",
+            ),
+            onCancel = {},
+            onPause = {},
+            onOpenFile = {},
+            onResume = {},
+            onOpenOriginPage = {},
+        )
+    }
+}
+
+@Preview(name = "一時停止中")
+@Composable
+private fun PreviewPaused() {
+    MaterialTheme {
+        DownloadItemRow(
+            item = DownloadManagementScreenUiState.DownloadItem(
+                id = UUID.randomUUID(),
+                fileName = "example.zip",
+                status = DownloadManagementScreenUiState.DownloadStatus.Paused(
+                    progress = 40,
+                    totalRead = 40L * 1024 * 1024,
+                    contentLength = 100L * 1024 * 1024,
+                ),
+                enqueuedAt = 0L,
+                originPageUrl = "https://example.com/page",
+            ),
+            onCancel = {},
+            onPause = {},
+            onOpenFile = {},
+            onResume = {},
+            onOpenOriginPage = {},
+        )
+    }
+}
+
 @Preview(name = "失敗・再開可能")
 @Composable
 private fun PreviewFailedCanResume() {
@@ -295,6 +379,7 @@ private fun PreviewFailedCanResume() {
                 originPageUrl = "https://example.com/page",
             ),
             onCancel = {},
+            onPause = {},
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
@@ -326,6 +411,7 @@ private fun PreviewCompletedWithThumbnail() {
                 originPageUrl = "https://example.com/page",
             ),
             onCancel = {},
+            onPause = {},
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
@@ -349,6 +435,7 @@ private fun PreviewCompletedWithoutThumbnail() {
                 originPageUrl = null,
             ),
             onCancel = {},
+            onPause = {},
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
@@ -369,6 +456,7 @@ private fun PreviewFailedCannotResume() {
                 originPageUrl = null,
             ),
             onCancel = {},
+            onPause = {},
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -43,6 +43,16 @@ data class DownloadManagementScreenUiState(
             val totalRead: Long,
             val contentLength: Long,
         ) : DownloadStatus
+
+        /**
+         * 一時停止を要求したがワーカーがまだ停止処理中の状態。
+         * 一時停止ボタンはグレーアウトし、周囲に円形のインジケーターを表示する。
+         */
+        data class Pausing(
+            val progress: Int,
+            val totalRead: Long,
+            val contentLength: Long,
+        ) : DownloadStatus
     }
 
     @Stable

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -34,6 +34,15 @@ data class DownloadManagementScreenUiState(
         data class Failed(val canResume: Boolean) : DownloadStatus
 
         data object Cancelled : DownloadStatus
+
+        /**
+         * ダウンロード一時停止中。再開ボタンを表示する。
+         */
+        data class Paused(
+            val progress: Int,
+            val totalRead: Long,
+            val contentLength: Long,
+        ) : DownloadStatus
     }
 
     @Stable
@@ -49,6 +58,8 @@ data class DownloadManagementScreenUiState(
     @Stable
     data class Callbacks(
         val onCancel: (UUID) -> Unit,
+        /** ダウンロード中のアイテムを一時停止する */
+        val onPause: (UUID) -> Unit,
         val onOpenFile: (fileUri: String) -> Unit,
         val onOpenDownloadsFolder: () -> Unit,
         /** 失敗したダウンロードを再開する */

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -43,16 +43,6 @@ data class DownloadManagementScreenUiState(
             val totalRead: Long,
             val contentLength: Long,
         ) : DownloadStatus
-
-        /**
-         * 一時停止を要求したがワーカーがまだ停止処理中の状態。
-         * 一時停止ボタンはグレーアウトし、周囲に円形のインジケーターを表示する。
-         */
-        data class Pausing(
-            val progress: Int,
-            val totalRead: Long,
-            val contentLength: Long,
-        ) : DownloadStatus
     }
 
     @Stable

--- a/ui/downloads/src/main/res/drawable/ic_close.xml
+++ b/ui/downloads/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M256,760L200,704L424,480L200,256L256,200L480,424L704,200L760,256L536,480L760,704L704,760L480,536L256,760Z"/>
+</vector>

--- a/ui/downloads/src/main/res/drawable/ic_pause.xml
+++ b/ui/downloads/src/main/res/drawable/ic_pause.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M520,760L520,200L760,200L760,760L520,760ZM200,760L200,200L440,200L440,760L200,760ZM600,680L680,680L680,280L600,280L600,680ZM280,680L360,680L360,280L280,280L280,680ZM280,280L280,280L280,680L280,680L280,280ZM600,280L600,280L600,680L600,680L600,280Z"/>
+</vector>

--- a/ui/downloads/src/main/res/drawable/ic_play_arrow.xml
+++ b/ui/downloads/src/main/res/drawable/ic_play_arrow.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M320,760L320,200L760,480L320,760ZM400,480L400,480L400,480L400,480ZM400,614L610,480L400,346L400,614Z"/>
+</vector>


### PR DESCRIPTION
## 概要
ダウンロード管理画面に一時停止機能を追加しました。実行中のダウンロードを一時停止でき、部分ファイルを保持して後で再開できます。

## 主な変更

### UI層（DownloadManagementScreen）
- `DownloadItemRow` に `onPause` コールバックを追加
- InProgress 状態で「一時停止」「キャンセル」ボタンを表示
- 新しい `Paused` ステータスに対応し、「再開」「キャンセル」ボタンを表示
- Paused 状態の進捗表示（進捗率、ダウンロード済みサイズ）を実装
- `PreviewInProgress` と `PreviewPaused` プレビューを追加

### ViewModel層（DownloadManagementScreenViewModel）
- `pauseDownload()` メソッドを実装
  - DB を PAUSED に更新してから WorkManager に割り込みを発行
  - Worker の CancellationException ハンドラが一時停止を検知して部分ファイルを保持
  - 通知を明示的に消去
- `resumeDownload()` を拡張して PAUSED 状態にも対応
- `cancelDownload()` で一時停止中のレコードの部分ファイルを削除

### Worker層（DownloadWorker）
- CancellationException ハンドラで PAUSED 状態を判定
- 一時停止時は部分ファイルを保持（再開用）
- キャンセル時は部分ファイルを削除
- `throwIfCancelledOnRecord()` を `isStopRequested()` に変更（キャンセル・一時停止両対応）

### データ層（DownloadRepository / DownloadDao）
- `DownloadRecordStatus` に `PAUSED` を追加
- `updatePaused()` メソッド：ENQUEUED/RUNNING のみ PAUSED に更新
- `updatePausedPartial()` メソッド：一時停止時に部分ファイル URI を保存
- `isPaused()` メソッド：一時停止状態を確認
- `isStopRequested()` メソッド：キャンセルまたは一時停止を確認
- DAO に `pauseIfActive()` と `updatePausedPartial()` クエリを追加

### UI State（DownloadManagementScreenUiState）
- `Paused` ステータスクラスを追加（progress, totalRead, contentLength を保持）
- `Callbacks` に `onPause` コールバックを追加

## 実装の特徴
- **DB 先行更新**：一時停止時に先に DB を PAUSED に更新してから WorkManager に割り込みを発行することで、Worker が確実に一時停止を検知できる
- **部分ファイル保持**：一時停止時は部分ファイルを保持し、再開時に HTTP Range リクエストで効率的に再開
- **通知管理**：WorkManager 起動前の GeckoDownloadManager による通知も明示的に消去

https://claude.ai/code/session_011ZCBMQ1QV2Gvndqmg2B3ah

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause downloads (persist partial progress) and resume from saved partials; resume also supports failed items. UI: icon-based Pause/Resume/Cancel and paused rows show determinate progress and “paused” status.

* **Bug Fixes**
  * Clearer pause vs cancel handling to preserve or remove partial files and update notifications correctly.

* **Chores**
  * Local database version bumped and migrations added to store pause/resume metadata.

* **Tests**
  * Migration test added to verify schema upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->