### PR TITLE
sessionState をファイルシステムに移行して CursorWindow 上限超過を回避

### DIFF
--- a/data/schemas/net.matsudamper.browser.data.tab.TabDatabase/4.json
+++ b/data/schemas/net.matsudamper.browser.data.tab.TabDatabase/4.json
@@ -1,0 +1,108 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "09d958584be119a427cfb83d7cb87bc7",
+    "entities": [
+      {
+        "tableName": "tab_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tabId` TEXT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `openerTabId` TEXT NOT NULL, `themeColor` INTEGER, `sortOrder` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `groupId` TEXT NOT NULL, PRIMARY KEY(`tabId`))",
+        "fields": [
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openerTabId",
+            "columnName": "openerTabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tabId"
+          ]
+        }
+      },
+      {
+        "tableName": "tab_group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` TEXT NOT NULL, `name` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, `isDefault` INTEGER NOT NULL, PRIMARY KEY(`groupId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '09d958584be119a427cfb83d7cb87bc7')"
+    ]
+  }
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -7,15 +7,78 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.matsudamper.browser.data.tab.TabDatabase
 import net.matsudamper.browser.data.tab.TabStateEntity
+import net.matsudamper.browser.data.tab.TabStateRow
 
 class TabRepository(context: Context) {
     private val db = TabDatabase.getInstance(context)
     private val dao = db.tabDao()
     private val thumbnailDir = File(context.cacheDir, "tab_thumbnails").apply { mkdirs() }
 
+    // sessionState は GeckoView のセッション状態(履歴・フォーム・スクロール等)を直列化した
+    // 実質 blob で、ヘビーに使われたタブでは Android の CursorWindow 上限(約2MB)を超え、
+    // tab_state の取得時に SQLiteBlobTooBigException でクラッシュする原因になる。
+    // そのため DB には保持せず、tabId をファイル名としてファイルへ保存する。
+    // 履歴等を含む永続データなので、消えうる cacheDir ではなく filesDir に置く。
+    private val sessionStateDir = File(context.filesDir, "tab_session_states").apply { mkdirs() }
+
+    private fun sessionStateFile(tabId: String) = File(sessionStateDir, tabId)
+
+    /** sessionState をファイルへ保存する。空の場合はファイルを削除する */
+    private fun writeSessionState(tabId: String, sessionState: String) {
+        val file = sessionStateFile(tabId)
+        if (sessionState.isBlank()) {
+            file.delete()
+            return
+        }
+        if (!sessionStateDir.exists()) {
+            sessionStateDir.mkdirs()
+        }
+        file.writeText(sessionState)
+    }
+
+    private fun deleteSessionStateFile(tabId: String) {
+        sessionStateFile(tabId).delete()
+    }
+
+    /**
+     * 指定タブの sessionState を解決する。
+     * ファイルがあればそれを返す。無い場合は旧バージョンで DB 列に保存された
+     * sessionState をファイルへ移行してから返す（移行後は DB 列を空にする）。
+     */
+    private suspend fun resolveSessionState(tabId: String): String {
+        val file = sessionStateFile(tabId)
+        if (file.exists()) {
+            return file.readText()
+        }
+        val fromDb = readSessionStateFromDb(tabId)
+        if (fromDb.isNotEmpty()) {
+            writeSessionState(tabId, fromDb)
+            dao.clearSessionState(tabId)
+        }
+        return fromDb
+    }
+
+    /**
+     * 旧バージョンで tab_state.sessionState に保存された文字列を読み出す。
+     * 巨大セルでも CursorWindow 上限(約2MB)を超えないよう substr で分割して読む。
+     */
+    private suspend fun readSessionStateFromDb(tabId: String): String {
+        val length = dao.getSessionStateLength(tabId) ?: return ""
+        if (length <= 0) return ""
+        val builder = StringBuilder(length)
+        var offset = 1 // SQLite の substr は 1 始まり
+        while (offset <= length) {
+            val chunk = dao.getSessionStateChunk(tabId, offset, SESSION_STATE_CHUNK_CHARS)
+            if (chunk.isNullOrEmpty()) break
+            builder.append(chunk)
+            offset += SESSION_STATE_CHUNK_CHARS
+        }
+        return builder.toString()
+    }
+
     fun observeTabs(): Flow<PersistedTabStateContainer> {
-        return dao.observeAllTabs().map { entities ->
-            entities.toPersistedTabStateContainer()
+        return dao.observeAllTabs().map { rows ->
+            rows.toPersistedTabStateContainer()
         }
     }
 
@@ -29,16 +92,17 @@ class TabRepository(context: Context) {
         selected: Boolean,
     ) {
         db.withTransaction {
-            val currentEntities = dao.getAllTabs()
-            val existing = currentEntities.firstOrNull { it.tabId == tab.tabId }
-            val visibleTabs = currentEntities.filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+            val currentRows = dao.getAllTabs()
+            val existing = currentRows.firstOrNull { it.tabId == tab.tabId }
+            val visibleTabs = currentRows.filterNot(TabStateRow::isPlaceholderForPreAssignment)
             val targetIndex = insertIndex.coerceIn(0, visibleTabs.size)
 
             dao.upsertTab(
                 TabStateEntity(
                     tabId = tab.tabId,
                     url = tab.url,
-                    sessionState = tab.sessionState,
+                    // sessionState はファイルへ保存するため DB 列は常に空にする
+                    sessionState = "",
                     title = tab.title,
                     openerTabId = tab.openerTabId,
                     themeColor = tab.themeColor,
@@ -58,6 +122,8 @@ class TabRepository(context: Context) {
                 dao.setSelectedTab(tab.tabId)
             }
         }
+        // sessionState はファイルへ保存する（DB トランザクション外で I/O を行う）
+        writeSessionState(tab.tabId, tab.sessionState)
     }
 
     suspend fun updateUrl(tabId: String, url: String) {
@@ -69,7 +135,8 @@ class TabRepository(context: Context) {
     }
 
     suspend fun updateSessionState(tabId: String, sessionState: String) {
-        dao.updateSessionState(tabId, sessionState)
+        // sessionState は DB ではなくファイルに保存する
+        writeSessionState(tabId, sessionState)
     }
 
     suspend fun updateThemeColor(tabId: String, themeColor: Int?) {
@@ -89,15 +156,15 @@ class TabRepository(context: Context) {
     suspend fun moveTab(fromIndex: Int, toIndex: Int) {
         db.withTransaction {
             val visibleTabs = dao.getAllTabs()
-                .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+                .filterNot(TabStateRow::isPlaceholderForPreAssignment)
                 .toMutableList()
             if (fromIndex !in visibleTabs.indices || toIndex !in visibleTabs.indices) {
                 return@withTransaction
             }
             visibleTabs.add(toIndex, visibleTabs.removeAt(fromIndex))
-            visibleTabs.forEachIndexed { index, entity ->
-                if (entity.sortOrder != index) {
-                    dao.updateSortOrder(entity.tabId, index)
+            visibleTabs.forEachIndexed { index, row ->
+                if (row.sortOrder != index) {
+                    dao.updateSortOrder(row.tabId, index)
                 }
             }
         }
@@ -114,6 +181,7 @@ class TabRepository(context: Context) {
             reorderVisibleTabs()
         }
         deleteTabThumbnail(tabId)
+        deleteSessionStateFile(tabId)
     }
 
     /** サムネイル画像をキャッシュファイルに保存する */
@@ -140,42 +208,50 @@ class TabRepository(context: Context) {
         targetIndex: Int? = null,
     ) {
         val visibleTabs = dao.getAllTabs()
-            .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+            .filterNot(TabStateRow::isPlaceholderForPreAssignment)
             .toMutableList()
 
         if (moveTabId != null && targetIndex != null) {
             val currentIndex = visibleTabs.indexOfFirst { it.tabId == moveTabId }
             if (currentIndex >= 0) {
-                val entity = visibleTabs.removeAt(currentIndex)
-                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), entity)
+                val row = visibleTabs.removeAt(currentIndex)
+                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), row)
             }
         }
 
-        visibleTabs.forEachIndexed { index, entity ->
-            if (entity.sortOrder != index) {
-                dao.updateSortOrder(entity.tabId, index)
+        visibleTabs.forEachIndexed { index, row ->
+            if (row.sortOrder != index) {
+                dao.updateSortOrder(row.tabId, index)
             }
         }
     }
 
-    private fun List<TabStateEntity>.toPersistedTabStateContainer(): PersistedTabStateContainer {
-        val visibleEntities = filterNot(TabStateEntity::isPlaceholderForPreAssignment)
-        val selectedTabId = visibleEntities.firstOrNull { it.isSelected == 1 }?.tabId
-            ?: visibleEntities.lastOrNull()?.tabId
+    private suspend fun List<TabStateRow>.toPersistedTabStateContainer(): PersistedTabStateContainer {
+        val visibleRows = filterNot(TabStateRow::isPlaceholderForPreAssignment)
+        val selectedTabId = visibleRows.firstOrNull { it.isSelected == 1 }?.tabId
+            ?: visibleRows.lastOrNull()?.tabId
         return PersistedTabStateContainer(
-            tabs = visibleEntities.map { it.toPersistedTabState() },
+            tabs = visibleRows.map { it.toPersistedTabState() },
             selectedTabId = selectedTabId,
         )
     }
 
-    private fun TabStateEntity.toPersistedTabState() = PersistedTabState(
+    private suspend fun TabStateRow.toPersistedTabState() = PersistedTabState(
         url = url,
-        sessionState = sessionState,
+        sessionState = resolveSessionState(tabId),
         title = title,
         tabId = tabId,
         openerTabId = openerTabId,
         themeColor = themeColor,
     )
+
+    private companion object {
+        /**
+         * 旧 DB から sessionState を分割読みする際の 1 チャンクの文字数。
+         * 最悪 4byte/文字でも約 1MB に収まり、CursorWindow 上限(約2MB)を超えない。
+         */
+        private const val SESSION_STATE_CHUNK_CHARS = 256 * 1024
+    }
 }
 
 data class PersistedTabStateContainer(
@@ -192,10 +268,12 @@ data class PersistedTabState(
     val themeColor: Int? = null,
 )
 
-private fun TabStateEntity.isPlaceholderForPreAssignment(): Boolean {
+private fun TabStateRow.isPlaceholderForPreAssignment(): Boolean {
+    // グループ先行割り当てのプレースホルダ行は全フィールドが空。
+    // sessionState はファイルへ移行したため、ここでは射影に含まれるフィールドのみで判定する。
+    // 実タブは必ず非空の url を持つため、これで一意に識別できる。
     return url.isBlank() &&
         title.isBlank() &&
-        sessionState.isBlank() &&
         openerTabId.isBlank() &&
         themeColor == null
 }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import net.matsudamper.browser.data.tab.TabDatabase
 import net.matsudamper.browser.data.tab.TabStateEntity
-import net.matsudamper.browser.data.tab.TabStateRow
 
 class TabRepository(context: Context) {
     private val db = TabDatabase.getInstance(context)
@@ -16,7 +15,7 @@ class TabRepository(context: Context) {
 
     // sessionState は GeckoView のセッション状態(履歴・フォーム・スクロール等)を直列化した
     // 実質 blob で、ヘビーに使われたタブでは Android の CursorWindow 上限(約2MB)を超え、
-    // tab_state の取得時に SQLiteBlobTooBigException でクラッシュする原因になる。
+    // tab_state の取得時に SQLiteBlobTooBigException でクラッシュする原因になっていた。
     // そのため DB には保持せず、tabId をファイル名としてファイルへ保存する。
     // 履歴等を含む永続データなので、消えうる cacheDir ではなく filesDir に置く。
     private val sessionStateDir = File(context.filesDir, "tab_session_states").apply { mkdirs() }
@@ -36,51 +35,19 @@ class TabRepository(context: Context) {
         file.writeText(sessionState)
     }
 
+    /** 指定タブの sessionState をファイルから読み出す。無ければ空文字。 */
+    private fun readSessionState(tabId: String): String {
+        val file = sessionStateFile(tabId)
+        return if (file.exists()) file.readText() else ""
+    }
+
     private fun deleteSessionStateFile(tabId: String) {
         sessionStateFile(tabId).delete()
     }
 
-    /**
-     * 指定タブの sessionState を解決する。
-     * ファイルがあればそれを返す。無い場合は旧バージョンで DB 列に保存された
-     * sessionState をファイルへコピーしてから返す。
-     * ファイル移行が正しく動くと確認できるまでは、安全のため DB 列のデータは消さずに残す。
-     * （DB 列データの削除と移行コードの撤去は別 Issue で対応する）
-     */
-    private suspend fun resolveSessionState(tabId: String): String {
-        val file = sessionStateFile(tabId)
-        if (file.exists()) {
-            return file.readText()
-        }
-        val fromDb = readSessionStateFromDb(tabId)
-        if (fromDb.isNotEmpty()) {
-            // DB のデータはバックアップとして温存し、ファイルへコピーするだけに留める
-            writeSessionState(tabId, fromDb)
-        }
-        return fromDb
-    }
-
-    /**
-     * 旧バージョンで tab_state.sessionState に保存された文字列を読み出す。
-     * 巨大セルでも CursorWindow 上限(約2MB)を超えないよう substr で分割して読む。
-     */
-    private suspend fun readSessionStateFromDb(tabId: String): String {
-        val length = dao.getSessionStateLength(tabId) ?: return ""
-        if (length <= 0) return ""
-        val builder = StringBuilder(length)
-        var offset = 1 // SQLite の substr は 1 始まり
-        while (offset <= length) {
-            val chunk = dao.getSessionStateChunk(tabId, offset, SESSION_STATE_CHUNK_CHARS)
-            if (chunk.isNullOrEmpty()) break
-            builder.append(chunk)
-            offset += SESSION_STATE_CHUNK_CHARS
-        }
-        return builder.toString()
-    }
-
     fun observeTabs(): Flow<PersistedTabStateContainer> {
-        return dao.observeAllTabs().map { rows ->
-            rows.toPersistedTabStateContainer()
+        return dao.observeAllTabs().map { entities ->
+            entities.toPersistedTabStateContainer()
         }
     }
 
@@ -94,17 +61,15 @@ class TabRepository(context: Context) {
         selected: Boolean,
     ) {
         db.withTransaction {
-            val currentRows = dao.getAllTabs()
-            val existing = currentRows.firstOrNull { it.tabId == tab.tabId }
-            val visibleTabs = currentRows.filterNot(TabStateRow::isPlaceholderForPreAssignment)
+            val currentEntities = dao.getAllTabs()
+            val existing = currentEntities.firstOrNull { it.tabId == tab.tabId }
+            val visibleTabs = currentEntities.filterNot(TabStateEntity::isPlaceholderForPreAssignment)
             val targetIndex = insertIndex.coerceIn(0, visibleTabs.size)
 
             dao.upsertTab(
                 TabStateEntity(
                     tabId = tab.tabId,
                     url = tab.url,
-                    // sessionState はファイルへ保存するため DB 列は常に空にする
-                    sessionState = "",
                     title = tab.title,
                     openerTabId = tab.openerTabId,
                     themeColor = tab.themeColor,
@@ -158,15 +123,15 @@ class TabRepository(context: Context) {
     suspend fun moveTab(fromIndex: Int, toIndex: Int) {
         db.withTransaction {
             val visibleTabs = dao.getAllTabs()
-                .filterNot(TabStateRow::isPlaceholderForPreAssignment)
+                .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
                 .toMutableList()
             if (fromIndex !in visibleTabs.indices || toIndex !in visibleTabs.indices) {
                 return@withTransaction
             }
             visibleTabs.add(toIndex, visibleTabs.removeAt(fromIndex))
-            visibleTabs.forEachIndexed { index, row ->
-                if (row.sortOrder != index) {
-                    dao.updateSortOrder(row.tabId, index)
+            visibleTabs.forEachIndexed { index, entity ->
+                if (entity.sortOrder != index) {
+                    dao.updateSortOrder(entity.tabId, index)
                 }
             }
         }
@@ -210,50 +175,42 @@ class TabRepository(context: Context) {
         targetIndex: Int? = null,
     ) {
         val visibleTabs = dao.getAllTabs()
-            .filterNot(TabStateRow::isPlaceholderForPreAssignment)
+            .filterNot(TabStateEntity::isPlaceholderForPreAssignment)
             .toMutableList()
 
         if (moveTabId != null && targetIndex != null) {
             val currentIndex = visibleTabs.indexOfFirst { it.tabId == moveTabId }
             if (currentIndex >= 0) {
-                val row = visibleTabs.removeAt(currentIndex)
-                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), row)
+                val entity = visibleTabs.removeAt(currentIndex)
+                visibleTabs.add(targetIndex.coerceIn(0, visibleTabs.size), entity)
             }
         }
 
-        visibleTabs.forEachIndexed { index, row ->
-            if (row.sortOrder != index) {
-                dao.updateSortOrder(row.tabId, index)
+        visibleTabs.forEachIndexed { index, entity ->
+            if (entity.sortOrder != index) {
+                dao.updateSortOrder(entity.tabId, index)
             }
         }
     }
 
-    private suspend fun List<TabStateRow>.toPersistedTabStateContainer(): PersistedTabStateContainer {
-        val visibleRows = filterNot(TabStateRow::isPlaceholderForPreAssignment)
-        val selectedTabId = visibleRows.firstOrNull { it.isSelected == 1 }?.tabId
-            ?: visibleRows.lastOrNull()?.tabId
+    private fun List<TabStateEntity>.toPersistedTabStateContainer(): PersistedTabStateContainer {
+        val visibleEntities = filterNot(TabStateEntity::isPlaceholderForPreAssignment)
+        val selectedTabId = visibleEntities.firstOrNull { it.isSelected == 1 }?.tabId
+            ?: visibleEntities.lastOrNull()?.tabId
         return PersistedTabStateContainer(
-            tabs = visibleRows.map { it.toPersistedTabState() },
+            tabs = visibleEntities.map { it.toPersistedTabState() },
             selectedTabId = selectedTabId,
         )
     }
 
-    private suspend fun TabStateRow.toPersistedTabState() = PersistedTabState(
+    private fun TabStateEntity.toPersistedTabState() = PersistedTabState(
         url = url,
-        sessionState = resolveSessionState(tabId),
+        sessionState = readSessionState(tabId),
         title = title,
         tabId = tabId,
         openerTabId = openerTabId,
         themeColor = themeColor,
     )
-
-    private companion object {
-        /**
-         * 旧 DB から sessionState を分割読みする際の 1 チャンクの文字数。
-         * 最悪 4byte/文字でも約 1MB に収まり、CursorWindow 上限(約2MB)を超えない。
-         */
-        private const val SESSION_STATE_CHUNK_CHARS = 256 * 1024
-    }
 }
 
 data class PersistedTabStateContainer(
@@ -270,9 +227,8 @@ data class PersistedTabState(
     val themeColor: Int? = null,
 )
 
-private fun TabStateRow.isPlaceholderForPreAssignment(): Boolean {
+private fun TabStateEntity.isPlaceholderForPreAssignment(): Boolean {
     // グループ先行割り当てのプレースホルダ行は全フィールドが空。
-    // sessionState はファイルへ移行したため、ここでは射影に含まれるフィールドのみで判定する。
     // 実タブは必ず非空の url を持つため、これで一意に識別できる。
     return url.isBlank() &&
         title.isBlank() &&

--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -43,7 +43,9 @@ class TabRepository(context: Context) {
     /**
      * 指定タブの sessionState を解決する。
      * ファイルがあればそれを返す。無い場合は旧バージョンで DB 列に保存された
-     * sessionState をファイルへ移行してから返す（移行後は DB 列を空にする）。
+     * sessionState をファイルへコピーしてから返す。
+     * ファイル移行が正しく動くと確認できるまでは、安全のため DB 列のデータは消さずに残す。
+     * （DB 列データの削除と移行コードの撤去は別 Issue で対応する）
      */
     private suspend fun resolveSessionState(tabId: String): String {
         val file = sessionStateFile(tabId)
@@ -52,8 +54,8 @@ class TabRepository(context: Context) {
         }
         val fromDb = readSessionStateFromDb(tabId)
         if (fromDb.isNotEmpty()) {
+            // DB のデータはバックアップとして温存し、ファイルへコピーするだけに留める
             writeSessionState(tabId, fromDb)
-            dao.clearSessionState(tabId)
         }
         return fromDb
     }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
@@ -47,7 +47,8 @@ interface TabDao {
     @Query("UPDATE tab_state SET isSelected = 0")
     suspend fun clearSelectedTab()
 
-    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへ移行するための補助クエリ ---
+    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへコピーするための補助クエリ ---
+    // 移行が正しく動くと確認できるまでは DB 列のデータは消さず、バックアップとして残す。
 
     /** sessionState の文字数を取得する。セルの中身は CursorWindow に載らないため安全 */
     @Query("SELECT length(sessionState) FROM tab_state WHERE tabId = :tabId")
@@ -59,10 +60,6 @@ interface TabDao {
      */
     @Query("SELECT substr(sessionState, :start, :count) FROM tab_state WHERE tabId = :tabId")
     suspend fun getSessionStateChunk(tabId: String, start: Int, count: Int): String?
-
-    /** ファイルへ移行済みの sessionState を DB から空にする */
-    @Query("UPDATE tab_state SET sessionState = '' WHERE tabId = :tabId")
-    suspend fun clearSessionState(tabId: String)
 }
 
 /**

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
@@ -11,14 +11,19 @@ interface TabDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertTab(tab: TabStateEntity)
 
-    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
-    suspend fun getAllTabs(): List<TabStateEntity>
+    // sessionState は CursorWindow 上限(約2MB)を超え得るため一覧取得では読まない。
+    // SELECT * を避け、sessionState 以外のメタデータのみを射影して取得する。
+    @Query(
+        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
+            "FROM tab_state ORDER BY sortOrder ASC",
+    )
+    suspend fun getAllTabs(): List<TabStateRow>
 
-    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
-    fun observeAllTabs(): Flow<List<TabStateEntity>>
-
-    @Query("SELECT * FROM tab_state WHERE tabId = :tabId LIMIT 1")
-    suspend fun getTab(tabId: String): TabStateEntity?
+    @Query(
+        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
+            "FROM tab_state ORDER BY sortOrder ASC",
+    )
+    fun observeAllTabs(): Flow<List<TabStateRow>>
 
     @Query("DELETE FROM tab_state WHERE tabId = :tabId")
     suspend fun deleteTab(tabId: String)
@@ -28,9 +33,6 @@ interface TabDao {
 
     @Query("UPDATE tab_state SET title = :title WHERE tabId = :tabId")
     suspend fun updateTitle(tabId: String, title: String)
-
-    @Query("UPDATE tab_state SET sessionState = :sessionState WHERE tabId = :tabId")
-    suspend fun updateSessionState(tabId: String, sessionState: String)
 
     @Query("UPDATE tab_state SET themeColor = :themeColor WHERE tabId = :tabId")
     suspend fun updateThemeColor(tabId: String, themeColor: Int?)
@@ -44,4 +46,36 @@ interface TabDao {
 
     @Query("UPDATE tab_state SET isSelected = 0")
     suspend fun clearSelectedTab()
+
+    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへ移行するための補助クエリ ---
+
+    /** sessionState の文字数を取得する。セルの中身は CursorWindow に載らないため安全 */
+    @Query("SELECT length(sessionState) FROM tab_state WHERE tabId = :tabId")
+    suspend fun getSessionStateLength(tabId: String): Int?
+
+    /**
+     * sessionState を substr で部分取得する（1始まり）。
+     * 巨大セルでも 1 チャンクずつなら CursorWindow 上限に収まるため、分割して読み出せる。
+     */
+    @Query("SELECT substr(sessionState, :start, :count) FROM tab_state WHERE tabId = :tabId")
+    suspend fun getSessionStateChunk(tabId: String, start: Int, count: Int): String?
+
+    /** ファイルへ移行済みの sessionState を DB から空にする */
+    @Query("UPDATE tab_state SET sessionState = '' WHERE tabId = :tabId")
+    suspend fun clearSessionState(tabId: String)
 }
+
+/**
+ * tab_state からセッション状態(sessionState)を除いたメタデータ射影。
+ * sessionState は肥大化して CursorWindow 上限を超え得るため一覧取得には含めない。
+ */
+data class TabStateRow(
+    val tabId: String,
+    val url: String,
+    val title: String,
+    val openerTabId: String,
+    val themeColor: Int?,
+    val sortOrder: Int,
+    val isSelected: Int,
+    val groupId: String,
+)

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDao.kt
@@ -11,19 +11,11 @@ interface TabDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertTab(tab: TabStateEntity)
 
-    // sessionState は CursorWindow 上限(約2MB)を超え得るため一覧取得では読まない。
-    // SELECT * を避け、sessionState 以外のメタデータのみを射影して取得する。
-    @Query(
-        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
-            "FROM tab_state ORDER BY sortOrder ASC",
-    )
-    suspend fun getAllTabs(): List<TabStateRow>
+    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
+    suspend fun getAllTabs(): List<TabStateEntity>
 
-    @Query(
-        "SELECT tabId, url, title, openerTabId, themeColor, sortOrder, isSelected, groupId " +
-            "FROM tab_state ORDER BY sortOrder ASC",
-    )
-    fun observeAllTabs(): Flow<List<TabStateRow>>
+    @Query("SELECT * FROM tab_state ORDER BY sortOrder ASC")
+    fun observeAllTabs(): Flow<List<TabStateEntity>>
 
     @Query("DELETE FROM tab_state WHERE tabId = :tabId")
     suspend fun deleteTab(tabId: String)
@@ -46,33 +38,4 @@ interface TabDao {
 
     @Query("UPDATE tab_state SET isSelected = 0")
     suspend fun clearSelectedTab()
-
-    // --- 旧バージョンで tab_state.sessionState に保存されたデータをファイルへコピーするための補助クエリ ---
-    // 移行が正しく動くと確認できるまでは DB 列のデータは消さず、バックアップとして残す。
-
-    /** sessionState の文字数を取得する。セルの中身は CursorWindow に載らないため安全 */
-    @Query("SELECT length(sessionState) FROM tab_state WHERE tabId = :tabId")
-    suspend fun getSessionStateLength(tabId: String): Int?
-
-    /**
-     * sessionState を substr で部分取得する（1始まり）。
-     * 巨大セルでも 1 チャンクずつなら CursorWindow 上限に収まるため、分割して読み出せる。
-     */
-    @Query("SELECT substr(sessionState, :start, :count) FROM tab_state WHERE tabId = :tabId")
-    suspend fun getSessionStateChunk(tabId: String, start: Int, count: Int): String?
 }
-
-/**
- * tab_state からセッション状態(sessionState)を除いたメタデータ射影。
- * sessionState は肥大化して CursorWindow 上限を超え得るため一覧取得には含めない。
- */
-data class TabStateRow(
-    val tabId: String,
-    val url: String,
-    val title: String,
-    val openerTabId: String,
-    val themeColor: Int?,
-    val sortOrder: Int,
-    val isSelected: Int,
-    val groupId: String,
-)

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDatabase.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import java.io.File
 
 @Database(
     entities = [TabStateEntity::class, TabGroupEntity::class],
@@ -18,7 +19,7 @@ abstract class TabDatabase : RoomDatabase() {
 
     companion object {
         /** Room の @Database version と連動。バックアップ互換性チェックでも参照する */
-        const val SCHEMA_VERSION: Int = 3
+        const val SCHEMA_VERSION: Int = 4
 
         @Volatile
         private var instance: TabDatabase? = null
@@ -40,20 +41,86 @@ abstract class TabDatabase : RoomDatabase() {
             }
         }
 
+        private const val SESSION_STATE_CHUNK_CHARS = 256 * 1024
+
+        /**
+         * v3→v4: tab_state から sessionState カラムを削除する。
+         * 削除前に、まだファイルへ移行されていない sessionState をファイルへコピーする。
+         * CursorWindow 上限(約2MB)を超え得るため substr で分割読みする。
+         * 既にアプリ側で移行済み（ファイルが存在する）タブはスキップする。
+         */
+        internal fun createMigration3To4(sessionStateDir: File): Migration = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                migrateSessionStatesToFiles(db, sessionStateDir)
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `tab_state_new` (" +
+                        "`tabId` TEXT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, " +
+                        "`openerTabId` TEXT NOT NULL, `themeColor` INTEGER, `sortOrder` INTEGER NOT NULL, " +
+                        "`isSelected` INTEGER NOT NULL, `groupId` TEXT NOT NULL, PRIMARY KEY(`tabId`))",
+                )
+                db.execSQL(
+                    "INSERT INTO `tab_state_new` " +
+                        "(`tabId`, `url`, `title`, `openerTabId`, `themeColor`, `sortOrder`, `isSelected`, `groupId`) " +
+                        "SELECT `tabId`, `url`, `title`, `openerTabId`, `themeColor`, `sortOrder`, `isSelected`, `groupId` " +
+                        "FROM `tab_state`",
+                )
+                db.execSQL("DROP TABLE `tab_state`")
+                db.execSQL("ALTER TABLE `tab_state_new` RENAME TO `tab_state`")
+            }
+        }
+
+        private fun migrateSessionStatesToFiles(db: SupportSQLiteDatabase, sessionStateDir: File) {
+            if (!sessionStateDir.exists()) sessionStateDir.mkdirs()
+            db.query(
+                "SELECT tabId, length(sessionState) FROM tab_state " +
+                    "WHERE sessionState IS NOT NULL AND length(sessionState) > 0",
+            ).use { cursor ->
+                while (cursor.moveToNext()) {
+                    val tabId = cursor.getString(0)
+                    val length = cursor.getInt(1)
+                    if (File(sessionStateDir, tabId).exists()) continue
+                    try {
+                        val builder = StringBuilder(length)
+                        var offset = 1
+                        while (offset <= length) {
+                            db.query(
+                                "SELECT substr(sessionState, ?, ?) FROM tab_state WHERE tabId = ?",
+                                arrayOf<Any?>(offset, SESSION_STATE_CHUNK_CHARS, tabId),
+                            ).use { chunkCursor ->
+                                if (chunkCursor.moveToFirst()) {
+                                    chunkCursor.getString(0)?.let { builder.append(it) }
+                                }
+                            }
+                            offset += SESSION_STATE_CHUNK_CHARS
+                        }
+                        if (builder.isNotEmpty()) {
+                            File(sessionStateDir, tabId).writeText(builder.toString())
+                        }
+                    } catch (_: Exception) {
+                        // ファイル書き込み失敗時はスキップ（セッション状態は失われるがアプリは起動できる）
+                    }
+                }
+            }
+        }
+
         /** 全マイグレーション。getInstance とマイグレーションテストで共用する */
-        internal val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
+        internal fun allMigrations(sessionStateDir: File): Array<Migration> = arrayOf(
+            MIGRATION_1_2, MIGRATION_2_3, createMigration3To4(sessionStateDir),
+        )
 
         fun getInstance(context: Context): TabDatabase {
-            // closeInstance() 後の fast-path で閉じた DB を返さないよう isOpen を確認する
             instance?.takeIf { it.isOpen }?.let { return it }
             return synchronized(this) {
-                instance?.takeIf { it.isOpen } ?: Room.databaseBuilder(
-                    context.applicationContext,
-                    TabDatabase::class.java,
-                    "tab.db",
-                )
-                    .addMigrations(*ALL_MIGRATIONS)
-                    .build().also { instance = it }
+                instance?.takeIf { it.isOpen } ?: run {
+                    val sessionStateDir = File(context.filesDir, "tab_session_states")
+                    Room.databaseBuilder(
+                        context.applicationContext,
+                        TabDatabase::class.java,
+                        "tab.db",
+                    )
+                        .addMigrations(*allMigrations(sessionStateDir))
+                        .build().also { instance = it }
+                }
             }
         }
 
@@ -64,9 +131,6 @@ abstract class TabDatabase : RoomDatabase() {
          * 復元後のファイルを開くので、復元完了→プロセス終了の流れで使うこと。
          */
         fun closeInstance() {
-            // 参照を先に切ってから close する。ロック内で close まで行うと
-            // close 完了前に getInstance() を素通りした呼び出しが
-            // すでに閉じたインスタンスを掴む可能性があるため。
             val toClose = synchronized(this) {
                 val current = instance
                 instance = null

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabGroupDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabGroupDao.kt
@@ -52,7 +52,6 @@ abstract class TabGroupDao {
             TabStateEntity(
                 tabId = tabId,
                 url = "",
-                sessionState = "",
                 title = "",
                 openerTabId = "",
                 themeColor = null,
@@ -75,7 +74,6 @@ abstract class TabGroupDao {
             TabStateEntity(
                 tabId = tabId,
                 url = "",
-                sessionState = "",
                 title = "",
                 openerTabId = "",
                 themeColor = null,

--- a/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabStateEntity.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/tab/TabStateEntity.kt
@@ -7,7 +7,6 @@ import androidx.room.PrimaryKey
 data class TabStateEntity(
     @PrimaryKey val tabId: String,
     val url: String,
-    val sessionState: String,
     val title: String,
     val openerTabId: String,
     val themeColor: Int?,

--- a/data/src/test/kotlin/net/matsudamper/browser/data/tab/TabDatabaseMigrationTest.kt
+++ b/data/src/test/kotlin/net/matsudamper/browser/data/tab/TabDatabaseMigrationTest.kt
@@ -2,11 +2,13 @@ package net.matsudamper.browser.data.tab
 
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -26,6 +28,9 @@ class TabDatabaseMigrationTest {
         TabDatabase::class.java,
     )
 
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
     /** v1→v2: tab_group テーブル追加と tab_state.groupId 追加。既存タブが保持されることを確認 */
     @Test
     fun migrate1To2() {
@@ -38,7 +43,9 @@ class TabDatabaseMigrationTest {
             close()
         }
 
-        val db = helper.runMigrationsAndValidate(TEST_DB, 2, true, *TabDatabase.ALL_MIGRATIONS)
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 2, true, *TabDatabase.allMigrations(sessionStateDir()),
+        )
 
         db.query("SELECT tabId, groupId FROM tab_state WHERE tabId = 't1'").use { cursor ->
             assertTrue(cursor.moveToFirst())
@@ -62,7 +69,9 @@ class TabDatabaseMigrationTest {
             close()
         }
 
-        val db = helper.runMigrationsAndValidate(TEST_DB, 3, true, *TabDatabase.ALL_MIGRATIONS)
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 3, true, *TabDatabase.allMigrations(sessionStateDir()),
+        )
 
         db.query("SELECT groupId, isDefault FROM tab_group WHERE groupId = 'g1'").use { cursor ->
             assertTrue(cursor.moveToFirst())
@@ -71,9 +80,74 @@ class TabDatabaseMigrationTest {
         }
     }
 
+    /** v3→v4: sessionState をファイルへ移行しカラム削除。既存タブのデータが保持されることを確認 */
+    @Test
+    fun migrate3To4() {
+        val sessionDir = sessionStateDir()
+
+        helper.createDatabase(TEST_DB, 3).apply {
+            execSQL(
+                "INSERT INTO tab_state " +
+                    "(tabId, url, sessionState, title, openerTabId, themeColor, sortOrder, isSelected, groupId) " +
+                    "VALUES ('t1', 'https://example.com', 'session_data', 'Example', '', NULL, 0, 1, '')",
+            )
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 4, true, *TabDatabase.allMigrations(sessionDir),
+        )
+
+        db.query("SELECT tabId, url, title FROM tab_state WHERE tabId = 't1'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("t1", cursor.getString(0))
+            assertEquals("https://example.com", cursor.getString(1))
+            assertEquals("Example", cursor.getString(2))
+        }
+        // sessionState カラムが削除されている
+        db.query("PRAGMA table_info(tab_state)").use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            val columnNames = buildList {
+                while (cursor.moveToNext()) {
+                    add(cursor.getString(nameIndex))
+                }
+            }
+            assertFalse(columnNames.contains("sessionState"))
+        }
+        // sessionState がファイルに移行されている
+        val sessionFile = File(sessionDir, "t1")
+        assertTrue(sessionFile.exists())
+        assertEquals("session_data", sessionFile.readText())
+    }
+
+    /** v3→v4: 既にファイルが存在する場合は上書きしない */
+    @Test
+    fun migrate3To4_existingFileNotOverwritten() {
+        val sessionDir = sessionStateDir()
+        File(sessionDir, "t1").writeText("already_migrated")
+
+        helper.createDatabase(TEST_DB, 3).apply {
+            execSQL(
+                "INSERT INTO tab_state " +
+                    "(tabId, url, sessionState, title, openerTabId, themeColor, sortOrder, isSelected, groupId) " +
+                    "VALUES ('t1', 'https://example.com', 'old_db_data', 'Example', '', NULL, 0, 1, '')",
+            )
+            close()
+        }
+
+        helper.runMigrationsAndValidate(
+            TEST_DB, 4, true, *TabDatabase.allMigrations(sessionDir),
+        )
+
+        // 既にファイルが存在する場合は上書きしない（アプリ側で既に移行済み）
+        assertEquals("already_migrated", File(sessionDir, "t1").readText())
+    }
+
     /** v1 から最新バージョンまで全マイグレーションを連続適用できることを確認 */
     @Test
     fun migrateAllFrom1() {
+        val sessionDir = sessionStateDir()
+
         helper.createDatabase(TEST_DB, 1).apply {
             execSQL(
                 "INSERT INTO tab_state " +
@@ -87,7 +161,7 @@ class TabDatabaseMigrationTest {
             TEST_DB,
             TabDatabase.SCHEMA_VERSION,
             true,
-            *TabDatabase.ALL_MIGRATIONS,
+            *TabDatabase.allMigrations(sessionDir),
         )
 
         db.query("SELECT count(*) FROM tab_state").use { cursor ->
@@ -95,7 +169,11 @@ class TabDatabaseMigrationTest {
             assertEquals(1, cursor.getInt(0))
         }
         assertFalse(db.isReadOnly)
+        // v1 から最新まで適用すると sessionState がファイルに移行されている
+        assertEquals("state", File(sessionDir, "t1").readText())
     }
+
+    private fun sessionStateDir(): File = File(tempFolder.root, "session_states").apply { mkdirs() }
 
     companion object {
         private const val TEST_DB = "migration-test-tab"


### PR DESCRIPTION
## 概要

GeckoView のセッション状態（履歴・フォーム・スクロール等）を `tab_state.sessionState` 列からファイルシステムへ移行し、最終的に DB 列も削除します。sessionState は肥大化して SQLite の CursorWindow 上限（約2MB）を超え、タブ一覧取得時に `SQLiteBlobTooBigException` で**起動時・ダウンロード時にクラッシュ**する問題を解決します。

## 原因

`tab_state.sessionState` に GeckoView のセッション状態を直列化して保存していたが、ヘビーに使われたタブで約2MB を超え、`getAllTabs()` の `SELECT *` 時に CursorWindow へ載らず `SQLiteBlobTooBigException` でクラッシュしていた（`requiredPos=75, totalRows=76`）。

## 対応

### 1. sessionState をファイル保存へ
- DB 列ではなく `filesDir/tab_session_states/<tabId>` にファイルとして保存
- 履歴等を含む永続データのため、消えうる `cacheDir` ではなく `filesDir` を使用
- 読み書き: `readSessionState` / `writeSessionState`（空なら削除）。タブ削除時は `deleteSessionStateFile` で対応ファイルも削除
- 一覧取得（`getAllTabs` / `observeAllTabs`）は `TabStateEntity` を `SELECT *` で取得（肥大化する列が無くなったため射影は不要）

### 2. DB 列の削除（schema v3 → v4）
- `TabStateEntity` から `sessionState` フィールドを削除
- `MIGRATION_3_4`: `sessionState` を除いた新テーブルを作成 → `INSERT ... SELECT` で他カラムをコピー → 旧テーブル破棄 → リネーム（テーブル再構築）
  - `sessionState` を SELECT しないため、巨大セルが残っていても CursorWindow 上限に当たらない
  - `DROP TABLE` による全データ破棄ではなく、URL・タイトル・グループ等の他データは保持される

## アップグレード時の挙動（要確認）

- 中間バージョン（ファイル保存導入済み・列削除前）を一度でも起動した端末は、sessionState がファイルへ保存済みのため、移行後も履歴・スクロール位置が保持される。
- 一方、**v3 から直接 v4 へ上がる端末（中間バージョン未起動）は、`MIGRATION_3_4` で列が削除されるためタブ内の履歴・スクロール位置・フォーム内容が失われる**（URL・タイトルは保持され、タブは URL から再読み込みされる）。
- 完全に保持したい場合は `MIGRATION_3_4` 内で列削除前に sessionState をファイルへ退避する実装も可能（マイグレーション内ファイル I/O の脆さについては #456 を参照）。

## テスト

- `:app:assembleDebug` / `detekt` / `test` すべてグリーン
- `TabDatabaseMigrationTest.migrate3To4` を追加（行データ保持と `sessionState` 列消失を検証）。`migrateAllFrom1` も v4 まで通過することを確認

Closes #456

https://claude.ai/code/session_016ev6X9c3fQXCwuN58SdNJm
