### PR TITLE
URL提案リストをSurfaceでラップし、プレビューを改善

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
@@ -204,22 +204,26 @@ internal fun BrowserTabOverlayLayer(
                 currentPageUrl = state.currentPageUrl,
             )
         ) {
-            UrlSuggestionList(
-                currentPageUrl = state.currentPageUrl,
-                historySuggestions = urlBarSuggestions.historySuggestions,
-                webSuggestions = urlBarSuggestions.webSuggestions,
-                isLoadingWebSuggestions = urlBarSuggestions.isLoadingWebSuggestions,
-                onHistorySuggestionClick = onHistorySuggestionClick,
-                onWebSuggestionClick = onWebSuggestionClick,
-                onCopyCurrentUrl = state::copyCurrentPageUrl,
-                onRestoreCurrentUrl = state::restoreCurrentPageUrlToInput,
-                clipboardUrl = clipboardUrl,
-                onClipboardUrlClick = onClipboardUrlClick,
+            Surface(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surface)
                     .testTag(BrowserTabSurfaceTestTags.UrlSuggestionList.testTag),
-            )
+                color = MaterialTheme.colorScheme.surface,
+            ) {
+                UrlSuggestionList(
+                    currentPageUrl = state.currentPageUrl,
+                    historySuggestions = urlBarSuggestions.historySuggestions,
+                    webSuggestions = urlBarSuggestions.webSuggestions,
+                    isLoadingWebSuggestions = urlBarSuggestions.isLoadingWebSuggestions,
+                    onHistorySuggestionClick = onHistorySuggestionClick,
+                    onWebSuggestionClick = onWebSuggestionClick,
+                    onCopyCurrentUrl = state::copyCurrentPageUrl,
+                    onRestoreCurrentUrl = state::restoreCurrentPageUrlToInput,
+                    clipboardUrl = clipboardUrl,
+                    onClipboardUrlClick = onClipboardUrlClick,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
     }
 }
@@ -448,10 +452,24 @@ private fun CurrentPageUrlActionRow(
     }
 }
 
-@Preview(name = "今のURL操作")
+@Preview(name = "今のURL操作Light")
 @Composable
-private fun PreviewCurrentPageUrlListItem() {
-    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_SYSTEM) {
+private fun PreviewCurrentPageUrlListItemLight() {
+    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_LIGHT) {
+        Surface {
+            CurrentPageUrlListItem(
+                currentPageUrl = "https://example.com/very/long/path?query=value",
+                onCopyCurrentUrl = {},
+                onRestoreCurrentUrl = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "今のURL操作Dark")
+@Composable
+private fun PreviewCurrentPageUrlListItemDark() {
+    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_DARK) {
         Surface {
             CurrentPageUrlListItem(
                 currentPageUrl = "https://example.com/very/long/path?query=value",

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabSurface.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import net.matsudamper.browser.data.ThemeMode
 import net.matsudamper.browser.ui.browser.UrlBarSuggestionsUiState
 import net.matsudamper.browser.ui.common.BrowserTheme
 import org.mozilla.geckoview.GeckoResult
@@ -455,7 +456,7 @@ private fun CurrentPageUrlActionRow(
 @Preview(name = "今のURL操作Light")
 @Composable
 private fun PreviewCurrentPageUrlListItemLight() {
-    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_LIGHT) {
+    BrowserTheme(themeMode = ThemeMode.THEME_LIGHT) {
         Surface {
             CurrentPageUrlListItem(
                 currentPageUrl = "https://example.com/very/long/path?query=value",
@@ -469,7 +470,7 @@ private fun PreviewCurrentPageUrlListItemLight() {
 @Preview(name = "今のURL操作Dark")
 @Composable
 private fun PreviewCurrentPageUrlListItemDark() {
-    BrowserTheme(themeMode = net.matsudamper.browser.data.ThemeMode.THEME_DARK) {
+    BrowserTheme(themeMode = ThemeMode.THEME_DARK) {
         Surface {
             CurrentPageUrlListItem(
                 currentPageUrl = "https://example.com/very/long/path?query=value",


### PR DESCRIPTION
## 概要
URL提案リストの表示層を改善し、プレビューの表示パターンを拡充しました。

## 主な変更

- **URL提案リストのSurfaceラップ**: `UrlSuggestionList` を `Surface` コンポーネントでラップし、背景色の管理を一元化。背景色の指定を `background()` modifier から `Surface` の `color` パラメータに移行
- **UrlSuggestionListへのmodifier追加**: `fillMaxSize()` を `UrlSuggestionList` に直接渡すことで、レイアウト構造を明確化
- **プレビューの拡充**: 
  - `PreviewCurrentPageUrlListItem` を Light/Dark の2つのテーマプレビューに分割
  - `THEME_SYSTEM` から `THEME_LIGHT` と `THEME_DARK` に変更し、各テーマでの表示を明確に確認可能に

## 実装の詳細

Material 3 の `Surface` コンポーネントを使用することで、テーマに応じた背景色管理がより適切になり、将来的な色スキーム変更への対応が容易になります。

https://claude.ai/code/session_01SrtJ6j2cZ7pMYqyrLkXLis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved URL suggestion interface with enhanced theme color application
  * Added separate light and dark theme preview variants for better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->