### PR TITLE
サイト権限設定をまとめたセクションに統合

### DIFF
--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -318,7 +318,8 @@ private val previewCallbacks = object : SiteSettingsScreenUiState.Callbacks {
     override fun consumeClearDataResultMessage() = Unit
 }
 
-@Preview(showBackground = true)
+// 証明書・位置情報・マイク・データ削除をすべて含むため、見切れないよう縦を広げて Preview する
+@Preview(showBackground = true, heightDp = 1100)
 @Composable
 private fun SiteSettingsScreenPreview() {
     MaterialTheme {

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SiteSettingsScreen.kt
@@ -121,81 +121,89 @@ fun SiteSettingsScreen(
                 Spacer(Modifier.height(12.dp))
             }
 
-            // 権限は一度でも要求された項目だけ表示する
-            if (uiState.geolocationState != null) {
-                SettingSection(title = "位置情報") {
-                    Column(Modifier.selectableGroup()) {
-                        SettingsRadioOption(
-                            label = "モック位置情報",
-                            selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_MOCK,
-                            onClick = {
-                                uiState.callbacks.setGeolocationState(
-                                    SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+            // 権限は証明書・データ削除と同じく1つのコンテナにまとめ、
+            // 要求が無い場合もタイトル付きセクション内に空メッセージを表示して見た目を揃える
+            SettingSection(title = "サイトが要求した権限") {
+                val hasGeolocation = uiState.geolocationState != null
+                val hasMicrophone = uiState.microphonePermission != null
+                if (!hasGeolocation && !hasMicrophone) {
+                    Text(
+                        text = "このサイトが要求した権限はありません",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    // 一度でも要求された権限だけをサブ項目として表示する
+                    if (hasGeolocation) {
+                        PermissionGroup(title = "位置情報") {
+                            Column(Modifier.selectableGroup()) {
+                                SettingsRadioOption(
+                                    label = "モック位置情報",
+                                    selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+                                    onClick = {
+                                        uiState.callbacks.setGeolocationState(
+                                            SiteGeolocationState.SITE_GEOLOCATION_MOCK,
+                                        )
+                                    },
                                 )
-                            },
-                        )
-                        SettingsRadioOption(
-                            label = "実際の位置情報",
-                            selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_REAL,
-                            onClick = {
-                                uiState.callbacks.setGeolocationState(
-                                    SiteGeolocationState.SITE_GEOLOCATION_REAL,
+                                SettingsRadioOption(
+                                    label = "実際の位置情報",
+                                    selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_REAL,
+                                    onClick = {
+                                        uiState.callbacks.setGeolocationState(
+                                            SiteGeolocationState.SITE_GEOLOCATION_REAL,
+                                        )
+                                    },
                                 )
-                            },
-                        )
-                        SettingsRadioOption(
-                            label = "ブロック",
-                            selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_DENY,
-                            onClick = {
-                                uiState.callbacks.setGeolocationState(
-                                    SiteGeolocationState.SITE_GEOLOCATION_DENY,
+                                SettingsRadioOption(
+                                    label = "ブロック",
+                                    selected = uiState.geolocationState == SiteGeolocationState.SITE_GEOLOCATION_DENY,
+                                    onClick = {
+                                        uiState.callbacks.setGeolocationState(
+                                            SiteGeolocationState.SITE_GEOLOCATION_DENY,
+                                        )
+                                    },
                                 )
-                            },
-                        )
+                            }
+                        }
+                    }
+                    if (hasMicrophone) {
+                        if (hasGeolocation) {
+                            Spacer(Modifier.height(12.dp))
+                        }
+                        PermissionGroup(title = "マイク") {
+                            Column(Modifier.selectableGroup()) {
+                                SettingsRadioOption(
+                                    label = "確認する",
+                                    selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_ASK,
+                                    onClick = {
+                                        uiState.callbacks.setMicrophonePermission(
+                                            SitePermissionState.SITE_PERMISSION_ASK,
+                                        )
+                                    },
+                                )
+                                SettingsRadioOption(
+                                    label = "許可",
+                                    selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_ALLOW,
+                                    onClick = {
+                                        uiState.callbacks.setMicrophonePermission(
+                                            SitePermissionState.SITE_PERMISSION_ALLOW,
+                                        )
+                                    },
+                                )
+                                SettingsRadioOption(
+                                    label = "ブロック",
+                                    selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_DENY,
+                                    onClick = {
+                                        uiState.callbacks.setMicrophonePermission(
+                                            SitePermissionState.SITE_PERMISSION_DENY,
+                                        )
+                                    },
+                                )
+                            }
+                        }
                     }
                 }
-                Spacer(Modifier.height(12.dp))
-            }
-            if (uiState.microphonePermission != null) {
-                SettingSection(title = "マイク") {
-                    Column(Modifier.selectableGroup()) {
-                        SettingsRadioOption(
-                            label = "確認する",
-                            selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_ASK,
-                            onClick = {
-                                uiState.callbacks.setMicrophonePermission(
-                                    SitePermissionState.SITE_PERMISSION_ASK,
-                                )
-                            },
-                        )
-                        SettingsRadioOption(
-                            label = "許可",
-                            selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_ALLOW,
-                            onClick = {
-                                uiState.callbacks.setMicrophonePermission(
-                                    SitePermissionState.SITE_PERMISSION_ALLOW,
-                                )
-                            },
-                        )
-                        SettingsRadioOption(
-                            label = "ブロック",
-                            selected = uiState.microphonePermission == SitePermissionState.SITE_PERMISSION_DENY,
-                            onClick = {
-                                uiState.callbacks.setMicrophonePermission(
-                                    SitePermissionState.SITE_PERMISSION_DENY,
-                                )
-                            },
-                        )
-                    }
-                }
-            }
-            if (uiState.geolocationState == null && uiState.microphonePermission == null) {
-                Text(
-                    text = "このサイトが要求した権限はありません",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
             }
 
             Spacer(Modifier.height(12.dp))
@@ -262,6 +270,21 @@ fun SiteSettingsScreen(
                 }
             },
         )
+    }
+}
+
+/** 権限セクション内の個別の権限（位置情報・マイクなど）をサブタイトル付きで表示する */
+@Composable
+private fun PermissionGroup(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+        )
+        content()
     }
 }
 


### PR DESCRIPTION
## 概要
サイト権限設定（位置情報・マイク）の UI レイアウトを改善し、複数の権限を1つの統合セクション内に表示するように変更しました。

## 主な変更

- **権限セクションの統合**: 位置情報とマイクの権限設定を「サイトが要求した権限」という統一されたセクションにまとめました
- **空状態の改善**: 権限が要求されていない場合、セクション内に「このサイトが要求した権限はありません」というメッセージを表示し、見た目の一貫性を保つようにしました
- **PermissionGroup コンポーザブルの追加**: 権限セクション内の個別権限（位置情報・マイクなど）をサブタイトル付きで表示するための新しいコンポーザブルを追加しました
- **レイアウト構造の簡潔化**: 複数の `SettingSection` から1つの親セクションに変更し、条件分岐をより明確にしました

## 実装の詳細

- 権限の有無を事前に判定（`hasGeolocation`、`hasMicrophone`）し、条件分岐を簡潔にしました
- 権限が複数ある場合のスペーサー（`Spacer(Modifier.height(12.dp))`）の配置を改善しました
- 新しい `PermissionGroup` コンポーザブルは、タイトルとコンテンツを受け取り、統一されたスタイルで表示します

https://claude.ai/code/session_01JaQePKfUmWmMVjwfxtUFW4