### PR TITLE
カスタムタブ・WebAppのリンク長押しダイアログに「新しいタブで開く」を追加

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -215,6 +215,7 @@ private fun BrowserAppContent(
                 tabId = tabId,
                 initialUrl = request.url,
                 restoredSessionState = request.sessionState,
+                initialReferrerUrl = request.referrerUrl,
                 insertAfterSelectedTab = false,
             )
             // selectTab より前に呼ぶことで、外部タブ開封前の selectedTabId を記録できる

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -61,12 +61,14 @@ internal fun BrowserTabDialogLayer(
     dialogState: PromptDialogState,
     enableTabUi: Boolean,
     onOpenNewTabRequest: (url: String, referrerUrl: String?) -> Unit,
+    customTabMode: Boolean = false,
     onOpenFile: ((String) -> Unit)? = null,
 ) {
     state.contextMenuState?.let { menu ->
         ContextMenuDialog(
             menu = menu,
             enableTabUi = enableTabUi,
+            customTabMode = customTabMode,
             // ホットリンク保護のあるサーバーで 403 にならないよう、元ページを referrer に付ける
             onOpenNewTab = { url ->
                 onOpenNewTabRequest(url, state.currentPageUrl)
@@ -393,6 +395,7 @@ internal fun BrowserTabDialogLayer(
 private fun ContextMenuDialog(
     menu: BrowserTabScreenState.ContextMenuState,
     enableTabUi: Boolean,
+    customTabMode: Boolean,
     onOpenNewTab: (String) -> Unit,
     onOpenUrl: (String) -> Unit,
     onCopyLink: (String) -> Unit,
@@ -428,7 +431,7 @@ private fun ContextMenuDialog(
                     is BrowserTabScreenState.ContextMenuState.Link -> {
                         LinkActionButtons(
                             url = menu.url,
-                            enableTabUi = enableTabUi,
+                            showOpenInNewTab = enableTabUi || customTabMode,
                             onOpenNewTab = onOpenNewTab,
                             onOpenUrl = onOpenUrl,
                             onCopyLink = onCopyLink,
@@ -446,7 +449,7 @@ private fun ContextMenuDialog(
                     is BrowserTabScreenState.ContextMenuState.LinkWithImage -> {
                         LinkActionButtons(
                             url = menu.url,
-                            enableTabUi = enableTabUi,
+                            showOpenInNewTab = enableTabUi || customTabMode,
                             onOpenNewTab = onOpenNewTab,
                             onOpenUrl = onOpenUrl,
                             onCopyLink = onCopyLink,
@@ -521,13 +524,13 @@ private fun ImageActionButtons(
 @Composable
 private fun LinkActionButtons(
     url: String,
-    enableTabUi: Boolean,
+    showOpenInNewTab: Boolean,
     onOpenNewTab: (String) -> Unit,
     onOpenUrl: (String) -> Unit,
     onCopyLink: (String) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        if (enableTabUi) {
+        if (showOpenInNewTab) {
             TextButton(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = { onOpenNewTab(url) },
@@ -1016,6 +1019,7 @@ private fun PreviewContextMenuDialog() {
                 imageSrcUrl = "https://example.com/image.png",
             ),
             enableTabUi = true,
+            customTabMode = false,
             onOpenNewTab = {},
             onOpenUrl = {},
             onCopyLink = {},

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -431,7 +431,8 @@ private fun ContextMenuDialog(
                     is BrowserTabScreenState.ContextMenuState.Link -> {
                         LinkActionButtons(
                             url = menu.url,
-                            showOpenInNewTab = enableTabUi || customTabMode,
+                            enableTabUi = enableTabUi,
+                            customTabMode = customTabMode,
                             onOpenNewTab = onOpenNewTab,
                             onOpenUrl = onOpenUrl,
                             onCopyLink = onCopyLink,
@@ -449,7 +450,8 @@ private fun ContextMenuDialog(
                     is BrowserTabScreenState.ContextMenuState.LinkWithImage -> {
                         LinkActionButtons(
                             url = menu.url,
-                            showOpenInNewTab = enableTabUi || customTabMode,
+                            enableTabUi = enableTabUi,
+                            customTabMode = customTabMode,
                             onOpenNewTab = onOpenNewTab,
                             onOpenUrl = onOpenUrl,
                             onCopyLink = onCopyLink,
@@ -524,20 +526,22 @@ private fun ImageActionButtons(
 @Composable
 private fun LinkActionButtons(
     url: String,
-    showOpenInNewTab: Boolean,
+    enableTabUi: Boolean,
+    customTabMode: Boolean,
     onOpenNewTab: (String) -> Unit,
     onOpenUrl: (String) -> Unit,
     onCopyLink: (String) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        if (showOpenInNewTab) {
+        if (enableTabUi || customTabMode) {
             TextButton(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = { onOpenNewTab(url) },
             ) {
                 Text(text = "新しいタブで開く")
             }
-        } else {
+        }
+        if (!enableTabUi) {
             TextButton(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = { onOpenUrl(url) },

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -114,6 +114,7 @@ class CustomTabActivity : ComponentActivity() {
                         mediaWebExtension = mediaWebExtensionInstance,
                         onClose = ::finish,
                         onOpenInBrowser = ::openInMainBrowser,
+                        onOpenNewTabInBrowser = ::openNewTabInMainBrowser,
                         onRequestDownloadNotificationPermission = { requestDownloadNotificationPermission() },
                     )
                 }
@@ -168,6 +169,15 @@ class CustomTabActivity : ComponentActivity() {
         }
     }
 
+    private fun openNewTabInMainBrowser(url: String) {
+        startActivity(
+            Intent(this, MainActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+                data = Uri.parse(url)
+            }
+        )
+    }
+
     private fun startMainBrowser(url: String, sessionState: String) {
         val targetUri = Uri.parse(url)
         startActivity(
@@ -204,6 +214,7 @@ private fun CustomTabScreen(
     mediaWebExtension: MediaWebExtension,
     onClose: () -> Unit,
     onOpenInBrowser: (url: String, tab: BrowserTab) -> Unit,
+    onOpenNewTabInBrowser: (url: String) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit,
 ) {
     val viewModel = viewModel(initializer = {
@@ -281,14 +292,8 @@ private fun CustomTabScreen(
         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
         onOpenNewSessionRequest = { null },
-        onOpenNewTabRequest = { uri, referrerUrl ->
-            if (referrerUrl != null) {
-                activeTab.session.load(
-                    GeckoSession.Loader().uri(uri).referrer(referrerUrl),
-                )
-            } else {
-                activeTab.session.loadUri(uri)
-            }
+        onOpenNewTabRequest = { uri, _ ->
+            onOpenNewTabInBrowser(uri)
         },
         onCloseTab = onClose,
         onHistoryRecord = uiState.callbacks::onHistoryRecord,

--- a/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/CustomTabActivity.kt
@@ -169,13 +169,18 @@ class CustomTabActivity : ComponentActivity() {
         }
     }
 
-    private fun openNewTabInMainBrowser(url: String) {
+    private fun openNewTabInMainBrowser(url: String, referrerUrl: String?) {
         startActivity(
             Intent(this, MainActivity::class.java).apply {
                 action = Intent.ACTION_VIEW
                 data = Uri.parse(url)
+                referrerUrl?.let { putExtra(EXTRA_NEW_TAB_REFERRER_URL, it) }
             }
         )
+    }
+
+    companion object {
+        internal const val EXTRA_NEW_TAB_REFERRER_URL = "extra_new_tab_referrer_url"
     }
 
     private fun startMainBrowser(url: String, sessionState: String) {
@@ -214,7 +219,7 @@ private fun CustomTabScreen(
     mediaWebExtension: MediaWebExtension,
     onClose: () -> Unit,
     onOpenInBrowser: (url: String, tab: BrowserTab) -> Unit,
-    onOpenNewTabInBrowser: (url: String) -> Unit,
+    onOpenNewTabInBrowser: (url: String, referrerUrl: String?) -> Unit,
     onRequestDownloadNotificationPermission: suspend () -> Unit,
 ) {
     val viewModel = viewModel(initializer = {
@@ -292,8 +297,8 @@ private fun CustomTabScreen(
         // onLoadRequest で TARGET_WINDOW_NEW を現在タブへ畳み込むため、
         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
         onOpenNewSessionRequest = { null },
-        onOpenNewTabRequest = { uri, _ ->
-            onOpenNewTabInBrowser(uri)
+        onOpenNewTabRequest = { uri, referrerUrl ->
+            onOpenNewTabInBrowser(uri, referrerUrl)
         },
         onCloseTab = onClose,
         onHistoryRecord = uiState.callbacks::onHistoryRecord,

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -923,7 +923,7 @@ internal fun GeckoBrowserTab(
             state = state,
             dialogState = dialogState,
             enableTabUi = enableTabUi,
-            customTabMode = customTabMode,
+            customTabMode = customTabMode || webAppMode,
             onOpenNewTabRequest = currentOnOpenNewTabRequest,
             onOpenFile = { fileUri ->
                 val uri = fileUri.toUri()

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -923,6 +923,7 @@ internal fun GeckoBrowserTab(
             state = state,
             dialogState = dialogState,
             enableTabUi = enableTabUi,
+            customTabMode = customTabMode,
             onOpenNewTabRequest = currentOnOpenNewTabRequest,
             onOpenFile = { fileUri ->
                 val uri = fileUri.toUri()

--- a/app/src/main/kotlin/net/matsudamper/browser/MainActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/MainActivity.kt
@@ -141,7 +141,11 @@ class MainActivity : ComponentActivity() {
             // 同じ URL であれば重複タブを作らないようスキップする。
             if (url != null && url != lastProcessedDeepLinkUrl) {
                 val result = createNewTabChannel.trySend(
-                    NewTabRequest(url = url, sessionState = consumeHandoffSessionState(intent)),
+                    NewTabRequest(
+                        url = url,
+                        sessionState = consumeHandoffSessionState(intent),
+                        referrerUrl = intent.getStringExtra(CustomTabActivity.EXTRA_NEW_TAB_REFERRER_URL),
+                    ),
                 )
                 if (result.isFailure) {
                     Log.e("MainActivity", "URL の送信に失敗: $url, reason=${result.exceptionOrNull()}")
@@ -203,7 +207,11 @@ class MainActivity : ComponentActivity() {
         val url = intent.dataString
         if (url != null) {
             val result = createNewTabChannel.trySend(
-                NewTabRequest(url = url, sessionState = consumeHandoffSessionState(intent)),
+                NewTabRequest(
+                    url = url,
+                    sessionState = consumeHandoffSessionState(intent),
+                    referrerUrl = intent.getStringExtra(CustomTabActivity.EXTRA_NEW_TAB_REFERRER_URL),
+                ),
             )
             if (result.isFailure) {
                 Log.e("MainActivity", "URL の送信に失敗: $url, reason=${result.exceptionOrNull()}")

--- a/app/src/main/kotlin/net/matsudamper/browser/NewTabRequest.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/NewTabRequest.kt
@@ -9,4 +9,5 @@ package net.matsudamper.browser
 internal data class NewTabRequest(
     val url: String,
     val sessionState: String? = null,
+    val referrerUrl: String? = null,
 )

--- a/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/WebAppActivity.kt
@@ -28,7 +28,7 @@ import net.matsudamper.browser.ui.common.BrowserTheme
 import net.matsudamper.browser.ui.browser.WebAppScreen
 import org.koin.android.ext.android.inject
 import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoSession
+
 import java.util.concurrent.CancellationException
 
 /**
@@ -135,13 +135,7 @@ class WebAppActivity : ComponentActivity() {
                         // ここへ到達することは想定しない。GeckoView 契約上 null を返して安全に拒否する。
                         onOpenNewSessionRequest = { null },
                         onOpenNewTabRequest = { uri, referrerUrl ->
-                            if (referrerUrl != null) {
-                                browserTab.session.load(
-                                    GeckoSession.Loader().uri(uri).referrer(referrerUrl),
-                                )
-                            } else {
-                                browserTab.session.loadUri(uri)
-                            }
+                            openNewTabInMainBrowser(uri, referrerUrl)
                         },
                         onHistoryRecord = webAppUiState.callbacks::onHistoryRecord,
                         onHistoryTitleUpdate = webAppUiState.callbacks::onHistoryTitleUpdate,
@@ -151,6 +145,16 @@ class WebAppActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    private fun openNewTabInMainBrowser(url: String, referrerUrl: String?) {
+        startActivity(
+            Intent(this, MainActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+                data = android.net.Uri.parse(url)
+                referrerUrl?.let { putExtra(CustomTabActivity.EXTRA_NEW_TAB_REFERRER_URL, it) }
+            }
+        )
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## 概要
カスタムタブ（app追加機能）およびWebApp（ホームに追加）モードでリンクを長押しした際のコンテキストメニューに「新しいタブで開く」ボタンを追加。既存の「開く」ボタンはそのまま維持する。

「新しいタブで開く」を押すと、メインブラウザのデフォルトグループ末尾に新しいタブとして開く。

## 主な変更

- **CustomTabActivity / WebAppActivity**: `openNewTabInMainBrowser()` メソッドを追加し、指定 URL をメインブラウザで新規タブとして開く処理を実装。referrerUrl も Intent extra 経由で引き回す
- **CustomTabScreen**: `onOpenNewTabInBrowser` コールバックを追加し、新規タブリクエストをメインブラウザに委譲するように変更
- **BrowserTabDialogLayer**: `customTabMode` パラメータを追加し、カスタムタブ/WebApp モード時にリンクコンテキストメニューで「開く」に加えて「新しいタブで開く」ボタンを表示
- **LinkActionButtons**: `enableTabUi` と `customTabMode` の2つのフラグで表示を制御
- **NewTabRequest / MainActivity / BrowserApp**: referrerUrl フィールドを追加し、Intent → NewTabRequest → createAndAppendTab まで引き回す

https://claude.ai/code/session_01TQwkFWb5YdtLkqQ9ptD23g