### PR TITLE
fix: WebAppのActivity再生成時にセッションがリセットされる問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
@@ -45,9 +45,6 @@ class WebAppActivity : ComponentActivity() {
     private val historyRepository: HistoryRepository by inject()
     private val webSuggestionRepository: WebSuggestionRepository by inject()
 
-    private lateinit var browserTabController: BrowserTabController
-    private lateinit var browserSessionLifecycleController: BrowserSessionLifecycleController
-
     private var pendingDownloadNotificationPermissionDeferred: CompletableDeferred<Unit>? = null
 
     private val requestDownloadNotificationPermissionLauncher = registerForActivityResult(
@@ -61,17 +58,17 @@ class WebAppActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         runtime.settings.setExtensionsWebAPIEnabled(true)
 
-        // 拡張機能は Koin の single で管理されるため、ここではセッション管理のみ担当する
-        browserTabController = BrowserTabController(
-            tabRepository = tabRepository,
-            tabGroupRepository = null,
-            isSinglePage = true,
-        )
-        browserSessionLifecycleController = BrowserSessionLifecycleController(runtime)
-
         // 外部アプリから任意のURLが渡されないよう、http/https スキームのみ許可する
         val initialUrl = resolveInitialUrl()
         setContent {
+            val browserViewModel = viewModel(initializer = {
+                WebAppBrowserViewModel(
+                    tabRepository = tabRepository,
+                    runtime = runtime,
+                )
+            })
+            val browserTabController = browserViewModel.browserTabController
+            val browserSessionLifecycleController = browserViewModel.browserSessionLifecycleController
             val settings by settingsRepository.settings.collectAsState(initial = null)
             val browserSettings = settings ?: return@setContent
             val webAppScreenViewModel = viewModel(initializer = {
@@ -161,10 +158,6 @@ class WebAppActivity : ComponentActivity() {
             CancellationException("Activity was destroyed before download notification permission completed.")
         )
         pendingDownloadNotificationPermissionDeferred = null
-        // セッションのみ閉じる。拡張機能はプロセススコープで管理されるため解放しない。
-        if (::browserTabController.isInitialized) {
-            browserTabController.close()
-        }
         super.onDestroy()
     }
 

--- a/app/src/main/kotlin/net/matsudamper/browser/WebAppBrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/WebAppBrowserViewModel.kt
@@ -1,0 +1,21 @@
+package net.matsudamper.browser
+
+import androidx.lifecycle.ViewModel
+import net.matsudamper.browser.data.TabRepository
+import org.mozilla.geckoview.GeckoRuntime
+
+internal class WebAppBrowserViewModel(
+    tabRepository: TabRepository,
+    runtime: GeckoRuntime,
+) : ViewModel() {
+    val browserTabController = BrowserTabController(
+        tabRepository = tabRepository,
+        tabGroupRepository = null,
+        isSinglePage = true,
+    )
+    val browserSessionLifecycleController = BrowserSessionLifecycleController(runtime)
+
+    override fun onCleared() {
+        browserTabController.close()
+    }
+}

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/WebAppScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/WebAppScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
@@ -24,21 +23,15 @@ fun WebAppScreen(
         uiState: BrowserScreenUiState,
     ) -> Unit,
 ) {
+    // Activity再生成（フォルダブル開閉等）時はViewModelのcontrollerに既存タブが残っているため再利用する。
+    // タブの破棄はViewModelの onCleared() で行う。
     val browserTab by produceState<BrowserTab?>(
         initialValue = null,
         key1 = browserTabController,
         key2 = initialUrl,
     ) {
-        value = null
-        value = browserTabController.createAndAppendTab(initialUrl = initialUrl)
-    }
-    DisposableEffect(browserTabController, browserTab?.tabId) {
-        val tabId = browserTab?.tabId
-        onDispose {
-            if (tabId != null) {
-                browserTabController.closeTab(tabId)
-            }
-        }
+        value = browserTabController.tabs.firstOrNull()
+            ?: browserTabController.createAndAppendTab(initialUrl = initialUrl)
     }
 
     val activeTab = browserTab


### PR DESCRIPTION
## 概要

ホームに「アプリとして追加」したWebAppで、フォルダブルデバイスの開閉などActivity再生成が発生すると、閲覧中のページが初期登録URLにリセットされる問題を修正。

## 原因

2つの問題が重なっていた：

1. **`WebAppActivity`**: `BrowserTabController` と `BrowserSessionLifecycleController` を `onCreate()` で毎回新規作成していたため、configuration change を跨いで GeckoView セッションが保持されなかった
2. **`WebAppScreen`**: `DisposableEffect` が Activity 再生成時にタブを閉じ、`produceState` が新しいタブを初期URLで作り直していた

## 修正内容

- `WebAppBrowserViewModel` を新設し、`BrowserTabController` と `BrowserSessionLifecycleController` を ViewModel に移動。configuration change を跨いでセッション状態を保持する
- `WebAppScreen` で既存タブがあればそれを再利用し、タブの破棄は ViewModel の `onCleared()` に委譲する

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `WebAppBrowserViewModel.kt` | 新規作成。ViewModel で controller のライフサイクルを管理 |
| `WebAppActivity.kt` | controller の生成を ViewModel 経由に変更 |
| `WebAppScreen.kt` | 既存タブの再利用、DisposableEffect によるタブ破棄を削除 |

## テスト

- `./gradlew :app:assembleDebug` ビルド確認済み
- `./gradlew detekt` lint通過
- `./gradlew test` ユニットテスト通過