### PR TITLE
サムネイル読み込みをCompose側で管理するよう変更

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.provider.MediaStore
 import android.provider.Settings
 import android.util.Size
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.net.toUri
 import androidx.lifecycle.AndroidViewModel
@@ -19,9 +18,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.matsudamper.browser.GeckoDownloadManager
 import net.matsudamper.browser.data.download.DownloadRecord
 import net.matsudamper.browser.data.download.DownloadRecordStatus
@@ -43,12 +42,6 @@ internal class DownloadManagementScreenViewModel(
     /** resumeDownload から最新のレコードを参照するためのキャッシュ */
     private var currentRecords: List<DownloadRecord> = emptyList()
 
-    /** 読み込み済みサムネイル。サムネイル非対応のファイルは null を保持して再読み込みを防ぐ */
-    private val thumbnailFlow = MutableStateFlow<Map<String, ImageBitmap?>>(emptyMap())
-
-    /** サムネイル読み込み要求済みの fileUri */
-    private val requestedThumbnailUris = mutableSetOf<String>()
-
     val uiState: StateFlow<DownloadManagementScreenUiState> = MutableStateFlow(
         DownloadManagementScreenUiState(
             isLoading = true,
@@ -57,18 +50,10 @@ internal class DownloadManagementScreenViewModel(
         ),
     ).also { uiStateFlow ->
         viewModelScope.launch {
-            combine(
-                downloadRepository.observeDownloads(),
-                thumbnailFlow,
-            ) { records, thumbnails -> records to thumbnails }
-                .collectLatest { (records, thumbnails) ->
+            downloadRepository.observeDownloads()
+                .collectLatest { records ->
                     currentRecords = records
-                    records.forEach { record ->
-                        if (record.status == DownloadRecordStatus.SUCCEEDED) {
-                            record.fileUri?.let { requestThumbnail(it) }
-                        }
-                    }
-                    val items = records.map { record -> record.toDownloadItem(thumbnails) }
+                    val items = records.map { record -> record.toDownloadItem() }
                     uiStateFlow.update {
                         DownloadManagementScreenUiState(
                             isLoading = false,
@@ -80,24 +65,6 @@ internal class DownloadManagementScreenViewModel(
         }
     }.asStateFlow()
 
-    /**
-     * ダウンロード完了ファイルのサムネイルを非同期で読み込む。
-     * MediaStore がサムネイルを生成できないファイル (zip 等) は null として記録する。
-     */
-    private fun requestThumbnail(fileUri: String) {
-        if (!requestedThumbnailUris.add(fileUri)) return
-        viewModelScope.launch(Dispatchers.IO) {
-            val thumbnail = runCatching {
-                getApplication<Application>().contentResolver.loadThumbnail(
-                    fileUri.toUri(),
-                    Size(THUMBNAIL_SIZE_PX, THUMBNAIL_SIZE_PX),
-                    null,
-                )
-            }.getOrNull()?.asImageBitmap()
-            thumbnailFlow.update { it + (fileUri to thumbnail) }
-        }
-    }
-
     private fun buildCallbacks() = DownloadManagementScreenUiState.Callbacks(
         onCancel = { id -> cancelDownload(id) },
         onPause = { id -> pauseDownload(id) },
@@ -105,19 +72,26 @@ internal class DownloadManagementScreenViewModel(
         onOpenDownloadsFolder = { openDownloadsFolder() },
         onResume = { id -> resumeDownload(id) },
         onOpenOriginPage = { url -> eventHandler.trySend { it.navigateToUrl(url) } },
+        loadThumbnail = { fileUri ->
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    getApplication<Application>().contentResolver.loadThumbnail(
+                        fileUri.toUri(),
+                        Size(THUMBNAIL_SIZE_PX, THUMBNAIL_SIZE_PX),
+                        null,
+                    )
+                }.getOrNull()?.asImageBitmap()
+            }
+        },
     )
 
-    private fun DownloadRecord.toDownloadItem(
-        thumbnails: Map<String, ImageBitmap?>,
-    ): DownloadManagementScreenUiState.DownloadItem {
+    private fun DownloadRecord.toDownloadItem(): DownloadManagementScreenUiState.DownloadItem {
         val uiStatus = when (status) {
             DownloadRecordStatus.SUCCEEDED -> {
                 val uri = fileUri
                 if (uri != null) {
                     DownloadManagementScreenUiState.DownloadStatus.Completed(
                         fileUri = uri,
-                        thumbnail = thumbnails[uri],
-                        thumbnailLoading = uri !in thumbnails,
                     )
                 } else {
                     DownloadManagementScreenUiState.DownloadStatus.Failed(canResume = false)

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/downloads/DownloadManagementScreenViewModel.kt
@@ -117,6 +117,7 @@ internal class DownloadManagementScreenViewModel(
                     DownloadManagementScreenUiState.DownloadStatus.Completed(
                         fileUri = uri,
                         thumbnail = thumbnails[uri],
+                        thumbnailLoading = uri !in thumbnails,
                     )
                 } else {
                     DownloadManagementScreenUiState.DownloadStatus.Failed(canResume = false)

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -139,6 +140,7 @@ private fun DownloadItemRow(
     onOpenOriginPage: (url: String) -> Unit,
     loadThumbnail: suspend (fileUri: String) -> ImageBitmap?,
 ) {
+    val currentLoadThumbnail by rememberUpdatedState(loadThumbnail)
     val dateFormat = remember { SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault()) }
     var menuExpanded by remember { mutableStateOf(false) }
     Box {
@@ -175,7 +177,7 @@ private fun DownloadItemRow(
                 var thumbnail by remember(completedStatus.fileUri) { mutableStateOf<ImageBitmap?>(null) }
                 var loaded by remember(completedStatus.fileUri) { mutableStateOf(false) }
                 LaunchedEffect(completedStatus.fileUri) {
-                    thumbnail = loadThumbnail(completedStatus.fileUri)
+                    thumbnail = currentLoadThumbnail(completedStatus.fileUri)
                     loaded = true
                 }
                 if (thumbnail != null || !loaded) {

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser.ui.downloads
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -166,17 +167,25 @@ private fun DownloadItemRow(
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            val thumbnail = (item.status as? DownloadManagementScreenUiState.DownloadStatus.Completed)?.thumbnail
-            if (thumbnail != null) {
-                Image(
-                    bitmap = thumbnail,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
+            val completedStatus = item.status as? DownloadManagementScreenUiState.DownloadStatus.Completed
+            if (completedStatus != null && (completedStatus.thumbnail != null || completedStatus.thumbnailLoading)) {
+                Box(
                     modifier = Modifier
                         .padding(end = 12.dp)
                         .size(48.dp)
-                        .clip(RoundedCornerShape(8.dp)),
-                )
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (completedStatus.thumbnail != null) {
+                        Image(
+                            bitmap = completedStatus.thumbnail,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                }
             }
             Column(
                 modifier = Modifier.weight(1f),
@@ -442,6 +451,7 @@ private fun PreviewCompletedWithThumbnail() {
                 status = DownloadManagementScreenUiState.DownloadStatus.Completed(
                     fileUri = "content://media/external/downloads/1",
                     thumbnail = thumbnail,
+                    thumbnailLoading = false,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = "https://example.com/page",
@@ -466,6 +476,7 @@ private fun PreviewCompletedWithoutThumbnail() {
                 status = DownloadManagementScreenUiState.DownloadStatus.Completed(
                     fileUri = "content://media/external/downloads/2",
                     thumbnail = null,
+                    thumbnailLoading = false,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = null,
@@ -511,6 +522,7 @@ private fun PreviewLongFileName() {
                 status = DownloadManagementScreenUiState.DownloadStatus.Completed(
                     fileUri = "content://media/external/downloads/3",
                     thumbnail = null,
+                    thumbnailLoading = false,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = "https://example.com/page",

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -119,6 +120,7 @@ fun DownloadManagementScreen(
                         onOpenFile = { fileUri -> uiState.callbacks.onOpenFile(fileUri) },
                         onResume = { uiState.callbacks.onResume(item.id) },
                         onOpenOriginPage = { url -> uiState.callbacks.onOpenOriginPage(url) },
+                        loadThumbnail = uiState.callbacks.loadThumbnail,
                     )
                 }
             }
@@ -135,6 +137,7 @@ private fun DownloadItemRow(
     onOpenFile: (String) -> Unit,
     onResume: () -> Unit,
     onOpenOriginPage: (url: String) -> Unit,
+    loadThumbnail: suspend (fileUri: String) -> ImageBitmap?,
 ) {
     val dateFormat = remember { SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault()) }
     var menuExpanded by remember { mutableStateOf(false) }
@@ -168,22 +171,30 @@ private fun DownloadItemRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             val completedStatus = item.status as? DownloadManagementScreenUiState.DownloadStatus.Completed
-            if (completedStatus != null && (completedStatus.thumbnail != null || completedStatus.thumbnailLoading)) {
-                Box(
-                    modifier = Modifier
-                        .padding(end = 12.dp)
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    if (completedStatus.thumbnail != null) {
-                        Image(
-                            bitmap = completedStatus.thumbnail,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize(),
-                        )
+            if (completedStatus != null) {
+                var thumbnail by remember(completedStatus.fileUri) { mutableStateOf<ImageBitmap?>(null) }
+                var loaded by remember(completedStatus.fileUri) { mutableStateOf(false) }
+                LaunchedEffect(completedStatus.fileUri) {
+                    thumbnail = loadThumbnail(completedStatus.fileUri)
+                    loaded = true
+                }
+                if (thumbnail != null || !loaded) {
+                    Box(
+                        modifier = Modifier
+                            .padding(end = 12.dp)
+                            .size(48.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (thumbnail != null) {
+                            Image(
+                                bitmap = thumbnail!!,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                     }
                 }
             }
@@ -382,6 +393,7 @@ private fun PreviewInProgress() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { null },
         )
     }
 }
@@ -407,6 +419,7 @@ private fun PreviewPaused() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { null },
         )
     }
 }
@@ -428,6 +441,7 @@ private fun PreviewFailedCanResume() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { null },
         )
     }
 }
@@ -450,8 +464,6 @@ private fun PreviewCompletedWithThumbnail() {
                 fileName = "photo.png",
                 status = DownloadManagementScreenUiState.DownloadStatus.Completed(
                     fileUri = "content://media/external/downloads/1",
-                    thumbnail = thumbnail,
-                    thumbnailLoading = false,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = "https://example.com/page",
@@ -461,6 +473,7 @@ private fun PreviewCompletedWithThumbnail() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { thumbnail },
         )
     }
 }
@@ -475,8 +488,6 @@ private fun PreviewCompletedWithoutThumbnail() {
                 fileName = "example.zip",
                 status = DownloadManagementScreenUiState.DownloadStatus.Completed(
                     fileUri = "content://media/external/downloads/2",
-                    thumbnail = null,
-                    thumbnailLoading = false,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = null,
@@ -486,6 +497,7 @@ private fun PreviewCompletedWithoutThumbnail() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { null },
         )
     }
 }
@@ -507,6 +519,7 @@ private fun PreviewFailedCannotResume() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { null },
         )
     }
 }
@@ -521,8 +534,6 @@ private fun PreviewLongFileName() {
                 fileName = "very_long_file_name_that_should_wrap_to_two_lines_example_document.pdf",
                 status = DownloadManagementScreenUiState.DownloadStatus.Completed(
                     fileUri = "content://media/external/downloads/3",
-                    thumbnail = null,
-                    thumbnailLoading = false,
                 ),
                 enqueuedAt = 0L,
                 originPageUrl = "https://example.com/page",
@@ -532,6 +543,7 @@ private fun PreviewLongFileName() {
             onOpenFile = {},
             onResume = {},
             onOpenOriginPage = {},
+            loadThumbnail = { null },
         )
     }
 }

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -22,10 +22,12 @@ data class DownloadManagementScreenUiState(
         /**
          * ダウンロード完了。
          * [thumbnail] はサムネイルを生成できるファイル (画像・動画など) の場合のみ非 null。
+         * [thumbnailLoading] はサムネイル読み込み中の場合に true。
          */
         data class Completed(
             val fileUri: String,
             val thumbnail: ImageBitmap?,
+            val thumbnailLoading: Boolean,
         ) : DownloadStatus
 
         /**

--- a/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
+++ b/ui/downloads/src/main/kotlin/net/matsudamper/browser/ui/downloads/DownloadManagementScreenUiState.kt
@@ -21,13 +21,9 @@ data class DownloadManagementScreenUiState(
 
         /**
          * ダウンロード完了。
-         * [thumbnail] はサムネイルを生成できるファイル (画像・動画など) の場合のみ非 null。
-         * [thumbnailLoading] はサムネイル読み込み中の場合に true。
          */
         data class Completed(
             val fileUri: String,
-            val thumbnail: ImageBitmap?,
-            val thumbnailLoading: Boolean,
         ) : DownloadStatus
 
         /**
@@ -69,5 +65,7 @@ data class DownloadManagementScreenUiState(
         val onResume: (UUID) -> Unit,
         /** ダウンロード開始時のページを新しいタブで開く */
         val onOpenOriginPage: (url: String) -> Unit,
+        /** ファイル URI からサムネイルを読み込む。サムネイル非対応の場合は null を返す */
+        val loadThumbnail: suspend (fileUri: String) -> ImageBitmap?,
     )
 }


### PR DESCRIPTION
## 概要
ダウンロード完了ファイルのサムネイル読み込みロジックをViewModel側からCompose側に移行しました。これにより、サムネイル読み込みがUI層の責務となり、アーキテクチャの関心の分離が改善されます。

## 主な変更

- **ViewModel側の変更**
  - `thumbnailFlow` と `requestedThumbnailUris` の状態管理を削除
  - `requestThumbnail()` メソッドを削除
  - `combine()` を使用した複合フロー監視を廃止し、`downloadRepository.observeDownloads()` の単純な監視に変更
  - `Callbacks` に `loadThumbnail: suspend (fileUri: String) -> ImageBitmap?` を追加
  - `DownloadRecord.toDownloadItem()` からサムネイル引数を削除

- **UI層の変更**
  - `DownloadItemRow()` で `LaunchedEffect` を使用してサムネイル読み込みを実装
  - 読み込み中の状態を `Box` で表現し、`MaterialTheme.colorScheme.surfaceVariant` の背景を表示
  - `DownloadManagementScreenUiState.DownloadStatus.Completed` から `thumbnail` フィールドを削除
  - 全ての `@Preview` 関数を `loadThumbnail` パラメータに対応

- **UiState定義の変更**
  - `Completed` データクラスから `thumbnail: ImageBitmap?` フィールドを削除
  - `Callbacks` にサムネイル読み込み関数を追加

## 実装の詳細

サムネイル読み込みは以下のフローで動作します：
1. Compose の `LaunchedEffect` が `fileUri` の変更を検知
2. `loadThumbnail()` コールバック経由でViewModel側の読み込み処理を呼び出し
3. 読み込み結果をローカル状態で管理し、UI に反映

この変更により、ViewModel はダウンロード状態の管理に専念し、UI の描画ロジックはCompose側で完結するようになります。

https://claude.ai/code/session_012s34s5JiEZQhNPgyGCkxQf