### PR TITLE
fix: GmdSmokeTestのfile URL表記ゆれによるフレーキーテストを修正

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GmdSmokeTest.kt
@@ -533,7 +533,7 @@ class GmdSmokeTest {
     private fun waitForUrlBarText(expected: String) {
         try {
             composeRule.waitUntil(timeoutMillis = 20_000) {
-                composeRule.currentUrlBarText() == expected
+                normalizeFileUrl(composeRule.currentUrlBarText()) == normalizeFileUrl(expected)
             }
         } catch (e: androidx.compose.ui.test.ComposeTimeoutException) {
             throw AssertionError(


### PR DESCRIPTION
## Summary

- `GmdSmokeTest.tappingUrlBarClearsInputAndShowsCurrentUrlActions` が `waitForUrlBarText` で `file:/data/...` と `file:///data/...` を別のURLとして完全一致比較し、20秒タイムアウトする問題を修正
- 既存の `normalizeFileUrl` ヘルパーで正規化してから比較するよう変更

## Test plan
- [ ] CI の instrumentation テストが通ること

Closes #461

https://claude.ai/code/session_01VpM8cHW3zPPPpcdZsuWZEy