### PR TITLE
タブプレビュー画像を上寄せに変更

### DIFF
--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabCard.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabCard.kt
@@ -204,6 +204,7 @@ internal fun TabCard(
                         bitmap = preview,
                         contentDescription = "Tab preview",
                         contentScale = ContentScale.Crop,
+                        alignment = Alignment.TopCenter,
                         modifier = Modifier.fillMaxSize(),
                     )
                 } else {


### PR DESCRIPTION
## Summary
- フォルダブルデバイスで撮影した縦長のプレビュー画像が、折りたたみ後のタブ一覧で中央クロップされ上部が表示されない問題を修正
- `TabCard` の `Image` に `alignment = Alignment.TopCenter` を追加し、上寄せでクロップされるように変更

## Test plan
- [ ] フォルダブルデバイスで開いた状態でタブプレビューを撮影し、閉じた状態でタブ一覧を表示してプレビュー画像が上寄せで表示されることを確認
- [ ] 通常デバイスでもタブプレビュー表示に問題がないことを確認

https://claude.ai/code/session_013yvi2GAvjaubusQEBcaTuz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yvi2GAvjaubusQEBcaTuz)_