### PR TITLE
外部タブの挿入位置をグループ末尾に修正

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/ExternalTabInsertionPositionTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/ExternalTabInsertionPositionTest.kt
@@ -1,0 +1,119 @@
+package net.matsudamper.browser
+
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import net.matsudamper.browser.ui.tabs.TabsScreenTestTags
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * 外部から開いたタブがデフォルトグループの末尾に追加されることを検証する。
+ * 選択中のタブが末尾でない場合に、選択タブの直後ではなくグループ末尾に配置されること。
+ */
+@RunWith(AndroidJUnit4::class)
+class ExternalTabInsertionPositionTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun externalTabShouldBeAppendedAtEndOfDefaultGroup() {
+        // ブラウザ画面が表示されるまで待つ（初期タブ A がインデックス 0）
+        waitForBrowserScreen()
+
+        // タブ一覧画面を開く
+        openTabsScreen()
+
+        // 新しいタブを追加する（タブ B がインデックス 1 に追加され、選択される）
+        composeRule.waitUntil(timeoutMillis = 10.seconds.inWholeMilliseconds) {
+            composeRule.onNode(hasTestTag(TabsScreenTestTags.AddTabButton.testTag))
+                .isDisplayed()
+        }
+        composeRule.onNode(hasTestTag(TabsScreenTestTags.AddTabButton.testTag)).performClick()
+        composeRule.waitForIdle()
+
+        // ブラウザ画面が表示されるまで待つ
+        waitForBrowserScreen()
+
+        // タブ一覧画面を開く
+        openTabsScreen()
+
+        // タブ A（インデックス 0）をタップして選択する
+        composeRule.waitUntil(timeoutMillis = 10.seconds.inWholeMilliseconds) {
+            composeRule.onNode(hasTestTag(TabsScreenTestTags.TabItem(0).testTag))
+                .isDisplayed()
+        }
+        composeRule.onNode(hasTestTag(TabsScreenTestTags.TabItem(0).testTag)).performClick()
+        composeRule.waitForIdle()
+
+        // ブラウザ画面が表示されるまで待つ
+        waitForBrowserScreen()
+
+        // 外部からリンクを開く
+        composeRule.openUrlViaViewIntent("https://www.example.com".toUri().toString())
+
+        // ページが開かれていることを確認する
+        composeRule.waitForUrlBarContains("www.example.com", timeoutMillis = 30_000)
+
+        // タブ一覧画面を開く
+        openTabsScreen()
+
+        // 外部タブがインデックス 2（末尾）に存在することを確認する
+        // インデックス 1（タブ A の直後）ではなくインデックス 2 にあることが修正のポイント
+        composeRule.waitUntil(timeoutMillis = 10.seconds.inWholeMilliseconds) {
+            composeRule.onNode(hasTestTag(TabsScreenTestTags.TabItem(2).testTag))
+                .isDisplayed()
+        }
+
+        // インデックス 2 のタブが選択状態（外部タブ）であることを確認する
+        // 外部タブは開いた直後に選択されるため、選択状態で末尾にあることが期待値
+        composeRule.onNode(hasTestTag(TabsScreenTestTags.TabItem(2).testTag)).performClick()
+        composeRule.waitForIdle()
+        waitForBrowserScreen()
+        composeRule.waitForUrlBarContains("www.example.com", timeoutMillis = 10_000)
+    }
+
+    private fun waitForBrowserScreen() {
+        composeRule.waitUntil(timeoutMillis = 60_000) {
+            composeRule.onAllNodes(hasTestTag(BrowserToolbarTestTags.Toolbar.testTag))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun openTabsScreen() {
+        val node = composeRule.onNode(
+            hasTestTag(BrowserToolbarTestTags.OpenTabsButton.testTag)
+                .and(hasParent(hasTestTag(BrowserToolbarTestTags.Toolbar.testTag)))
+        )
+        repeat(12) {
+            val opened = runCatching {
+                composeRule.waitForTabsScreenLoaded(timeoutMillis = 2_000)
+                true
+            }.getOrDefault(false)
+            if (opened) return
+
+            val visible = runCatching {
+                composeRule.waitUntil(timeoutMillis = 5_000) {
+                    node.isDisplayed()
+                }
+                true
+            }.getOrDefault(false)
+            if (!visible) return@repeat
+
+            node.performClick()
+            composeRule.waitForIdle()
+            val openedAfterTap = runCatching {
+                composeRule.waitForTabsScreenLoaded(timeoutMillis = 5_000)
+                true
+            }.getOrDefault(false)
+            if (openedAfterTap) return
+        }
+        composeRule.waitForTabsScreenLoaded()
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -215,6 +215,7 @@ private fun BrowserAppContent(
                 tabId = tabId,
                 initialUrl = request.url,
                 restoredSessionState = request.sessionState,
+                insertAfterSelectedTab = false,
             )
             // selectTab より前に呼ぶことで、外部タブ開封前の selectedTabId を記録できる
             viewModel.registerExternalTab(newTab.tabId)

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/GroupTabGrid.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -36,6 +36,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
@@ -180,10 +181,10 @@ internal fun GroupTabGrid(
             verticalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
             horizontalArrangement = Arrangement.spacedBy(TabsLayoutDefaults.gridSpacing),
         ) {
-            items(
+            itemsIndexed(
                 items = tabs,
-                key = { tab -> tab.id },
-            ) { tab ->
+                key = { _, tab -> tab.id },
+            ) { index, tab ->
                 val selected = tab.id == selectedTabId
                 // ドラッグ中のアイテムはグリッド上で非表示（透明）にする
                 val isDraggingThis = dragDropState.draggedItemKey == tab.id
@@ -199,6 +200,7 @@ internal fun GroupTabGrid(
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(TabsLayoutDefaults.cardAspectRatio)
+                        .testTag(TabsScreenTestTags.TabItem(index).testTag)
                         .animateItem()
                         .then(if (isDraggingThis) Modifier.alpha(0f) else Modifier),
                 )

--- a/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
+++ b/ui/tabs/src/main/kotlin/net/matsudamper/browser/ui/tabs/TabsScreen.kt
@@ -777,4 +777,8 @@ sealed interface TabsScreenTestTags {
     class DefaultGroupSwitch(index: Int) : TabsScreenTestTags {
         override val id: String = "default_group_switch_$index"
     }
+
+    class TabItem(index: Int) : TabsScreenTestTags {
+        override val id: String = "tab_item_$index"
+    }
 }


### PR DESCRIPTION
## 概要
外部から開かれたタブがデフォルトグループの末尾に追加されるよう修正しました。従来は選択中のタブの直後に挿入されていましたが、この変更により常にグループの末尾に配置されるようになります。

## 主な変更

- **BrowserApp.kt**: 外部タブ開封時に `insertAfterSelectedTab = false` を指定し、グループ末尾への挿入を強制
- **GroupTabGrid.kt**: `items()` から `itemsIndexed()` に変更し、タブのインデックスを取得可能に。テストタグの付与に対応
- **TabsScreen.kt**: テスト用の `TabItem(index)` テストタグを追加
- **ExternalTabInsertionPositionTest.kt**: 新規追加。外部タブが正しくグループ末尾に配置されることを検証するインストルメンテーションテスト

## 実装の詳細

外部タブ開封時に `insertAfterSelectedTab = false` パラメータを渡すことで、選択中のタブ位置に関わらず常にグループの末尾にタブが追加されます。テストでは、選択中のタブが末尾でない状態で外部リンクを開き、新しいタブが末尾（インデックス2）に配置されることを確認しています。

https://claude.ai/code/session_01NrPeNVrXysg9tg8QWthhcC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added UI test verifying external tabs append to the end of the default tab group

* **Bug Fixes**
  * Fixed external tab insertion position to append at the end of the tab group rather than after the currently selected tab

<!-- end of auto-generated comment: release notes by coderabbit.ai -->