### PR TITLE
ダウンロード画面のタップジェスチャーとメニュー位置を改善

### DIFF
--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -147,7 +146,12 @@ private fun DownloadItemRow(
                 .fillMaxWidth()
                 .combinedClickable(
                     onLongClick = { menuExpanded = true },
-                    onClick = {},
+                    onClick = {
+                        val status = item.status
+                        if (status is DownloadManagementScreenUiState.DownloadStatus.Completed) {
+                            onOpenFile(status.fileUri)
+                        }
+                    },
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -212,11 +216,7 @@ private fun DownloadItemRow(
                             }
                         }
 
-                        is DownloadManagementScreenUiState.DownloadStatus.Completed -> {
-                            TextButton(onClick = { onOpenFile(status.fileUri) }) {
-                                Text("開く")
-                            }
-                        }
+                        is DownloadManagementScreenUiState.DownloadStatus.Completed -> Unit
 
                         is DownloadManagementScreenUiState.DownloadStatus.Failed -> {
                             if (status.canResume) {

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -175,7 +175,7 @@ private fun DownloadItemRow(
                     Text(
                         text = item.fileName,
                         style = MaterialTheme.typography.bodyLarge,
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .weight(1f)

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -500,3 +500,27 @@ private fun PreviewFailedCannotResume() {
         )
     }
 }
+
+@Preview(name = "長いファイル名・2行表示")
+@Composable
+private fun PreviewLongFileName() {
+    MaterialTheme {
+        DownloadItemRow(
+            item = DownloadManagementScreenUiState.DownloadItem(
+                id = UUID.randomUUID(),
+                fileName = "very_long_file_name_that_should_wrap_to_two_lines_example_document.pdf",
+                status = DownloadManagementScreenUiState.DownloadStatus.Completed(
+                    fileUri = "content://media/external/downloads/3",
+                    thumbnail = null,
+                ),
+                enqueuedAt = 0L,
+                originPageUrl = "https://example.com/page",
+            ),
+            onCancel = {},
+            onPause = {},
+            onOpenFile = {},
+            onResume = {},
+            onOpenOriginPage = {},
+        )
+    }
+}

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -1,7 +1,8 @@
 package net.matsudamper.browser.ui.downloads
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,13 +40,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -117,6 +115,7 @@ fun DownloadManagementScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DownloadItemRow(
     item: DownloadManagementScreenUiState.DownloadItem,
@@ -128,13 +127,10 @@ private fun DownloadItemRow(
 ) {
     val dateFormat = remember { SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault()) }
     var menuExpanded by remember { mutableStateOf(false) }
-    var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
-    val density = LocalDensity.current
     Box {
         DropdownMenu(
             expanded = menuExpanded,
             onDismissRequest = { menuExpanded = false },
-            offset = menuOffset,
         ) {
             DropdownMenuItem(
                 text = { Text("開始ページを開く") },
@@ -148,22 +144,15 @@ private fun DownloadItemRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onLongPress = { offset ->
-                            with(density) {
-                                menuOffset = DpOffset(offset.x.toDp(), offset.y.toDp())
-                            }
-                            menuExpanded = true
-                        },
-                        onTap = {
-                            val status = item.status
-                            if (status is DownloadManagementScreenUiState.DownloadStatus.Completed) {
-                                onOpenFile(status.fileUri)
-                            }
-                        },
-                    )
-                }
+                .combinedClickable(
+                    onLongClick = { menuExpanded = true },
+                    onClick = {
+                        val status = item.status
+                        if (status is DownloadManagementScreenUiState.DownloadStatus.Completed) {
+                            onOpenFile(status.fileUri)
+                        }
+                    },
+                )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -1,8 +1,7 @@
 package net.matsudamper.browser.ui.downloads
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,10 +39,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -115,7 +117,6 @@ fun DownloadManagementScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DownloadItemRow(
     item: DownloadManagementScreenUiState.DownloadItem,
@@ -127,10 +128,13 @@ private fun DownloadItemRow(
 ) {
     val dateFormat = remember { SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault()) }
     var menuExpanded by remember { mutableStateOf(false) }
+    var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
+    val density = LocalDensity.current
     Box {
         DropdownMenu(
             expanded = menuExpanded,
             onDismissRequest = { menuExpanded = false },
+            offset = menuOffset,
         ) {
             DropdownMenuItem(
                 text = { Text("開始ページを開く") },
@@ -144,15 +148,22 @@ private fun DownloadItemRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .combinedClickable(
-                    onLongClick = { menuExpanded = true },
-                    onClick = {
-                        val status = item.status
-                        if (status is DownloadManagementScreenUiState.DownloadStatus.Completed) {
-                            onOpenFile(status.fileUri)
-                        }
-                    },
-                )
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onLongPress = { offset ->
+                            with(density) {
+                                menuOffset = DpOffset(offset.x.toDp(), offset.y.toDp())
+                            }
+                            menuExpanded = true
+                        },
+                        onTap = {
+                            val status = item.status
+                            if (status is DownloadManagementScreenUiState.DownloadStatus.Completed) {
+                                onOpenFile(status.fileUri)
+                            }
+                        },
+                    )
+                }
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
## 概要
ダウンロード管理画面のアイテム行のタップジェスチャー処理を `combinedClickable` から `detectTapGestures` に変更し、長押しメニューの位置制御を改善しました。また、ファイル名の表示行数を2行に拡張し、完了状態のアイテムをタップで開けるようにしました。

## 主な変更

- **ジェスチャー処理の改善**
  - `ExperimentalFoundationApi` の `combinedClickable` から `detectTapGestures` に移行
  - 長押し時のメニュー位置を正確に計算・設定（`menuOffset` で管理）
  - タップ時の動作を明示的に実装（完了状態のファイルを開く）

- **UI/UX の改善**
  - ファイル名の最大表示行数を1行から2行に変更（長いファイル名に対応）
  - 完了状態のアイテムで「開く」ボタンを削除し、タップで直接ファイルを開くように統一
  - ドロップダウンメニューの位置を長押し位置に合わせて表示

- **不要な import の削除**
  - `ExperimentalFoundationApi`
  - `TextButton`

- **新規 Preview の追加**
  - 長いファイル名での2行表示を確認するプレビュー (`PreviewLongFileName`)

## 実装の詳細

- `LocalDensity` を使用してピクセル座標を Dp に変換し、メニューの表示位置を正確に制御
- `detectTapGestures` で `onLongPress` と `onTap` を分離し、各ジェスチャーの処理を明確化
- ファイル名表示の行数制限を増やすことで、長いファイル名の可読性を向上

https://claude.ai/code/session_01Dqht8p7LiY4fz1smBCExXH