### PR TITLE
新しいタブを開く際に右スライドアニメーションを追加

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -251,6 +251,22 @@ private fun BrowserAppContent(
                 val target = targetState.entries.lastOrNull() ?: return@NavDisplay default
 
                 if (target.contentKey is AppDestination.Browser && initial.contentKey is AppDestination.Browser) {
+                    val targetBrowser = target.contentKey as AppDestination.Browser
+                    val initialBrowser = initial.contentKey as AppDestination.Browser
+                    // 新しいタブを開いた場合（beforeTab が設定されている）は右にスライド
+                    if (targetBrowser.beforeTab != null) {
+                        return@NavDisplay ContentTransform(
+                            targetContentEnter = slideIn { IntOffset(it.width, 0) },
+                            initialContentExit = slideOut { IntOffset(-it.width / 3, 0) },
+                        )
+                    }
+                    // 新しいタブから元のタブに戻る場合は左にスライド
+                    if (initialBrowser.beforeTab?.tabId == targetBrowser.tabId) {
+                        return@NavDisplay ContentTransform(
+                            targetContentEnter = slideIn { IntOffset(-it.width / 3, 0) },
+                            initialContentExit = slideOut { IntOffset(it.width, 0) },
+                        )
+                    }
                     return@NavDisplay ContentTransform(
                         initialContentExit = fadeOut(snap(100)),
                         targetContentEnter = fadeIn(snap(100)),
@@ -800,6 +816,17 @@ private fun <T : NavKey> AnimatedContentTransitionScope<Scene<T>>.popTransition(
             },
             targetContentEnter = EnterTransition.None,
         )
+    }
+
+    // 新しいタブから元のタブに戻る場合は左にスライド
+    if (initial.contentKey is AppDestination.Browser && target.contentKey is AppDestination.Browser) {
+        val initialBrowser = initial.contentKey as AppDestination.Browser
+        if (initialBrowser.beforeTab?.tabId == (target.contentKey as AppDestination.Browser).tabId) {
+            return ContentTransform(
+                targetContentEnter = slideIn { IntOffset(-it.width / 3, 0) },
+                initialContentExit = slideOut { IntOffset(it.width, 0) },
+            )
+        }
     }
 
     if (target.contentKey is AppDestination.Browser) {

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -252,8 +252,10 @@ private fun BrowserAppContent(
 
                 if (target.contentKey is AppDestination.Browser && initial.contentKey is AppDestination.Browser) {
                     val targetBrowser = target.contentKey as AppDestination.Browser
-                    // 新しいタブを開いた場合（beforeTab が設定されている）は右にスライド
-                    if (targetBrowser.beforeTab != null) {
+                    // 遷移元のタブから新しいタブを開いた場合のみ右にスライド。
+                    // beforeTab の存在だけで判定すると、連鎖的にタブを開いた後の
+                    // back() 時にも beforeTab が残っているためスライドが誤って再生される。
+                    if (targetBrowser.beforeTab == initial.contentKey) {
                         return@NavDisplay ContentTransform(
                             targetContentEnter = slideIn { IntOffset(it.width, 0) },
                             initialContentExit = slideOut { IntOffset(-it.width / 3, 0) },

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -252,7 +252,6 @@ private fun BrowserAppContent(
 
                 if (target.contentKey is AppDestination.Browser && initial.contentKey is AppDestination.Browser) {
                     val targetBrowser = target.contentKey as AppDestination.Browser
-                    val initialBrowser = initial.contentKey as AppDestination.Browser
                     // 新しいタブを開いた場合（beforeTab が設定されている）は右にスライド
                     if (targetBrowser.beforeTab != null) {
                         return@NavDisplay ContentTransform(
@@ -260,13 +259,8 @@ private fun BrowserAppContent(
                             initialContentExit = slideOut { IntOffset(-it.width / 3, 0) },
                         )
                     }
-                    // 新しいタブから元のタブに戻る場合は左にスライド
-                    if (initialBrowser.beforeTab?.tabId == targetBrowser.tabId) {
-                        return@NavDisplay ContentTransform(
-                            targetContentEnter = slideIn { IntOffset(-it.width / 3, 0) },
-                            initialContentExit = slideOut { IntOffset(it.width, 0) },
-                        )
-                    }
+                    // ジェスチャーでのタブ切替は BrowserScreen 側でアニメーションを処理するため、
+                    // NavDisplay 側では即座に切り替える
                     return@NavDisplay ContentTransform(
                         initialContentExit = fadeOut(snap(100)),
                         targetContentEnter = fadeIn(snap(100)),
@@ -816,17 +810,6 @@ private fun <T : NavKey> AnimatedContentTransitionScope<Scene<T>>.popTransition(
             },
             targetContentEnter = EnterTransition.None,
         )
-    }
-
-    // 新しいタブから元のタブに戻る場合は左にスライド
-    if (initial.contentKey is AppDestination.Browser && target.contentKey is AppDestination.Browser) {
-        val initialBrowser = initial.contentKey as AppDestination.Browser
-        if (initialBrowser.beforeTab?.tabId == (target.contentKey as AppDestination.Browser).tabId) {
-            return ContentTransform(
-                targetContentEnter = slideIn { IntOffset(-it.width / 3, 0) },
-                initialContentExit = slideOut { IntOffset(it.width, 0) },
-            )
-        }
     }
 
     if (target.contentKey is AppDestination.Browser) {


### PR DESCRIPTION
## 概要
新しいタブを開く際に、ジェスチャー移動と同様の右スライドアニメーションを追加しました。

## 変更内容

### BrowserAppContent の NavDisplay トランジション
- `AppDestination.Browser` 間の遷移時に、`beforeTab` フィールドを参照してアニメーション方向を判定
  - **新しいタブを開いた場合**（`targetBrowser.beforeTab != null`）：右からスライドイン、元のタブは左に 1/3 スライドアウト
  - **その他の遷移**（ジェスチャーでのタブ切替等）：従来通り即座に切り替え（BrowserScreen 側でアニメーションを処理するため）

## 実装の詳細
- `beforeTab` フィールドを活用して、新しいタブの開封を判定
- `slideIn`/`slideOut` で方向性のあるアニメーションを実現
- 元タブのスライドアウト距離を 1/3 に設定し、視覚的な奥行きを表現

https://claude.ai/code/session_01F5ig5hEjYQqKFGBoBZ9JzM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browser navigation animations when opening a new tab, with a smoother slide transition between screens.
* **Bug Fixes**
  * Kept the existing transition behavior unchanged for standard browser-to-browser navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->