### PR TITLE
新しいタブを選択中のタブの直後に挿入するよう変更

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -629,7 +629,10 @@ private fun BrowserAppContent(
                                     if (currentGroupId != null) {
                                         tabGroupRepository.assignTabToGroup(tabId, currentGroupId)
                                     }
-                                    val newTab = viewModel.createTabWithHomepage(tabId = tabId)
+                                    val newTab = viewModel.createTabWithHomepage(
+                                        tabId = tabId,
+                                        insertAfterSelectedTab = false,
+                                    )
                                     selectTab(newTab.tabId, null)
                                 }
                             },

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserViewModel.kt
@@ -205,10 +205,12 @@ internal class BrowserViewModel(
 
     suspend fun createTabWithHomepage(
         tabId: String,
+        insertAfterSelectedTab: Boolean = true,
     ): BrowserTab {
         return browserTabController.createAndAppendTab(
             tabId = tabId,
             initialUrl = currentHomepageUrl(),
+            insertAfterSelectedTab = insertAfterSelectedTab,
         )
     }
 

--- a/browser-core/src/main/kotlin/net/matsudamper/browser/core/TabInsertionPolicy.kt
+++ b/browser-core/src/main/kotlin/net/matsudamper/browser/core/TabInsertionPolicy.kt
@@ -4,11 +4,22 @@ object TabInsertionPolicy {
     /**
      * 新しいタブを挿入するインデックスを計算する。
      * openerTabId が指定されていてリストに存在する場合はその次のインデックス、
-     * そうでない場合は末尾のインデックスを返す。
+     * openerTabId がなく selectedTabId が存在する場合はその次のインデックス、
+     * いずれもない場合は末尾のインデックスを返す。
      */
-    fun resolveInsertionIndex(tabIds: List<String>, openerTabId: String?): Int {
-        if (openerTabId == null) return tabIds.size
-        val openerIndex = tabIds.indexOf(openerTabId)
-        return if (openerIndex < 0) tabIds.size else openerIndex + 1
+    fun resolveInsertionIndex(
+        tabIds: List<String>,
+        openerTabId: String?,
+        selectedTabId: String? = null,
+    ): Int {
+        if (openerTabId != null) {
+            val openerIndex = tabIds.indexOf(openerTabId)
+            if (openerIndex >= 0) return openerIndex + 1
+        }
+        if (selectedTabId != null) {
+            val selectedIndex = tabIds.indexOf(selectedTabId)
+            if (selectedIndex >= 0) return selectedIndex + 1
+        }
+        return tabIds.size
     }
 }

--- a/browser-core/src/test/kotlin/net/matsudamper/browser/core/TabInsertionPolicyTest.kt
+++ b/browser-core/src/test/kotlin/net/matsudamper/browser/core/TabInsertionPolicyTest.kt
@@ -63,4 +63,82 @@ class TabInsertionPolicyTest {
 
         assertEquals(0, result)
     }
+
+    @Test
+    fun selectedTabIdが指定されている場合はその次に挿入する() {
+        val tabIds = listOf("a", "b", "c")
+
+        val result = TabInsertionPolicy.resolveInsertionIndex(
+            tabIds,
+            openerTabId = null,
+            selectedTabId = "b",
+        )
+
+        assertEquals(2, result)
+    }
+
+    @Test
+    fun selectedTabIdが先頭タブの場合は2番目に挿入する() {
+        val tabIds = listOf("a", "b", "c")
+
+        val result = TabInsertionPolicy.resolveInsertionIndex(
+            tabIds,
+            openerTabId = null,
+            selectedTabId = "a",
+        )
+
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun selectedTabIdが末尾タブの場合は末尾に挿入する() {
+        val tabIds = listOf("a", "b", "c")
+
+        val result = TabInsertionPolicy.resolveInsertionIndex(
+            tabIds,
+            openerTabId = null,
+            selectedTabId = "c",
+        )
+
+        assertEquals(3, result)
+    }
+
+    @Test
+    fun selectedTabIdがリストに存在しない場合は末尾に追加する() {
+        val tabIds = listOf("a", "b", "c")
+
+        val result = TabInsertionPolicy.resolveInsertionIndex(
+            tabIds,
+            openerTabId = null,
+            selectedTabId = "x",
+        )
+
+        assertEquals(3, result)
+    }
+
+    @Test
+    fun openerTabIdとselectedTabIdの両方が指定されている場合はopenerTabIdが優先される() {
+        val tabIds = listOf("a", "b", "c")
+
+        val result = TabInsertionPolicy.resolveInsertionIndex(
+            tabIds,
+            openerTabId = "a",
+            selectedTabId = "c",
+        )
+
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun openerTabIdが存在しない場合はselectedTabIdにフォールバックする() {
+        val tabIds = listOf("a", "b", "c")
+
+        val result = TabInsertionPolicy.resolveInsertionIndex(
+            tabIds,
+            openerTabId = "x",
+            selectedTabId = "b",
+        )
+
+        assertEquals(2, result)
+    }
 }

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
@@ -201,7 +201,11 @@ class BrowserTabController(
         }
         return withContext(Dispatchers.Main) {
             val normalizedInitialUrl = initialUrl.ifBlank { "about:blank" }
-            val insertIndex = tabs.size
+            val insertIndex = TabInsertionPolicy.resolveInsertionIndex(
+                tabIds = tabs.map { it.tabId },
+                openerTabId = openerTabId,
+                selectedTabId = selectedTabId,
+            )
             val tab = createRegisteredTab(
                 tabId = tabId,
                 session = GeckoSession(),

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTabController.kt
@@ -195,6 +195,7 @@ class BrowserTabController(
         restoredThemeColor: Int? = null,
         openerTabId: String? = null,
         initialReferrerUrl: String? = null,
+        insertAfterSelectedTab: Boolean = true,
     ): BrowserTab {
         if (!isSinglePage && restoreState != RestoreState.COMPLETED) {
             Log.w(TAG, "タブ復元完了前に createAndAppendTab が呼ばれました (状態: $restoreState)")
@@ -204,7 +205,7 @@ class BrowserTabController(
             val insertIndex = TabInsertionPolicy.resolveInsertionIndex(
                 tabIds = tabs.map { it.tabId },
                 openerTabId = openerTabId,
-                selectedTabId = selectedTabId,
+                selectedTabId = if (insertAfterSelectedTab) selectedTabId else null,
             )
             val tab = createRegisteredTab(
                 tabId = tabId,


### PR DESCRIPTION
## 概要
新しいタブを開いたとき、タブグループの末尾ではなく選択中のタブの直後に挿入されるよう変更。

## 変更内容

### TabInsertionPolicy.kt
- `resolveInsertionIndex()` に `selectedTabId` パラメータを追加（デフォルト値: null）
- 優先度ベースの挿入位置決定ロジック：
  1. `openerTabId` が指定されていてリストに存在する場合 → その次のインデックス
  2. `selectedTabId` が存在する場合 → その次のインデックス
  3. いずれも存在しない場合 → 末尾

### BrowserTabController.kt
- `createAndAppendTab()` で `TabInsertionPolicy.resolveInsertionIndex()` を使用し、`selectedTabId` を渡すよう変更
- `insertAfterSelectedTab` パラメータを追加。タブ一覧画面からの呼び出しでは `false` を渡し、グループ内の正しい位置（末尾）に追加されるようにした

### BrowserViewModel.kt / BrowserApp.kt
- `createTabWithHomepage()` に `insertAfterSelectedTab` パラメータを追加
- タブ一覧画面からの新規タブ追加時に `insertAfterSelectedTab = false` を指定

### TabInsertionPolicyTest.kt
- 6つの新しいテストケースを追加：
  - `selectedTabId` の基本動作（中間・先頭・末尾）
  - `selectedTabId` がリストに存在しない場合のフォールバック
  - `openerTabId` と `selectedTabId` の両方指定時の優先度
  - `openerTabId` が存在しない場合の `selectedTabId` へのフォールバック

https://claude.ai/code/session_01CUgziUdgXDx2JEfTAUphJC