### PR TITLE
URL バーに表示モードを追加し、編集時のみ入力フィールドを表示

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/BrowserTestUiDriver.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/BrowserTestUiDriver.kt
@@ -3,6 +3,7 @@ package net.matsudamper.browser
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -98,10 +99,13 @@ internal fun AndroidComposeTestRule<*, MainActivity>.tapGeckoContainer() {
 
 internal fun AndroidComposeTestRule<*, MainActivity>.currentUrlBarText(): String {
     return runCatching {
-        onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag)
+        val config = onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag)
             .fetchSemanticsNode()
-            .config[SemanticsProperties.EditableText]
-            .text
+            .config
+        // 編集モードは EditableText、表示モード(UrlDisplay)は Text セマンティクスを持つ。
+        config.getOrNull(SemanticsProperties.EditableText)?.text
+            ?: config.getOrNull(SemanticsProperties.Text)?.joinToString(separator = "") { it.text }
+            ?: ""
     }.getOrDefault("")
 }
 

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
@@ -2,7 +2,6 @@ package net.matsudamper.browser
 
 import android.view.WindowInsets
 import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -534,11 +533,11 @@ class GmdSmokeTest {
     private fun waitForUrlBarText(expected: String) {
         try {
             composeRule.waitUntil(timeoutMillis = 20_000) {
-                getUrlBarText() == expected
+                composeRule.currentUrlBarText() == expected
             }
         } catch (e: androidx.compose.ui.test.ComposeTimeoutException) {
             throw AssertionError(
-                "URL バー復元待機がタイムアウト: expected=\"$expected\" actual=\"${getUrlBarText()}\"",
+                "URL バー復元待機がタイムアウト: expected=\"$expected\" actual=\"${composeRule.currentUrlBarText()}\"",
                 e,
             )
         }
@@ -550,21 +549,6 @@ class GmdSmokeTest {
      */
     private fun normalizeFileUrl(url: String): String {
         return url.replaceFirst(Regex("^file:/+"), "file:///")
-    }
-
-    /**
-     * 現在の URL バー文字列を返す。
-     */
-    private fun getUrlBarText(): String {
-        return runCatching {
-            val config = composeRule.onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag)
-                .fetchSemanticsNode()
-                .config
-            // 編集モードは EditableText、表示モード(UrlDisplay)は Text セマンティクスを持つ。
-            config.getOrNull(SemanticsProperties.EditableText)?.text
-                ?: config.getOrNull(SemanticsProperties.Text)?.joinToString(separator = "") { it.text }
-                ?: ""
-        }.getOrDefault("")
     }
 
     /**

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser
 
 import android.view.WindowInsets
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -556,10 +557,13 @@ class GmdSmokeTest {
      */
     private fun getUrlBarText(): String {
         return runCatching {
-            composeRule.onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag)
+            val config = composeRule.onNodeWithTag(UrlTextInputTestTags.UrlBar.testTag)
                 .fetchSemanticsNode()
-                .config[SemanticsProperties.EditableText]
-                .text
+                .config
+            // 編集モードは EditableText、表示モード(UrlDisplay)は Text セマンティクスを持つ。
+            config.getOrNull(SemanticsProperties.EditableText)?.text
+                ?: config.getOrNull(SemanticsProperties.Text)?.joinToString(separator = "") { it.text }
+                ?: ""
         }.getOrDefault("")
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -307,6 +307,7 @@ private fun BrowserAppContent(
                                     modifier = modifier,
                                     toolbarColor = null,
                                     isFocused = false,
+                                    onLongClickUrl = {},
                                     tabCount = tabCount,
                                     onOpenTabs = {},
                                     toolbarMenu = {},

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -86,6 +86,7 @@ internal fun BrowserToolBar(
     onSubmit: (String) -> Unit,
     isFocused: Boolean,
     onFocusChanged: (Boolean) -> Unit,
+    onLongClickUrl: () -> Unit,
     showInstallExtensionItem: Boolean,
     onInstallExtension: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -132,6 +133,7 @@ internal fun BrowserToolBar(
             null
         },
         toolbarColor = toolbarColor,
+        onLongClickUrl = onLongClickUrl,
         onOpenTabs = onOpenTabs,
         tabCount = tabCount,
         showTabButton = showTabActions,
@@ -234,6 +236,7 @@ internal fun BrowserToolbar(
     gestureState: BrowserToolBarGestureState?,
     urlInputState: UrlInputState,
     toolbarColor: Color?,
+    onLongClickUrl: () -> Unit,
     updateVisibleMenu: (Boolean) -> Unit,
     onOpenTabs: () -> Unit,
     tabCount: Int?,
@@ -400,32 +403,35 @@ internal fun BrowserToolbar(
                     color = toolbarColors.urlBarBackgroundColor,
                     shape = CircleShape,
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .padding(
-                                end = 4.dp,
-                            ),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        UrlTextInput(
+                    val urlBarPaddingValues = PaddingValues(
+                        start = 8.dp,
+                        top = 4.dp,
+                        bottom = 4.dp,
+                    )
+                    if (isFocused) {
+                        // 編集モード: テキスト入力フィールド + クリアボタン
+                        Row(
                             modifier = Modifier
                                 .testTag(BrowserToolbarTestTags.Url(urlInputState.value).testTag)
-                                .weight(1f),
-                            enableSuggest = urlInputState.enableSuggest,
-                            paddingValues = PaddingValues(
-                                start = 8.dp,
-                                top = 4.dp,
-                                bottom = 4.dp
-                            ),
-                            scrollEnabled = isFocused,
-                            value = urlInputState.value,
-                            onValueChange = urlInputState.onValueChange,
-                            onSubmit = urlInputState.onSubmit,
-                            onFocusChanged = urlInputState.onFocusChanged,
-                            textColor = LocalContentColor.current,
-                        )
+                                .padding(
+                                    end = 4.dp,
+                                ),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            UrlTextInput(
+                                modifier = Modifier
+                                    .weight(1f),
+                                enableSuggest = urlInputState.enableSuggest,
+                                paddingValues = urlBarPaddingValues,
+                                scrollEnabled = true,
+                                value = urlInputState.value,
+                                onValueChange = urlInputState.onValueChange,
+                                onSubmit = urlInputState.onSubmit,
+                                onFocusChanged = urlInputState.onFocusChanged,
+                                textColor = LocalContentColor.current,
+                                requestFocusOnShow = true,
+                            )
 
-                        if (isFocused) {
                             CompositionLocalProvider(
                                 LocalMinimumInteractiveComponentSize provides 0.dp
                             ) {
@@ -443,6 +449,20 @@ internal fun BrowserToolbar(
                                 )
                             }
                         }
+                    } else {
+                        // 表示モード: URL を表示するだけ。タップで編集モードへ、ロングプレスでURLコピー。
+                        UrlDisplay(
+                            modifier = Modifier
+                                .testTag(BrowserToolbarTestTags.Url(urlInputState.value).testTag)
+                                .fillMaxWidth()
+                                .padding(end = 4.dp),
+                            value = urlInputState.value,
+                            textColor = LocalContentColor.current,
+                            enableSuggest = urlInputState.enableSuggest,
+                            paddingValues = urlBarPaddingValues,
+                            onClick = { urlInputState.onFocusChanged(true) },
+                            onLongClick = onLongClickUrl,
+                        )
                     }
                 }
 
@@ -623,6 +643,7 @@ private fun Preview() {
                     onSubmit = {},
                     isFocused = isFocused,
                     onFocusChanged = {},
+                    onLongClickUrl = {},
                     showInstallExtensionItem = true,
                     onInstallExtension = {},
                     onOpenSettings = {},
@@ -666,6 +687,7 @@ private fun PreviewTabCountVariants() {
                     onSubmit = {},
                     isFocused = false,
                     onFocusChanged = {},
+                    onLongClickUrl = {},
                     showInstallExtensionItem = true,
                     onInstallExtension = {},
                     onOpenSettings = {},
@@ -708,6 +730,7 @@ private fun PreviewWideToolbar() {
                 onSubmit = {},
                 isFocused = false,
                 onFocusChanged = {},
+                onLongClickUrl = {},
                 showInstallExtensionItem = true,
                 onInstallExtension = {},
                 onOpenSettings = {},

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -451,9 +451,10 @@ internal fun BrowserToolbar(
                         }
                     } else {
                         // 表示モード: URL を表示するだけ。タップで編集モードへ、ロングプレスでURLコピー。
+                        // UrlBar の testTag は UrlDisplay 内部で付与するため、ここでは付けない
+                        // （同一ノードに testTag を二重付与すると外側が優先され UrlBar が消えてしまう）。
                         UrlDisplay(
                             modifier = Modifier
-                                .testTag(BrowserToolbarTestTags.Url(urlInputState.value).testTag)
                                 .fillMaxWidth()
                                 .padding(end = 4.dp),
                             value = urlInputState.value,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarUrlTextInput.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarUrlTextInput.kt
@@ -215,7 +215,9 @@ internal fun UrlDisplay(
                     Modifier
                 }
             )
-            .semantics {
+            // 子 BasicText の Text セマンティクスを UrlBar ノードへ集約する。
+            // テストは UrlBar ノードの Text から表示中の URL を読むため必須。
+            .semantics(mergeDescendants = true) {
                 if (enableSuggest) {
                     contentDescription = "Address bar"
                 }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarUrlTextInput.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarUrlTextInput.kt
@@ -1,10 +1,14 @@
 package net.matsudamper.browser
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -17,9 +21,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.ContentDataType
 import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -35,6 +42,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.viewinterop.AndroidView
 
 internal sealed interface UrlTextInputTestTags {
@@ -55,6 +63,7 @@ internal fun UrlTextInput(
     enableSuggest: Boolean,
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
+    requestFocusOnShow: Boolean = false,
 ) {
     val currentValue by rememberUpdatedState(value)
     val currentOnValueChange by rememberUpdatedState(onValueChange)
@@ -73,6 +82,15 @@ internal fun UrlTextInput(
                     val scrollState = rememberScrollState()
                     var textFieldValue by remember { mutableStateOf(TextFieldValue(currentValue)) }
                     var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+                    val focusRequester = remember { FocusRequester() }
+
+                    // 表示モードのタップで編集モードに入った直後は、
+                    // フィールドへ直接タッチされていないため自前でフォーカスを要求する。
+                    LaunchedEffect(Unit) {
+                        if (requestFocusOnShow) {
+                            runCatching { focusRequester.requestFocus() }
+                        }
+                    }
 
                     // 外部から値が変更された場合にテキストを反映（カーソルは末尾へ）
                     LaunchedEffect(currentValue) {
@@ -108,6 +126,7 @@ internal fun UrlTextInput(
                     BasicTextField(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .focusRequester(focusRequester)
                             .horizontalScroll(
                                 state = scrollState,
                                 enabled = resolvedScrollEnabled,
@@ -161,4 +180,59 @@ internal fun UrlTextInput(
             }
         },
     )
+}
+
+/**
+ * 非フォーカス時の URL バー表示。
+ *
+ * 編集機能（[UrlTextInput]）とは完全に分離し、現在ページの URL を 1 行で表示するだけにする。
+ * タップで編集モードへ遷移し、ロングプレスで URL コピーなどの任意アクションを実行する。
+ *
+ * テストは UrlBar ノードの Text セマンティクスから表示中の URL を読むため、
+ * [enableSuggest] が true のときのみ testTag を付与する。
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun UrlDisplay(
+    value: String,
+    textColor: Color,
+    enableSuggest: Boolean,
+    paddingValues: PaddingValues,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+            )
+            .then(
+                if (enableSuggest) {
+                    Modifier.testTag(UrlTextInputTestTags.UrlBar.testTag)
+                } else {
+                    Modifier
+                }
+            )
+            .semantics {
+                if (enableSuggest) {
+                    contentDescription = "Address bar"
+                }
+            },
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        BasicText(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues),
+            text = value,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodyLarge.merge(
+                color = textColor,
+                textAlign = TextAlign.Start,
+            ),
+        )
+    }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -779,6 +779,7 @@ internal fun GeckoBrowserTab(
                         }
                         state.isUrlInputFocused = hasFocus
                     },
+                    onLongClickUrl = state::copyCurrentPageUrl,
                     showInstallExtensionItem = showInstallExtensionItem && state.showInstallExtensionItem,
                     onInstallExtension = { onInstallExtensionRequest(state.currentPageUrl) },
                     onOpenSettings = onOpenSettings,


### PR DESCRIPTION
## 概要

URL バーの UI を2つのモードに分離しました。フォーカスされていない時は URL を読み取り専用で表示し、フォーカス時のみ編集可能な入力フィールドを表示します。これにより、通常時の UI をシンプルにしつつ、タップで編集、ロングプレスで URL コピーなどのアクションに対応できるようになりました。

## 主な変更

- **新規 Composable `UrlDisplay` を追加**
  - フォーカスされていない時の URL 表示専用コンポーネント
  - `combinedClickable` で onClick（編集モード遷移）と onLongClick（URL コピーなど）に対応
  - `BasicText` で 1 行表示、末尾は省略記号で処理

- **`UrlTextInput` に `requestFocusOnShow` パラメータを追加**
  - 表示モードから編集モードへ遷移した直後、フィールドへ直接タッチされていないため、自前でフォーカスを要求する仕組みを実装
  - `FocusRequester` を使用して実装

- **`BrowserToolbar` の URL バー表示ロジックを条件分岐化**
  - `isFocused` が true の場合：編集モード（`UrlTextInput` + クリアボタン）
  - `isFocused` が false の場合：表示モード（`UrlDisplay`）

- **`onLongClickUrl` コールバックを追加**
  - `BrowserToolBar` → `BrowserToolbar` → `UrlDisplay` へ伝播
  - URL ロングプレス時のアクション（コピーなど）を実装可能に

- **テスト対応の改善**
  - `BrowserTestUiDriver.currentUrlBarText()` と `GmdSmokeTest.getUrlBarText()` を更新
  - 編集モードの `EditableText` セマンティクスと表示モードの `Text` セマンティクスの両方に対応

## 実装の詳細

- URL バーの padding 値を `urlBarPaddingValues` として共通化し、両モードで統一
- `UrlDisplay` は `enableSuggest` が true の場合のみ testTag を付与（テスト対応）
- `LaunchedEffect` で `requestFocusOnShow` フラグをチェックし、必要に応じてフォーカスを要求

https://claude.ai/code/session_013B2uzSdukKmHET2KE7Br96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added long-click gesture support on the URL bar.

* **Tests**
  * Improved test stability with safer semantics property access for URL bar text extraction, now handling both editable and display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->