### PR TITLE
BrowserToolBarGestureState のコールバック更新を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserToolBar.kt
@@ -124,11 +124,17 @@ internal fun BrowserToolBar(
             .testTag(BrowserToolbarTestTags.Toolbar.testTag),
         isFocused = isFocused,
         gestureState = if (showTabActions) {
-            BrowserToolBarGestureState(
-                onHorizontalDrag = onHorizontalDrag,
-                onHorizontalDragEnd = onHorizontalDragEnd,
-                onOpenTabs = onOpenTabs
-            )
+            remember {
+                BrowserToolBarGestureState(
+                    onHorizontalDrag = onHorizontalDrag,
+                    onHorizontalDragEnd = onHorizontalDragEnd,
+                    onOpenTabs = onOpenTabs,
+                )
+            }.apply {
+                this.onHorizontalDrag = onHorizontalDrag
+                this.onHorizontalDragEnd = onHorizontalDragEnd
+                this.onOpenTabs = onOpenTabs
+            }
         } else {
             null
         },
@@ -193,6 +199,11 @@ internal class BrowserToolBarGestureState(
     onHorizontalDragEnd: () -> Unit,
     onOpenTabs: () -> Unit,
 ) {
+    // pointerInput コルーチンはキーが変わらない限り再起動されないため、
+    // コンストラクタでキャプチャした値ではなく var プロパティ経由で最新のコールバックを参照する。
+    var onHorizontalDrag = onHorizontalDrag
+    var onHorizontalDragEnd = onHorizontalDragEnd
+    var onOpenTabs = onOpenTabs
     var isFocused by mutableStateOf(false)
 
     val modifier = Modifier
@@ -202,10 +213,10 @@ internal class BrowserToolBarGestureState(
             if (isFocused) return@pointerInput
             detectHorizontalDragGestures(
                 onHorizontalDrag = { _, dragAmount ->
-                    onHorizontalDrag(dragAmount)
+                    this@BrowserToolBarGestureState.onHorizontalDrag(dragAmount)
                 },
-                onDragEnd = { onHorizontalDragEnd() },
-                onDragCancel = { onHorizontalDragEnd() },
+                onDragEnd = { this@BrowserToolBarGestureState.onHorizontalDragEnd() },
+                onDragCancel = { this@BrowserToolBarGestureState.onHorizontalDragEnd() },
             )
         }
         .pointerInput(isFocused) {
@@ -214,7 +225,7 @@ internal class BrowserToolBarGestureState(
             detectDownSwipe(
                 density = this,
                 onDownSwipe = {
-                    onOpenTabs()
+                    this@BrowserToolBarGestureState.onOpenTabs()
                 }
             )
         }

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
@@ -714,6 +714,7 @@ private fun PreviewWithSnackbar() {
             groups = groups,
             activeGroupIndex = 0,
             selectedTabId = "1",
+            groupHasPlayingTab = emptyList(),
             snackbarHostState = remember { SnackbarHostState() },
             onSelectTab = {},
             onCloseTab = {},


### PR DESCRIPTION
## 概要

`BrowserToolBarGestureState` のジェスチャーコールバックが最新の値を参照するように修正しました。`pointerInput` コルーチンはキーが変わらない限り再起動されないため、コンストラクタでキャプチャした値ではなく var プロパティ経由で常に最新のコールバックを参照する必要があります。

## 主な変更

- `BrowserToolBarGestureState` に `onHorizontalDrag`、`onHorizontalDragEnd`、`onOpenTabs` を var プロパティとして追加
- `BrowserToolBar` で `gestureState` を `remember` でメモ化し、`.apply` ブロックで毎回プロパティを更新
- `pointerInput` ブロック内のコールバック呼び出しを明示的に `this@BrowserToolBarGestureState` 経由に変更し、常に最新のプロパティ値を参照するように修正

## 実装の詳細

`pointerInput` は key が変わらない限り再起動されないため、コンストラクタでキャプチャした値を使用すると古いコールバックが呼ばれ続けます。この修正により、親コンポーネントからコールバックが更新されるたびに、ジェスチャーハンドラーが最新のコールバックを参照するようになります。

https://claude.ai/code/session_01Pg8xbx42RntqjJ7VRoAVX8