### PR TITLE
fix: タブサムネイルの保存先をcacheDirからfilesDirに変更

### DIFF
--- a/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/TabRepository.kt
@@ -11,7 +11,24 @@ import net.matsudamper.browser.data.tab.TabStateEntity
 class TabRepository(context: Context) {
     private val db = TabDatabase.getInstance(context)
     private val dao = db.tabDao()
-    private val thumbnailDir = File(context.cacheDir, "tab_thumbnails").apply { mkdirs() }
+    // サムネイルはタブの永続データなので、消えうる cacheDir ではなく filesDir に置く。
+    // 以前は cacheDir に保存していたため、旧ディレクトリからのマイグレーションを行う。
+    private val thumbnailDir = File(context.filesDir, "tab_thumbnails").apply { mkdirs() }
+
+    init {
+        val oldDir = File(context.cacheDir, "tab_thumbnails")
+        if (oldDir.exists()) {
+            oldDir.listFiles()?.forEach { file ->
+                val dest = File(thumbnailDir, file.name)
+                if (!dest.exists()) {
+                    file.renameTo(dest)
+                } else {
+                    file.delete()
+                }
+            }
+            oldDir.delete()
+        }
+    }
 
     // sessionState は GeckoView のセッション状態(履歴・フォーム・スクロール等)を直列化した
     // 実質 blob で、ヘビーに使われたタブでは Android の CursorWindow 上限(約2MB)を超え、
@@ -151,7 +168,7 @@ class TabRepository(context: Context) {
         deleteSessionStateFile(tabId)
     }
 
-    /** サムネイル画像をキャッシュファイルに保存する */
+    /** サムネイル画像をファイルに保存する */
     fun saveTabThumbnail(tabId: String, imageBytes: ByteArray) {
         if (imageBytes.isEmpty()) return
         if (!thumbnailDir.exists()) {
@@ -160,7 +177,7 @@ class TabRepository(context: Context) {
         File(thumbnailDir, "$tabId.webp").writeBytes(imageBytes)
     }
 
-    /** サムネイル画像をキャッシュファイルから読み込む */
+    /** サムネイル画像をファイルから読み込む */
     fun loadTabThumbnail(tabId: String): ByteArray? {
         val file = File(thumbnailDir, "$tabId.webp")
         return if (file.exists()) file.readBytes() else null


### PR DESCRIPTION
## Summary
- タブ一覧のプレビュー画像が消える問題を修正
- サムネイルの保存先を `context.cacheDir` から `context.filesDir` に変更
- 既存の `cacheDir/tab_thumbnails/` からのマイグレーション処理を追加

## 原因
`TabRepository` のサムネイル保存先が `cacheDir` だったため、Android OS のキャッシュクリア（ディスク容量逼迫時の自動削除やユーザーによるキャッシュクリア）でプレビュー画像が消失していた。セッション状態（`tab_session_states`）は同様の理由で既に `filesDir` に保存されていたが、サムネイルは `cacheDir` のままだった。

## Test plan
- [ ] ビルド確認済み (`./gradlew :app:assembleDebug`)
- [ ] detekt 通過済み
- [ ] ユニットテスト通過済み (`./gradlew test`)
- [ ] アプリ起動後、タブのプレビュー画像が表示されることを確認
- [ ] 設定からアプリのキャッシュをクリアしてもプレビュー画像が保持されることを確認

https://claude.ai/code/session_01At6h72PujvcLocfKenGA3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01At6h72PujvcLocfKenGA3Z)_