### PR TITLE
Snackbar のパディングを調整

### DIFF
--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
@@ -300,7 +300,10 @@ private fun TabsScreenLoadedContent(
             .fillMaxSize(),
         contentWindowInsets = WindowInsets.safeDrawing,
         snackbarHost = {
-            SnackbarHost(snackbarHostState) { snackbarData ->
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            ) { snackbarData ->
                 // スワイプで Snackbar を dismiss できるようにする
                 key(snackbarData) {
                     val dismissState = rememberSwipeToDismissBoxState(

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
@@ -682,10 +682,10 @@ private fun PreviewSingleGroup() {
     )
 }
 
-/** Snackbar が表示されている状態（pendingClosedTab が non-null）の Preview */
+/** Snackbar が表示されている状態の Preview */
 @Composable
 @Preview
-private fun PreviewWithPendingClosedTab() {
+private fun PreviewWithSnackbar() {
     val groups = remember {
         listOf(
             TabGroupData(TabGroupId("g1"), "デフォルト"),
@@ -703,36 +703,48 @@ private fun PreviewWithPendingClosedTab() {
             ),
         )
     }
-    TabsScreen(
-        uiState = TabsScreenUiState(
-            callbacks = object : TabsScreenUiState.Callbacks {
-                override fun onCloseTab(tabId: String) {}
-                override fun onUndoCloseTab() {}
-                override fun onConfirmCloseTab() {}
-                override fun onReorderTabs(groupIndex: Int, fromLocalIndex: Int, toLocalIndex: Int) {}
-                override fun onReorderGroups(fromIndex: Int, toIndex: Int) {}
-                override fun onGroupSelected(index: Int) {}
-                override fun onGroupPageChanged(page: Int) {}
-                override fun onAddGroup() {}
-                override fun onMoveTabToGroup(tabId: String, targetGroupIndex: Int) {}
-                override fun onRenameGroup(groupIndex: Int, newName: String) {}
-                override fun onDeleteGroup(groupIndex: Int) {}
-                override fun onToggleDefaultGroup(groupIndex: Int) {}
+    Box {
+        TabsScreenLoadedContent(
+            groupedTabs = groupedTabs,
+            groups = groups,
+            activeGroupIndex = 0,
+            selectedTabId = "1",
+            snackbarHostState = remember { SnackbarHostState() },
+            onSelectTab = {},
+            onCloseTab = {},
+            onOpenNewTab = {},
+            onReorderTabs = { _, _, _ -> },
+            onReorderGroups = { _, _ -> },
+            onGroupSelected = {},
+            onGroupPageChanged = {},
+            onAddGroup = {},
+            onMoveTabToGroup = { _, _ -> },
+            onRenameGroup = { _, _ -> },
+            onDeleteGroup = {},
+            onToggleDefaultGroup = {},
+        )
+        Snackbar(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            action = {
+                TextButton(
+                    onClick = {},
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = SnackbarDefaults.actionContentColor,
+                    ),
+                ) {
+                    Text("戻す")
+                }
             },
-            loadingState = TabsScreenUiState.LoadingState.Loaded(
-                groupedTabs = groupedTabs,
-                groups = groups,
-                activeGroupIndex = 0,
-                selectedTabId = "1",
-            ),
-            pendingClosedTab = TabsScreenUiState.PendingClosedTab(
-                tabId = "2",
-                title = "Google",
-            ),
-        ),
-        onSelectTab = {},
-        onOpenNewTab = {},
-    )
+        ) {
+            Text(
+                text = "Google",
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
 }
 
 sealed interface TabsScreenTestTags {


### PR DESCRIPTION
## 概要
TabsScreen の Snackbar ホストにパディングを追加し、画面端からの余白を確保しました。

## 変更内容
- `SnackbarHost` の呼び出しを名前付き引数形式に変更
- `modifier` パラメータを追加し、水平方向 16.dp、垂直方向 8.dp のパディングを設定
  - これにより Snackbar が画面端に密着するのを防ぎ、より良い UI/UX を実現

## 実装詳細
- 既存の `snackbarHostState` パラメータを `hostState` として明示的に指定
- Material Design のガイドラインに沿った適切な余白を確保

https://claude.ai/code/session_01CWwpQ1SvodKgEpJGvhEGH1