### PR TITLE
GitHub Actions: upload-artifact から archive パラメータを削除

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -42,9 +42,8 @@ jobs:
       - name: Upload release APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: app-release.apk
+          name: app-release-apk
           path: app/build/outputs/apk/release/app-release.apk
-          archive: false
 
       - name: Run Android Lint
         run: ./gradlew :app:lintDebug
@@ -55,7 +54,6 @@ jobs:
         with:
           name: app-lint-report
           path: app/build/reports/lint-results-debug.html
-          archive: false
 
   android-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -66,7 +66,6 @@ jobs:
         with:
           name: ${{ env.APK_NAME }}
           path: ${{ env.APK_PATH }}
-          archive: false
 
       - name: Upload APK to S3
         id: upload_s3
@@ -87,7 +86,6 @@ jobs:
         with:
           name: apk-qr-code-github
           path: qrcode-github.png
-          archive: false
 
       - name: Generate and Upload S3 QR code
         if: steps.upload_s3.outputs.url != ''
@@ -102,7 +100,6 @@ jobs:
         with:
           name: apk-qr-code-s3
           path: qrcode-s3.png
-          archive: false
 
       - name: Comment APK download URLs
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
@@ -129,7 +126,6 @@ jobs:
         with:
           name: app-lint-report
           path: app/build/reports/lint-results-debug.html
-          archive: false
 
   android-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

GitHub Actions の `upload-artifact` アクションから非推奨の `archive` パラメータを削除しました。

## 変更内容

- `main-build.yml` と `pr-build.yml` の複数の `upload-artifact` ステップから `archive: false` パラメータを削除
- `main-build.yml` の APK アップロード時のアーティファクト名を `app-release.apk` から `app-release-apk` に変更（ドットをハイフンに統一）

## 詳細

`upload-artifact` アクション v7.0.1 では `archive` パラメータが非推奨となっており、以下のステップから削除しました：

- APK ファイルのアップロード
- Lint レポートのアップロード
- QR コード画像のアップロード（GitHub/S3 両方）

これにより、アクションの最新の推奨設定に準拠します。

https://claude.ai/code/session_01DqQMK2WhoPQoxzZ6zXUDYL