### PR TITLE
Gradle Toolchain Resolver プラグインを常に有効化

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,9 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    if (System.getenv("CLAUDE_CODE_REMOTE") != "true") {
-        id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-    }
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## 概要
`CLAUDE_CODE_REMOTE` 環境変数による条件付きプラグイン読み込みを削除し、Gradle Toolchain Resolver プラグインを常に有効化するよう変更しました。

## 変更内容
- `settings.gradle.kts` の `org.gradle.toolchains.foojay-resolver-convention` プラグイン読み込みから環境変数チェック条件を削除
- プラグインが常に有効になるため、Java ツールチェーンの自動解決が全ての環境で機能するようになります

## 実装詳細
- 環境変数 `CLAUDE_CODE_REMOTE` の値に関わらず、Foojay Resolver Convention プラグイン（v1.0.0）が常に読み込まれます
- これにより、ローカル開発環境とリモート環境での Gradle ビルド動作が統一されます

https://claude.ai/code/session_01EeAoJK53wZL6fD69xjfv6U