### PR TITLE
ツールバーの無効状態アイコン色をシステムテーマから独立させる

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -340,7 +340,7 @@ internal fun BrowserToolbar(
                             tint = if (canGoBack) {
                                 LocalContentColor.current
                             } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                LocalContentColor.current.copy(alpha = 0.38f)
                             },
                         )
                     }
@@ -367,7 +367,7 @@ internal fun BrowserToolbar(
                             tint = if (canGoForward) {
                                 LocalContentColor.current
                             } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                LocalContentColor.current.copy(alpha = 0.38f)
                             },
                         )
                     }
@@ -757,6 +757,54 @@ private fun PreviewWideToolbar() {
                 onLongPressHistory = {},
                 onTranslatePage = {},
             )
+        }
+    }
+}
+
+// テーマカラーが黒/白のサイトで戻る/進むが disable のとき、
+// disable アイコンの色がシステムテーマではなくツールバーのコンテンツカラー(メニュー等と同じ色)に
+// 基づいて決まることを確認するプレビュー。戻る=有効・進む=無効で有効/無効のコントラストを見る。
+@Preview(name = "DisabledOnThemeColorLight", widthDp = 600)
+@Preview(name = "DisabledOnThemeColorDark", widthDp = 600, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PreviewDisabledOnThemeColor() {
+    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_SYSTEM) {
+        Column {
+            for (toolbarColor in listOf(Color.Black, Color.White)) {
+                BrowserToolBar(
+                    value = "https://google.com",
+                    onValueChange = {},
+                    onSubmit = {},
+                    isFocused = false,
+                    onFocusChanged = {},
+                    onLongClickUrl = {},
+                    showInstallExtensionItem = true,
+                    onInstallExtension = {},
+                    onOpenSettings = {},
+                    onShare = {},
+                    tabCount = 2,
+                    onOpenTabs = {},
+                    isPcMode = false,
+                    onPcModeToggle = {},
+                    onFindInPage = {},
+                    onAddToHomeScreen = {},
+                    pageZoomPercent = 100,
+                    onPageZoomIn = {},
+                    onPageZoomOut = {},
+                    onResetPageZoom = {},
+                    toolbarColor = toolbarColor,
+                    onRefresh = {},
+                    onSuperRefresh = {},
+                    onHome = {},
+                    onForward = {},
+                    canGoForward = false,
+                    onBack = {},
+                    canGoBack = true,
+                    onLongPressHistory = {},
+                    onTranslatePage = {},
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
         }
     }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolbarMenu.kt
@@ -177,7 +177,7 @@ private fun ToolbarMenuContent(
                             tint = if (canGoBack) {
                                 LocalContentColor.current
                             } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                LocalContentColor.current.copy(alpha = 0.38f)
                             },
                         )
                     }
@@ -215,7 +215,7 @@ private fun ToolbarMenuContent(
                             tint = if (canGoForward) {
                                 LocalContentColor.current
                             } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                LocalContentColor.current.copy(alpha = 0.38f)
                             },
                         )
                     }


### PR DESCRIPTION
## 概要
ツールバーの戻る/進むボタンが無効状態のときのアイコン色を、システムテーマの `MaterialTheme.colorScheme.onSurface` から `LocalContentColor.current` に変更しました。これにより、ツールバーのコンテンツカラー（メニューなど他の要素と同じ色）に基づいて無効状態のアイコン色が決定されるようになります。

## 変更内容

### BrowserToolBar.kt
- 戻るボタンの無効状態アイコン色: `MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)` → `LocalContentColor.current.copy(alpha = 0.38f)`
- 進むボタンの無効状態アイコン色: `MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)` → `LocalContentColor.current.copy(alpha = 0.38f)`
- テーマカラーが黒/白のサイトでの表示確認用プレビュー `PreviewDisabledOnThemeColor()` を追加
  - ライト/ダークモード両方で、黒と白のツールバーカラーでの表示を確認可能

### BrowserToolbarMenu.kt
- 戻るボタンの無効状態アイコン色: `MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)` → `LocalContentColor.current.copy(alpha = 0.38f)`
- 進むボタンの無効状態アイコン色: `MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)` → `LocalContentColor.current.copy(alpha = 0.38f)`

## 実装の詳細
この変更により、ツールバーのコンテンツカラーが黒または白の場合でも、無効状態のアイコンが適切なコントラストで表示されるようになります。システムテーマに依存せず、ツールバー自体のカラースキームに合わせた色が使用されます。

https://claude.ai/code/session_01EhqGshxLMXjrnzdkxAq8bZ