### PR TITLE
Mozilla 系依存の Renovate 自動マージを有効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,9 @@
   ],
   "packageRules": [
     {
-      "matchPackagePrefixes": [
-        "org.mozilla.components",
-        "org.mozilla.geckoview"
+      "matchPackageNames": [
+        "org.mozilla.components:**",
+        "org.mozilla.geckoview:**"
       ],
       "automerge": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": [
+        "org.mozilla.components",
+        "org.mozilla.geckoview"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- `org.mozilla.components` と `org.mozilla.geckoview` の依存更新を Renovate で自動マージするよう設定
- CI（required status checks）が通った後に自動マージされる
- 非推奨の `matchPackagePrefixes` ではなく `matchPackageNames` にワイルドカードを使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9AJafeEd5kDDYTvjaFvMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9AJafeEd5kDDYTvjaFvMw)_