### PR TITLE
住所フォーム自動入力機能を実装

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -19,9 +19,10 @@ import org.junit.runner.RunWith
 import org.mozilla.geckoview.ExperimentalGeckoViewApi
 import org.mozilla.geckoview.GeckoPreferenceController
 import org.mozilla.geckoview.GeckoResult
-import java.net.InetAddress
+import java.net.HttpURLConnection
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.URL
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeoutException
 
@@ -59,6 +60,10 @@ class AddressAutofillPromptTest {
         httpServer = server
         val pageUri = "http://127.0.0.1:${server.port}/$ADDRESS_FORM_FILE_NAME"
 
+        // サーバがテストプロセスから到達可能であることを先に確認する。
+        // ここで失敗する場合は Gecko 以前に環境の問題。
+        val selfCheck = selfCheckHttp(pageUri)
+
         applyTestPrefsAndAwaitAddressAutofillEnabled()
 
         composeRule.openUrlFromUrlBar(pageUri)
@@ -90,10 +95,45 @@ class AddressAutofillPromptTest {
                     "現在URL=${composeRule.currentPageUrlFromUi()}\n" +
                     "PageLoadError表示=$pageLoadErrorVisible 内容=${pageLoadErrorText()}\n" +
                     "サーバ受信リクエスト=${server.requests}\n" +
+                    "テストプロセスからの自己接続=$selfCheck\n" +
+                    "関連プレフ=${dumpNetworkPrefs()}\n" +
                     "--- logcat (formautofill関連) ---\n${collectFormAutofillLogcat()}",
                 e,
             )
         }
+    }
+
+    /**
+     * テストプロセス自身からサーバへ HTTP 接続できるか確認する。失敗時の診断用。
+     */
+    private fun selfCheckHttp(url: String): String {
+        return runCatching {
+            val connection = URL(url).openConnection() as HttpURLConnection
+            connection.connectTimeout = 5_000
+            connection.readTimeout = 5_000
+            val code = connection.responseCode
+            connection.disconnect()
+            "HTTP $code"
+        }.getOrElse { "失敗: $it" }
+    }
+
+    /**
+     * ネットワーク関連の Gecko プレフを収集する。失敗時の診断用。
+     */
+    @OptIn(ExperimentalGeckoViewApi::class)
+    private fun dumpNetworkPrefs(): String {
+        val prefs = awaitGeckoResult {
+            GeckoPreferenceController.getGeckoPrefs(
+                listOf(
+                    "dom.security.https_only_mode",
+                    "dom.security.https_first",
+                    "network.proxy.type",
+                    "network.lna.enabled",
+                    "network.lna.blocking",
+                ),
+            )
+        }
+        return prefs.orEmpty().joinToString(", ") { "${it.pref}=${it.value}" }
     }
 
     /**
@@ -336,7 +376,9 @@ class AddressAutofillPromptTest {
     private class LocalHttpServer(
         private val pages: Map<String, String>,
     ) : AutoCloseable {
-        private val serverSocket = ServerSocket(0, BACKLOG, InetAddress.getLoopbackAddress())
+        // 全インターフェースにバインドする (ループバック限定だと Gecko からの接続が
+        // 拒否される事象の切り分けのため)
+        private val serverSocket = ServerSocket(0, BACKLOG)
 
         val port: Int get() = serverSocket.localPort
 

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,6 +39,16 @@ import java.util.concurrent.TimeoutException
  */
 @RunWith(AndroidJUnit4::class)
 class AddressAutofillPromptTest {
+
+    /*
+     * 【現状 @Ignore の理由】
+     * GeckoView 152.0.20260621 同梱の Android 版 FormAutofillPrompter.promptToSaveAddress は
+     * NS_ERROR_NOT_IMPLEMENTED を throw する未実装スタブのため、住所フォームを送信しても
+     * PromptDelegate.onAddressSave は発火しない (クレジットカードの promptToSaveCreditCard は実装済み)。
+     * capture パイプライン (プリファレンス適用・フィールド検出・送信検出・_onAddressSubmit 到達) までは
+     * このテストの診断で動作を確認済み。mozilla-central の main には promptToSaveAddress の実装が
+     * 入っているため、GeckoView 更新後に @Ignore を外して有効化する。
+     */
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
 
@@ -50,6 +61,7 @@ class AddressAutofillPromptTest {
     }
 
     @Test
+    @Ignore("GeckoView 152 の FormAutofillPrompter.promptToSaveAddress が未実装 (NS_ERROR_NOT_IMPLEMENTED) のため保存プロンプトは発火しない。GeckoView 更新後に有効化する")
     fun submittingAddressFormShowsAddressSaveDialog() {
         val server = LocalHttpServer(
             pages = mapOf(

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -36,14 +36,48 @@ class AddressAutofillPromptTest {
         composeRule.waitForUrlBarContains(ADDRESS_FORM_FILE_NAME, timeoutMillis = 60_000)
 
         // ページは load 後にフォームへ値を投入して自動送信する。
+        // まずフォーム送信 (done.html への遷移) が行われたことを確認し、
+        // 送信自体の失敗と capture 未発火を切り分ける。
+        val submitted = runCatching {
+            composeRule.waitForUrlBarContains(ADDRESS_FORM_DONE_FILE_NAME, timeoutMillis = 30_000)
+        }.isSuccess
+
         // 送信を Gecko の formautofill が検出すると onAddressSave プロンプトが発火し、
         // AddressSaveDialog が表示されるはず。
-        composeRule.waitUntil(timeoutMillis = 90_000) {
-            composeRule
-                .onAllNodesWithTag(BrowserTabDialogLayerTestTags.AddressSaveDialog.testTag)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
+        try {
+            composeRule.waitUntil(timeoutMillis = 60_000) {
+                composeRule
+                    .onAllNodesWithTag(BrowserTabDialogLayerTestTags.AddressSaveDialog.testTag)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        } catch (e: androidx.compose.ui.test.ComposeTimeoutException) {
+            throw AssertionError(
+                "住所保存ダイアログが表示されない (フォーム送信=$submitted)\n" +
+                    "--- logcat (formautofill関連) ---\n${collectFormAutofillLogcat()}",
+                e,
+            )
         }
+    }
+
+    /**
+     * formautofill 関連の logcat を収集する。失敗時の診断用。
+     */
+    private fun collectFormAutofillLogcat(): String {
+        val output = runCatching {
+            val pfd = InstrumentationRegistry.getInstrumentation().uiAutomation
+                .executeShellCommand("logcat -d")
+            android.os.ParcelFileDescriptor.AutoCloseInputStream(pfd)
+                .bufferedReader()
+                .readLines()
+        }.getOrElse { return "logcat取得失敗: $it" }
+        return output
+            .filter { line ->
+                listOf("autofill", "GeckoConsole", "GeckoViewPrompt", "prompt")
+                    .any { line.contains(it, ignoreCase = true) }
+            }
+            .takeLast(LOGCAT_TAIL_LINES)
+            .joinToString("\n")
     }
 
     /**
@@ -58,6 +92,14 @@ class AddressAutofillPromptTest {
             GeckoPreferenceController.setGeckoPref(
                 "extensions.formautofill.skipProgrammaticCheckForTests",
                 true,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            )
+        }
+        // 失敗時の診断のため formautofill の Debug ログを logcat (GeckoConsole) に出す
+        awaitGeckoResult {
+            GeckoPreferenceController.setGeckoPref(
+                "extensions.formautofill.loglevel",
+                "Debug",
                 GeckoPreferenceController.PREF_BRANCH_USER,
             )
         }
@@ -185,5 +227,6 @@ class AddressAutofillPromptTest {
         private const val ADDRESS_FORM_FILE_NAME = "address-form.html"
         private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
         private const val PREF_TIMEOUT_MILLIS = 30_000L
+        private const val LOGCAT_TAIL_LINES = 120
     }
 }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -1,6 +1,8 @@
 package net.matsudamper.browser
 
+import android.os.ParcelFileDescriptor
 import androidx.annotation.OptIn
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -13,6 +15,7 @@ import org.mozilla.geckoview.ExperimentalGeckoViewApi
 import org.mozilla.geckoview.GeckoPreferenceController
 import org.mozilla.geckoview.GeckoResult
 import java.io.File
+import java.util.concurrent.TimeoutException
 
 /**
  * GeckoView の住所フォーム自動入力 (formautofill) が実際に動作することを確認するテスト。
@@ -51,7 +54,7 @@ class AddressAutofillPromptTest {
                     .fetchSemanticsNodes()
                     .isNotEmpty()
             }
-        } catch (e: androidx.compose.ui.test.ComposeTimeoutException) {
+        } catch (e: ComposeTimeoutException) {
             throw AssertionError(
                 "住所保存ダイアログが表示されない (フォーム送信=$submitted)\n" +
                     "--- logcat (formautofill関連) ---\n${collectFormAutofillLogcat()}",
@@ -67,7 +70,7 @@ class AddressAutofillPromptTest {
         val output = runCatching {
             val pfd = InstrumentationRegistry.getInstrumentation().uiAutomation
                 .executeShellCommand("logcat -d")
-            android.os.ParcelFileDescriptor.AutoCloseInputStream(pfd)
+            ParcelFileDescriptor.AutoCloseInputStream(pfd)
                 .bufferedReader()
                 .readLines()
         }.getOrElse { return "logcat取得失敗: $it" }
@@ -132,13 +135,18 @@ class AddressAutofillPromptTest {
      *
      * GeckoResult の生成 (内部の then/map 連鎖) は Handler を持つスレッドで行う必要があり、
      * poll はメインスレッドでは呼べないため、生成と待機でスレッドを分ける。
+     * poll のタイムアウトは呼び出し側のリトライと診断メッセージに委ねるため null を返す。
      */
     private fun <T> awaitGeckoResult(block: () -> GeckoResult<T>): T? {
         var geckoResult: GeckoResult<T>? = null
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             geckoResult = block()
         }
-        return requireNotNull(geckoResult).poll(PREF_TIMEOUT_MILLIS)
+        return try {
+            requireNotNull(geckoResult).poll(PREF_POLL_TIMEOUT_MILLIS)
+        } catch (@Suppress("SwallowedException") e: TimeoutException) {
+            null
+        }
     }
 
     /**
@@ -227,6 +235,7 @@ class AddressAutofillPromptTest {
         private const val ADDRESS_FORM_FILE_NAME = "address-form.html"
         private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
         private const val PREF_TIMEOUT_MILLIS = 30_000L
+        private const val PREF_POLL_TIMEOUT_MILLIS = 5_000L
         private const val LOGCAT_TAIL_LINES = 120
     }
 }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -190,27 +190,23 @@ class AddressAutofillPromptTest {
             "MediaBridge",
             "updateActiveElement",
             "Disregarding",
-            "GeckoConsole",
+            "ThemeColor",
             "getSavedFieldNames",
             "updateSavedFieldNames",
         )
         val includes = listOf(
+            " I Gecko ",
+            " E Gecko ",
+            " W Gecko ",
+            "GeckoConsole",
             "addr-test",
-            "submi",
-            "capture",
-            "doorhanger",
-            "prompt",
-            "duplicat",
-            "mergeable",
-            "record",
-            "address",
-            "onPageNavigation",
-            "navigation",
+            "GeckoView:Prompt",
         )
+        // logcat は入力完了後にクリアしているため、先頭側 (送信直後) に重要なログが集まる
         return output
             .filter { line -> excludes.none { line.contains(it) } }
             .filter { line -> includes.any { line.contains(it, ignoreCase = true) } }
-            .takeLast(LOGCAT_TAIL_LINES)
+            .take(LOGCAT_TAIL_LINES)
             .joinToString("\n")
     }
 

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -76,7 +76,7 @@ class AddressAutofillPromptTest {
         }.getOrElse { return "logcat取得失敗: $it" }
         return output
             .filter { line ->
-                listOf("autofill", "GeckoConsole", "GeckoViewPrompt", "prompt")
+                listOf("autofill", "GeckoConsole", "GeckoViewPrompt", "prompt", "addr-test")
                     .any { line.contains(it, ignoreCase = true) }
             }
             .takeLast(LOGCAT_TAIL_LINES)
@@ -103,6 +103,14 @@ class AddressAutofillPromptTest {
             GeckoPreferenceController.setGeckoPref(
                 "extensions.formautofill.loglevel",
                 "Debug",
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            )
+        }
+        // テストページの console.log を logcat に出してページ内 JS の進行を確認できるようにする
+        awaitGeckoResult {
+            GeckoPreferenceController.setGeckoPref(
+                "geckoview.console.enabled",
+                true,
                 GeckoPreferenceController.PREF_BRANCH_USER,
             )
         }
@@ -192,6 +200,12 @@ class AddressAutofillPromptTest {
                   <button id="submit-button" type="submit">Submit</button>
                 </form>
                 <script>
+                  function log(message) {
+                    console.log('addr-test: ' + message);
+                  }
+                  window.addEventListener('error', (e) => {
+                    log('js-error: ' + e.message);
+                  });
                   function setValue(id, value) {
                     const el = document.getElementById(id);
                     el.focus();
@@ -204,10 +218,13 @@ class AddressAutofillPromptTest {
                   // 同一タスク内で focus→入力→送信まで行うとリスナー登録前に送信されて
                   // capture が動かないため、検出起動・入力・送信を時間差で分ける。
                   window.addEventListener('load', () => {
+                    log('load');
                     setTimeout(() => {
+                      log('focus');
                       document.getElementById('given-name').focus();
                     }, 2000);
                     setTimeout(() => {
+                      log('fill');
                       setValue('given-name', 'John');
                       setValue('family-name', 'Doe');
                       setValue('organization', 'Example Inc');
@@ -217,10 +234,23 @@ class AddressAutofillPromptTest {
                       setValue('postal-code', '94043');
                       setValue('tel', '+16505551234');
                       setValue('email', 'john.doe@example.com');
+                      log('fill-done value=' + document.getElementById('given-name').value);
                     }, 5000);
                     setTimeout(() => {
-                      document.getElementById('submit-button').click();
+                      log('submit href=' + location.href);
+                      const form = document.getElementById('address-form');
+                      if (form.requestSubmit) {
+                        form.requestSubmit();
+                      } else {
+                        form.submit();
+                      }
+                      log('submit-called');
                     }, 8000);
+                    setTimeout(() => {
+                      // 8 秒時点の送信で遷移しなかった場合のフォールバック
+                      log('fallback-submit still-here href=' + location.href);
+                      document.getElementById('address-form').submit();
+                    }, 12000);
                   });
                 </script>
               </body>

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -69,7 +69,9 @@ class AddressAutofillPromptTest {
         composeRule.openUrlFromUrlBar(pageUri)
         composeRule.waitForUrlBarContains(ADDRESS_FORM_FILE_NAME, timeoutMillis = 60_000)
 
-        // 以降の診断ログを入力〜送信〜capture 判定の範囲に絞る
+        // ページ内スクリプトの入力完了 (load+5秒) まで待ってから logcat をクリアし、
+        // 診断ログを送信〜capture 判定の範囲に絞る
+        Thread.sleep(FILL_COMPLETE_WAIT_MILLIS)
         clearLogcat()
 
         // ページは load 後にフォームへ値を投入して自動送信する。
@@ -168,10 +170,10 @@ class AddressAutofillPromptTest {
     }
 
     /**
-     * formautofill 関連の logcat を収集する。失敗時の診断用。
+     * formautofill の capture 判定に関わる logcat を収集する。失敗時の診断用。
      *
-     * console.debug の本文は接頭辞と別行の Gecko タグで出力されるため Gecko タグ行も拾う。
-     * テスト失敗スタックトレースの echo (TestRunner) はノイズなので除外する。
+     * console.debug の本文は接頭辞と別行の Gecko タグで出力されるため、
+     * capture 判定パスのキーワードを含む本文行を狙って拾う。
      */
     private fun collectFormAutofillLogcat(): String {
         val output = runCatching {
@@ -181,12 +183,31 @@ class AddressAutofillPromptTest {
                 .bufferedReader()
                 .readLines()
         }.getOrElse { return "logcat取得失敗: $it" }
+        val excludes = listOf(
+            "TestRunner",
+            "MediaBridge",
+            "updateActiveElement",
+            "Disregarding",
+            "GeckoConsole",
+            "getSavedFieldNames",
+            "updateSavedFieldNames",
+        )
+        val includes = listOf(
+            "addr-test",
+            "submi",
+            "capture",
+            "doorhanger",
+            "prompt",
+            "duplicat",
+            "mergeable",
+            "record",
+            "address",
+            "onPageNavigation",
+            "navigation",
+        )
         return output
-            .filter { line -> !line.contains("TestRunner") }
-            .filter { line ->
-                listOf("autofill", "GeckoConsole", "prompt", "addr-test", "console.", " Gecko ")
-                    .any { line.contains(it, ignoreCase = true) }
-            }
+            .filter { line -> excludes.none { line.contains(it) } }
+            .filter { line -> includes.any { line.contains(it, ignoreCase = true) } }
             .takeLast(LOGCAT_TAIL_LINES)
             .joinToString("\n")
     }
@@ -467,6 +488,7 @@ class AddressAutofillPromptTest {
         private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
         private const val PREF_TIMEOUT_MILLIS = 30_000L
         private const val PREF_POLL_TIMEOUT_MILLIS = 5_000L
+        private const val FILL_COMPLETE_WAIT_MILLIS = 6_500L
         private const val LOGCAT_TAIL_LINES = 250
     }
 }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -1,0 +1,120 @@
+package net.matsudamper.browser
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * GeckoView の住所フォーム自動入力 (formautofill) が実際に動作することを確認するテスト。
+ *
+ * geckoview-config.yaml で有効化した extensions.formautofill.addresses.capture.enabled により、
+ * 住所フォーム送信時に PromptDelegate.onAddressSave が発火して保存ダイアログが表示されることを検証する。
+ * フォームへの値の投入と送信はページ内 JavaScript で行うため、Web コンテンツへの直接操作は行わない。
+ */
+@RunWith(AndroidJUnit4::class)
+class AddressAutofillPromptTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun submittingAddressFormShowsAddressSaveDialog() {
+        val pageUri = prepareAddressFormPageUri()
+
+        composeRule.openUrlFromUrlBar(pageUri)
+        composeRule.waitForUrlBarContains(ADDRESS_FORM_FILE_NAME, timeoutMillis = 60_000)
+
+        // ページは load 後にフォームへ値を投入して自動送信する。
+        // 送信を Gecko の formautofill が検出すると onAddressSave プロンプトが発火し、
+        // AddressSaveDialog が表示されるはず。
+        composeRule.waitUntil(timeoutMillis = 90_000) {
+            composeRule
+                .onAllNodesWithTag(BrowserTabDialogLayerTestTags.AddressSaveDialog.testTag)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    /**
+     * 住所フォームのローカルHTMLをキャッシュへ生成し、file URI を返す。
+     *
+     * formautofill の対象判定はロケール・地域に依存するため、確実に対象となる US 形式の住所を使う。
+     */
+    private fun prepareAddressFormPageUri(): String {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val destinationDir = File(targetContext.cacheDir, ADDRESS_FORM_DIR_NAME).apply { mkdirs() }
+        File(destinationDir, ADDRESS_FORM_DONE_FILE_NAME).writeText(
+            """
+            <!doctype html>
+            <html lang="en">
+              <head><meta charset="utf-8" /><title>Done</title></head>
+              <body><main>Submitted</main></body>
+            </html>
+            """.trimIndent(),
+        )
+        val destination = File(destinationDir, ADDRESS_FORM_FILE_NAME)
+        destination.writeText(
+            """
+            <!doctype html>
+            <html lang="en">
+              <head>
+                <meta charset="utf-8" />
+                <title>Address Form Test</title>
+              </head>
+              <body>
+                <form id="address-form" method="get" action="$ADDRESS_FORM_DONE_FILE_NAME">
+                  <input id="given-name" name="given-name" autocomplete="given-name" />
+                  <input id="family-name" name="family-name" autocomplete="family-name" />
+                  <input id="organization" name="organization" autocomplete="organization" />
+                  <input id="street-address" name="street-address" autocomplete="street-address" />
+                  <input id="address-level2" name="city" autocomplete="address-level2" />
+                  <input id="address-level1" name="state" autocomplete="address-level1" />
+                  <input id="postal-code" name="zip" autocomplete="postal-code" />
+                  <select id="country" name="country" autocomplete="country">
+                    <option value="US" selected>United States</option>
+                  </select>
+                  <input id="tel" name="tel" autocomplete="tel" />
+                  <input id="email" name="email" autocomplete="email" />
+                  <button id="submit-button" type="submit">Submit</button>
+                </form>
+                <script>
+                  function setValue(id, value) {
+                    const el = document.getElementById(id);
+                    el.focus();
+                    el.value = value;
+                    el.dispatchEvent(new Event('input', { bubbles: true }));
+                    el.dispatchEvent(new Event('change', { bubbles: true }));
+                  }
+                  window.addEventListener('load', () => {
+                    // formautofill のフィールド検出が完了するのを待ってから投入・送信する
+                    setTimeout(() => {
+                      setValue('given-name', 'John');
+                      setValue('family-name', 'Doe');
+                      setValue('organization', 'Example Inc');
+                      setValue('street-address', '123 Main Street');
+                      setValue('address-level2', 'Mountain View');
+                      setValue('address-level1', 'CA');
+                      setValue('postal-code', '94043');
+                      setValue('tel', '+16505551234');
+                      setValue('email', 'john.doe@example.com');
+                      document.getElementById('submit-button').click();
+                    }, 3000);
+                  });
+                </script>
+              </body>
+            </html>
+            """.trimIndent(),
+        )
+        return destination.toURI().toString()
+    }
+
+    private companion object {
+        private const val ADDRESS_FORM_DIR_NAME = "test-address-form"
+        private const val ADDRESS_FORM_FILE_NAME = "address-form.html"
+        private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
+    }
+}

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -2,9 +2,13 @@ package net.matsudamper.browser
 
 import android.os.ParcelFileDescriptor
 import androidx.annotation.OptIn
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
@@ -84,12 +88,29 @@ class AddressAutofillPromptTest {
             throw AssertionError(
                 "住所保存ダイアログが表示されない (フォーム送信=$submitted)\n" +
                     "現在URL=${composeRule.currentPageUrlFromUi()}\n" +
-                    "PageLoadError表示=$pageLoadErrorVisible\n" +
+                    "PageLoadError表示=$pageLoadErrorVisible 内容=${pageLoadErrorText()}\n" +
                     "サーバ受信リクエスト=${server.requests}\n" +
                     "--- logcat (formautofill関連) ---\n${collectFormAutofillLogcat()}",
                 e,
             )
         }
+    }
+
+    /**
+     * ページロードエラー画面に表示されているテキストを収集する。失敗時の診断用。
+     */
+    private fun pageLoadErrorText(): String {
+        return runCatching {
+            val node = composeRule
+                .onNodeWithTag(BrowserTabSurfaceTestTags.PageLoadError.testTag, useUnmergedTree = true)
+                .fetchSemanticsNode()
+            collectTexts(node).joinToString(" / ")
+        }.getOrDefault("")
+    }
+
+    private fun collectTexts(node: SemanticsNode): List<String> {
+        val own = node.config.getOrNull(SemanticsProperties.Text)?.map { it.text }.orEmpty()
+        return own + node.children.flatMap { collectTexts(it) }
     }
 
     /**
@@ -147,6 +168,22 @@ class AddressAutofillPromptTest {
             GeckoPreferenceController.setGeckoPref(
                 "devtools.console.stdout.content",
                 true,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            )
+        }
+        // CI の診断でループバック HTTP サーバへの接続が一切行われずページロードに失敗して
+        // いたため、Local Network Access のブロッキングを無効化する
+        awaitGeckoResult {
+            GeckoPreferenceController.setGeckoPref(
+                "network.lna.enabled",
+                false,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            )
+        }
+        awaitGeckoResult {
+            GeckoPreferenceController.setGeckoPref(
+                "network.lna.blocking",
+                false,
                 GeckoPreferenceController.PREF_BRANCH_USER,
             )
         }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -75,10 +75,12 @@ class AddressAutofillPromptTest {
         clearLogcat()
 
         // ページは load 後にフォームへ値を投入して自動送信する。
-        // まずフォーム送信 (done.html への遷移) が行われたことを確認し、
-        // 送信自体の失敗と capture 未発火を切り分ける。
+        // 送信先は hidden iframe (メインページは遷移しない) のため、
+        // サーバが done.html リクエストを受信したことで送信完了を判定する。
         val submitted = runCatching {
-            composeRule.waitForUrlBarContains(ADDRESS_FORM_DONE_FILE_NAME, timeoutMillis = 30_000)
+            composeRule.waitUntil(timeoutMillis = 30_000) {
+                server.requests.any { it.contains(ADDRESS_FORM_DONE_FILE_NAME) }
+            }
         }.isSuccess
 
         // 送信を Gecko の formautofill が検出すると onAddressSave プロンプトが発火し、
@@ -323,7 +325,9 @@ class AddressAutofillPromptTest {
                 <title>Address Form Test</title>
               </head>
               <body>
-                <form id="address-form" method="get" action="/$ADDRESS_FORM_DONE_FILE_NAME">
+                <!-- メインページを遷移させると doorhanger 表示前にドキュメントが破棄されて
+                     プロンプトが出ないため、hidden iframe へ送信する -->
+                <form id="address-form" method="get" action="/$ADDRESS_FORM_DONE_FILE_NAME" target="result-frame">
                   <input id="given-name" name="given-name" autocomplete="given-name" />
                   <input id="family-name" name="family-name" autocomplete="family-name" />
                   <input id="organization" name="organization" autocomplete="organization" />
@@ -338,6 +342,7 @@ class AddressAutofillPromptTest {
                   <input id="email" name="email" autocomplete="email" />
                   <button id="submit-button" type="submit">Submit</button>
                 </form>
+                <iframe name="result-frame" id="result-frame" style="width:1px;height:1px;border:0"></iframe>
                 <script>
                   function log(message) {
                     console.log('addr-test: ' + message);

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -1,5 +1,6 @@
 package net.matsudamper.browser
 
+import androidx.annotation.OptIn
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -8,7 +9,9 @@ import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.geckoview.ExperimentalGeckoViewApi
 import org.mozilla.geckoview.GeckoPreferenceController
+import org.mozilla.geckoview.GeckoResult
 import java.io.File
 
 /**
@@ -49,22 +52,27 @@ class AddressAutofillPromptTest {
      * skipProgrammaticCheckForTests は GeckoView 本家の AutocompleteTest と同様に、
      * JavaScript によるプログラム的なフォーム操作を formautofill が無視しないようにする。
      */
+    @OptIn(ExperimentalGeckoViewApi::class)
     private fun applyTestPrefsAndAwaitAddressAutofillEnabled() {
-        GeckoPreferenceController.setGeckoPref(
-            "extensions.formautofill.skipProgrammaticCheckForTests",
-            true,
-            GeckoPreferenceController.PREF_BRANCH_USER,
-        ).poll(PREF_TIMEOUT_MILLIS)
+        awaitGeckoResult {
+            GeckoPreferenceController.setGeckoPref(
+                "extensions.formautofill.skipProgrammaticCheckForTests",
+                true,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            )
+        }
 
         val deadline = System.currentTimeMillis() + PREF_TIMEOUT_MILLIS
         while (true) {
-            val prefs = GeckoPreferenceController.getGeckoPrefs(
-                listOf(
-                    "extensions.formautofill.addresses.enabled",
-                    "extensions.formautofill.addresses.capture.enabled",
-                    "extensions.formautofill.addresses.supported",
-                ),
-            ).poll(PREF_TIMEOUT_MILLIS)
+            val prefs = awaitGeckoResult {
+                GeckoPreferenceController.getGeckoPrefs(
+                    listOf(
+                        "extensions.formautofill.addresses.enabled",
+                        "extensions.formautofill.addresses.capture.enabled",
+                        "extensions.formautofill.addresses.supported",
+                    ),
+                )
+            }
             val values = prefs.orEmpty().associate { it.pref to it.value }
             val applied = values["extensions.formautofill.addresses.enabled"] == true &&
                 values["extensions.formautofill.addresses.capture.enabled"] == true &&
@@ -75,6 +83,20 @@ class AddressAutofillPromptTest {
             }
             Thread.sleep(500)
         }
+    }
+
+    /**
+     * GeckoResult をメインスレッドで生成し、テストスレッドで完了を待つ。
+     *
+     * GeckoResult の生成 (内部の then/map 連鎖) は Handler を持つスレッドで行う必要があり、
+     * poll はメインスレッドでは呼べないため、生成と待機でスレッドを分ける。
+     */
+    private fun <T> awaitGeckoResult(block: () -> GeckoResult<T>): T? {
+        var geckoResult: GeckoResult<T>? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            geckoResult = block()
+        }
+        return requireNotNull(geckoResult).poll(PREF_TIMEOUT_MILLIS)
     }
 
     /**

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -149,8 +149,14 @@ class AddressAutofillPromptTest {
                     el.dispatchEvent(new Event('input', { bubbles: true }));
                     el.dispatchEvent(new Event('change', { bubbles: true }));
                   }
+                  // GeckoView の formautofill は focusin がフィールド検出のトリガーで、
+                  // 検出とフォーム送信リスナー登録は親プロセスとの非同期通信で行われる。
+                  // 同一タスク内で focus→入力→送信まで行うとリスナー登録前に送信されて
+                  // capture が動かないため、検出起動・入力・送信を時間差で分ける。
                   window.addEventListener('load', () => {
-                    // formautofill のフィールド検出が完了するのを待ってから投入・送信する
+                    setTimeout(() => {
+                      document.getElementById('given-name').focus();
+                    }, 2000);
                     setTimeout(() => {
                       setValue('given-name', 'John');
                       setValue('family-name', 'Doe');
@@ -161,8 +167,10 @@ class AddressAutofillPromptTest {
                       setValue('postal-code', '94043');
                       setValue('tel', '+16505551234');
                       setValue('email', 'john.doe@example.com');
+                    }, 5000);
+                    setTimeout(() => {
                       document.getElementById('submit-button').click();
-                    }, 3000);
+                    }, 8000);
                   });
                 </script>
               </body>

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -69,6 +69,9 @@ class AddressAutofillPromptTest {
         composeRule.openUrlFromUrlBar(pageUri)
         composeRule.waitForUrlBarContains(ADDRESS_FORM_FILE_NAME, timeoutMillis = 60_000)
 
+        // 以降の診断ログを入力〜送信〜capture 判定の範囲に絞る
+        clearLogcat()
+
         // ページは load 後にフォームへ値を投入して自動送信する。
         // まずフォーム送信 (done.html への遷移) が行われたことを確認し、
         // 送信自体の失敗と capture 未発火を切り分ける。
@@ -154,7 +157,21 @@ class AddressAutofillPromptTest {
     }
 
     /**
+     * logcat をクリアする。
+     */
+    private fun clearLogcat() {
+        runCatching {
+            val pfd = InstrumentationRegistry.getInstrumentation().uiAutomation
+                .executeShellCommand("logcat -c")
+            ParcelFileDescriptor.AutoCloseInputStream(pfd).use { it.readBytes() }
+        }
+    }
+
+    /**
      * formautofill 関連の logcat を収集する。失敗時の診断用。
+     *
+     * console.debug の本文は接頭辞と別行の Gecko タグで出力されるため Gecko タグ行も拾う。
+     * テスト失敗スタックトレースの echo (TestRunner) はノイズなので除外する。
      */
     private fun collectFormAutofillLogcat(): String {
         val output = runCatching {
@@ -165,8 +182,9 @@ class AddressAutofillPromptTest {
                 .readLines()
         }.getOrElse { return "logcat取得失敗: $it" }
         return output
+            .filter { line -> !line.contains("TestRunner") }
             .filter { line ->
-                listOf("autofill", "GeckoConsole", "GeckoViewPrompt", "prompt", "addr-test")
+                listOf("autofill", "GeckoConsole", "prompt", "addr-test", "console.", " Gecko ")
                     .any { line.contains(it, ignoreCase = true) }
             }
             .takeLast(LOGCAT_TAIL_LINES)
@@ -449,6 +467,6 @@ class AddressAutofillPromptTest {
         private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
         private const val PREF_TIMEOUT_MILLIS = 30_000L
         private const val PREF_POLL_TIMEOUT_MILLIS = 5_000L
-        private const val LOGCAT_TAIL_LINES = 120
+        private const val LOGCAT_TAIL_LINES = 250
     }
 }

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -18,6 +18,7 @@ import org.mozilla.geckoview.GeckoResult
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeoutException
 
 /**
@@ -76,8 +77,15 @@ class AddressAutofillPromptTest {
                     .isNotEmpty()
             }
         } catch (e: ComposeTimeoutException) {
+            val pageLoadErrorVisible = composeRule
+                .onAllNodesWithTag(BrowserTabSurfaceTestTags.PageLoadError.testTag)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
             throw AssertionError(
                 "住所保存ダイアログが表示されない (フォーム送信=$submitted)\n" +
+                    "現在URL=${composeRule.currentPageUrlFromUi()}\n" +
+                    "PageLoadError表示=$pageLoadErrorVisible\n" +
+                    "サーバ受信リクエスト=${server.requests}\n" +
                     "--- logcat (formautofill関連) ---\n${collectFormAutofillLogcat()}",
                 e,
             )
@@ -295,6 +303,9 @@ class AddressAutofillPromptTest {
 
         val port: Int get() = serverSocket.localPort
 
+        /** 受信した HTTP リクエストライン。失敗時の診断用。 */
+        val requests = CopyOnWriteArrayList<String>()
+
         init {
             Thread {
                 while (!serverSocket.isClosed) {
@@ -309,6 +320,7 @@ class AddressAutofillPromptTest {
                 socket.use { s ->
                     val reader = s.getInputStream().bufferedReader()
                     val requestLine = reader.readLine() ?: return
+                    requests.add(requestLine)
                     // リクエストヘッダは読み捨てる
                     while (true) {
                         val line = reader.readLine() ?: break

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
 import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
@@ -14,24 +15,44 @@ import org.junit.runner.RunWith
 import org.mozilla.geckoview.ExperimentalGeckoViewApi
 import org.mozilla.geckoview.GeckoPreferenceController
 import org.mozilla.geckoview.GeckoResult
-import java.io.File
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.util.concurrent.TimeoutException
 
 /**
  * GeckoView の住所フォーム自動入力 (formautofill) が実際に動作することを確認するテスト。
  *
- * geckoview-config.yaml で有効化した extensions.formautofill.addresses.capture.enabled により、
+ * AppModule で有効化した extensions.formautofill.addresses.capture.enabled により、
  * 住所フォーム送信時に PromptDelegate.onAddressSave が発火して保存ダイアログが表示されることを検証する。
  * フォームへの値の投入と送信はページ内 JavaScript で行うため、Web コンテンツへの直接操作は行わない。
+ *
+ * file:// ではフォーム送信が行われないことが CI の診断で判明したため、
+ * ループバック HTTP サーバでページを配信する。
  */
 @RunWith(AndroidJUnit4::class)
 class AddressAutofillPromptTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
 
+    private var httpServer: LocalHttpServer? = null
+
+    @After
+    fun tearDown() {
+        httpServer?.close()
+        httpServer = null
+    }
+
     @Test
     fun submittingAddressFormShowsAddressSaveDialog() {
-        val pageUri = prepareAddressFormPageUri()
+        val server = LocalHttpServer(
+            pages = mapOf(
+                "/$ADDRESS_FORM_FILE_NAME" to buildAddressFormHtml(),
+                "/$ADDRESS_FORM_DONE_FILE_NAME" to buildDoneHtml(),
+            ),
+        )
+        httpServer = server
+        val pageUri = "http://127.0.0.1:${server.port}/$ADDRESS_FORM_FILE_NAME"
 
         applyTestPrefsAndAwaitAddressAutofillEnabled()
 
@@ -114,6 +135,13 @@ class AddressAutofillPromptTest {
                 GeckoPreferenceController.PREF_BRANCH_USER,
             )
         }
+        awaitGeckoResult {
+            GeckoPreferenceController.setGeckoPref(
+                "devtools.console.stdout.content",
+                true,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            )
+        }
 
         val deadline = System.currentTimeMillis() + PREF_TIMEOUT_MILLIS
         while (true) {
@@ -158,25 +186,12 @@ class AddressAutofillPromptTest {
     }
 
     /**
-     * 住所フォームのローカルHTMLをキャッシュへ生成し、file URI を返す。
+     * 住所フォームのテストページ。
      *
      * formautofill の対象判定はロケール・地域に依存するため、確実に対象となる US 形式の住所を使う。
      */
-    private fun prepareAddressFormPageUri(): String {
-        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val destinationDir = File(targetContext.cacheDir, ADDRESS_FORM_DIR_NAME).apply { mkdirs() }
-        File(destinationDir, ADDRESS_FORM_DONE_FILE_NAME).writeText(
-            """
-            <!doctype html>
-            <html lang="en">
-              <head><meta charset="utf-8" /><title>Done</title></head>
-              <body><main>Submitted</main></body>
-            </html>
-            """.trimIndent(),
-        )
-        val destination = File(destinationDir, ADDRESS_FORM_FILE_NAME)
-        destination.writeText(
-            """
+    private fun buildAddressFormHtml(): String {
+        return """
             <!doctype html>
             <html lang="en">
               <head>
@@ -184,7 +199,7 @@ class AddressAutofillPromptTest {
                 <title>Address Form Test</title>
               </head>
               <body>
-                <form id="address-form" method="get" action="$ADDRESS_FORM_DONE_FILE_NAME">
+                <form id="address-form" method="get" action="/$ADDRESS_FORM_DONE_FILE_NAME">
                   <input id="given-name" name="given-name" autocomplete="given-name" />
                   <input id="family-name" name="family-name" autocomplete="family-name" />
                   <input id="organization" name="organization" autocomplete="organization" />
@@ -255,13 +270,90 @@ class AddressAutofillPromptTest {
                 </script>
               </body>
             </html>
-            """.trimIndent(),
-        )
-        return destination.toURI().toString()
+        """.trimIndent()
+    }
+
+    private fun buildDoneHtml(): String {
+        return """
+            <!doctype html>
+            <html lang="en">
+              <head><meta charset="utf-8" /><title>Done</title></head>
+              <body><main>Submitted</main></body>
+            </html>
+        """.trimIndent()
+    }
+
+    /**
+     * テストページ配信用の最小限のループバック HTTP サーバ。
+     *
+     * file:// ではフォーム送信が行われないため、http:// でページを配信する。
+     */
+    private class LocalHttpServer(
+        private val pages: Map<String, String>,
+    ) : AutoCloseable {
+        private val serverSocket = ServerSocket(0, BACKLOG, InetAddress.getLoopbackAddress())
+
+        val port: Int get() = serverSocket.localPort
+
+        init {
+            Thread {
+                while (!serverSocket.isClosed) {
+                    val socket = runCatching { serverSocket.accept() }.getOrNull() ?: break
+                    Thread { handle(socket) }.apply { isDaemon = true }.start()
+                }
+            }.apply { isDaemon = true }.start()
+        }
+
+        private fun handle(socket: Socket) {
+            runCatching {
+                socket.use { s ->
+                    val reader = s.getInputStream().bufferedReader()
+                    val requestLine = reader.readLine() ?: return
+                    // リクエストヘッダは読み捨てる
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        if (line.isEmpty()) break
+                    }
+                    val path = requestLine.split(" ").getOrNull(1)
+                        ?.substringBefore("?")
+                        ?: "/"
+                    val body = pages[path]
+                    val output = s.getOutputStream()
+                    if (body != null) {
+                        val bytes = body.toByteArray(Charsets.UTF_8)
+                        output.write(
+                            (
+                                "HTTP/1.1 200 OK\r\n" +
+                                    "Content-Type: text/html; charset=utf-8\r\n" +
+                                    "Content-Length: ${bytes.size}\r\n" +
+                                    "Connection: close\r\n\r\n"
+                                ).toByteArray(),
+                        )
+                        output.write(bytes)
+                    } else {
+                        output.write(
+                            (
+                                "HTTP/1.1 404 Not Found\r\n" +
+                                    "Content-Length: 0\r\n" +
+                                    "Connection: close\r\n\r\n"
+                                ).toByteArray(),
+                        )
+                    }
+                    output.flush()
+                }
+            }
+        }
+
+        override fun close() {
+            runCatching { serverSocket.close() }
+        }
+
+        private companion object {
+            private const val BACKLOG = 8
+        }
     }
 
     private companion object {
-        private const val ADDRESS_FORM_DIR_NAME = "test-address-form"
         private const val ADDRESS_FORM_FILE_NAME = "address-form.html"
         private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
         private const val PREF_TIMEOUT_MILLIS = 30_000L

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/AddressAutofillPromptTest.kt
@@ -4,9 +4,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.geckoview.GeckoPreferenceController
 import java.io.File
 
 /**
@@ -25,6 +27,8 @@ class AddressAutofillPromptTest {
     fun submittingAddressFormShowsAddressSaveDialog() {
         val pageUri = prepareAddressFormPageUri()
 
+        applyTestPrefsAndAwaitAddressAutofillEnabled()
+
         composeRule.openUrlFromUrlBar(pageUri)
         composeRule.waitForUrlBarContains(ADDRESS_FORM_FILE_NAME, timeoutMillis = 60_000)
 
@@ -36,6 +40,40 @@ class AddressAutofillPromptTest {
                 .onAllNodesWithTag(BrowserTabDialogLayerTestTags.AddressSaveDialog.testTag)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
+        }
+    }
+
+    /**
+     * テスト用プリファレンスを設定し、AppModule が設定する住所自動入力プリファレンスの反映を待つ。
+     *
+     * skipProgrammaticCheckForTests は GeckoView 本家の AutocompleteTest と同様に、
+     * JavaScript によるプログラム的なフォーム操作を formautofill が無視しないようにする。
+     */
+    private fun applyTestPrefsAndAwaitAddressAutofillEnabled() {
+        GeckoPreferenceController.setGeckoPref(
+            "extensions.formautofill.skipProgrammaticCheckForTests",
+            true,
+            GeckoPreferenceController.PREF_BRANCH_USER,
+        ).poll(PREF_TIMEOUT_MILLIS)
+
+        val deadline = System.currentTimeMillis() + PREF_TIMEOUT_MILLIS
+        while (true) {
+            val prefs = GeckoPreferenceController.getGeckoPrefs(
+                listOf(
+                    "extensions.formautofill.addresses.enabled",
+                    "extensions.formautofill.addresses.capture.enabled",
+                    "extensions.formautofill.addresses.supported",
+                ),
+            ).poll(PREF_TIMEOUT_MILLIS)
+            val values = prefs.orEmpty().associate { it.pref to it.value }
+            val applied = values["extensions.formautofill.addresses.enabled"] == true &&
+                values["extensions.formautofill.addresses.capture.enabled"] == true &&
+                values["extensions.formautofill.addresses.supported"] == "on"
+            if (applied) return
+            if (System.currentTimeMillis() > deadline) {
+                fail("住所自動入力プリファレンスが適用されていない: $values")
+            }
+            Thread.sleep(500)
         }
     }
 
@@ -116,5 +154,6 @@ class AddressAutofillPromptTest {
         private const val ADDRESS_FORM_DIR_NAME = "test-address-form"
         private const val ADDRESS_FORM_FILE_NAME = "address-form.html"
         private const val ADDRESS_FORM_DONE_FILE_NAME = "done.html"
+        private const val PREF_TIMEOUT_MILLIS = 30_000L
     }
 }

--- a/app/src/main/assets/geckoview-config.yaml
+++ b/app/src/main/assets/geckoview-config.yaml
@@ -1,3 +1,0 @@
-prefs:
-  extensions.formautofill.addresses.enabled: true
-  extensions.formautofill.addresses.capture.enabled: true

--- a/app/src/main/assets/geckoview-config.yaml
+++ b/app/src/main/assets/geckoview-config.yaml
@@ -1,0 +1,3 @@
+prefs:
+  extensions.formautofill.addresses.enabled: true
+  extensions.formautofill.addresses.capture.enabled: true

--- a/app/src/main/kotlin/net/matsudamper/browser/AutocompleteStorageDelegate.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/AutocompleteStorageDelegate.kt
@@ -1,0 +1,103 @@
+package net.matsudamper.browser
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import net.matsudamper.browser.data.address.AddressEntity
+import net.matsudamper.browser.data.address.AddressRepository
+import org.mozilla.geckoview.Autocomplete
+import org.mozilla.geckoview.GeckoResult
+
+class AutocompleteStorageDelegate(
+    private val addressRepository: AddressRepository,
+    private val coroutineScope: CoroutineScope,
+) : Autocomplete.StorageDelegate {
+
+    override fun onAddressFetch(): GeckoResult<Array<Autocomplete.Address>> {
+        val result = GeckoResult<Array<Autocomplete.Address>>()
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                val addresses = addressRepository.getAll().map { it.toGeckoAddress() }.toTypedArray()
+                result.complete(addresses)
+            } catch (e: Exception) {
+                Log.w(TAG, "住所の取得に失敗", e)
+                result.complete(emptyArray())
+            }
+        }
+        return result
+    }
+
+    override fun onAddressSave(address: Autocomplete.Address) {
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                val entity = address.toEntity()
+                addressRepository.save(entity)
+                Log.d(TAG, "住所を保存しました: ${address.familyName} ${address.givenName}")
+            } catch (e: Exception) {
+                Log.w(TAG, "住所の保存に失敗", e)
+            }
+        }
+    }
+
+    override fun onLoginFetch(domain: String): GeckoResult<Array<Autocomplete.LoginEntry>> {
+        return GeckoResult.fromValue(emptyArray())
+    }
+
+    override fun onLoginSave(login: Autocomplete.LoginEntry) {
+        // ログイン保存は未実装
+    }
+
+    override fun onLoginUsed(login: Autocomplete.LoginEntry, usedFields: Int) {
+        // ログイン使用通知は未実装
+    }
+
+    override fun onCreditCardFetch(): GeckoResult<Array<Autocomplete.CreditCard>> {
+        return GeckoResult.fromValue(emptyArray())
+    }
+
+    override fun onCreditCardSave(creditCard: Autocomplete.CreditCard) {
+        // クレジットカード保存は未実装
+    }
+
+    companion object {
+        private const val TAG = "AutocompleteStorage"
+    }
+}
+
+internal fun AddressEntity.toGeckoAddress(): Autocomplete.Address {
+    return Autocomplete.Address.Builder()
+        .guid(id.toString())
+        .givenName(givenName)
+        .additionalName(additionalName)
+        .familyName(familyName)
+        .organization(organization)
+        .streetAddress(streetAddress)
+        .addressLevel1(addressLevel1)
+        .addressLevel2(addressLevel2)
+        .addressLevel3(addressLevel3)
+        .postalCode(postalCode)
+        .country(country)
+        .tel(tel)
+        .email(email)
+        .build()
+}
+
+internal fun Autocomplete.Address.toEntity(): AddressEntity {
+    val existingId = guid?.toLongOrNull() ?: 0L
+    return AddressEntity(
+        id = existingId,
+        givenName = givenName,
+        additionalName = additionalName,
+        familyName = familyName,
+        organization = organization,
+        streetAddress = streetAddress,
+        addressLevel1 = addressLevel1,
+        addressLevel2 = addressLevel2,
+        addressLevel3 = addressLevel3,
+        postalCode = postalCode,
+        country = country,
+        tel = tel,
+        email = email,
+    )
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/AutocompleteStorageDelegate.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/AutocompleteStorageDelegate.kt
@@ -33,7 +33,7 @@ class AutocompleteStorageDelegate(
             try {
                 val entity = address.toEntity()
                 addressRepository.save(entity)
-                Log.d(TAG, "住所を保存しました: ${address.familyName} ${address.givenName}")
+                Log.d(TAG, "住所を保存しました")
             } catch (e: Exception) {
                 Log.w(TAG, "住所の保存に失敗", e)
             }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -50,9 +50,11 @@ import androidx.core.graphics.toColorInt
 import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
+import androidx.compose.foundation.layout.padding
 import net.matsudamper.browser.data.ThemeMode
 import net.matsudamper.browser.data.download.DownloadRecordStatus
 import net.matsudamper.browser.ui.common.BrowserTheme
+import org.mozilla.geckoview.Autocomplete
 import org.mozilla.geckoview.GeckoSession
 
 @Composable
@@ -387,6 +389,22 @@ internal fun BrowserTabDialogLayer(
                     Text("キャンセル")
                 }
             },
+        )
+    }
+
+    dialogState.pendingAddressSelectPrompt?.let { prompt ->
+        AddressSelectDialog(
+            options = prompt.options.toList(),
+            onSelect = dialogState::confirmAddressSelect,
+            onDismiss = dialogState::dismissAddressSelect,
+        )
+    }
+
+    dialogState.pendingAddressSaveAddress?.let { address ->
+        AddressSaveDialog(
+            address = address,
+            onSave = dialogState::confirmAddressSave,
+            onDismiss = dialogState::dismissAddressSave,
         )
     }
 }
@@ -971,6 +989,106 @@ private fun DuplicateDownloadDialog(
             }
         },
     )
+}
+
+@Composable
+private fun AddressSelectDialog(
+    options: List<Autocomplete.AddressSelectOption>,
+    onSelect: (Autocomplete.AddressSelectOption) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("住所を選択") },
+        text = {
+            LazyColumn {
+                items(options) { option ->
+                    val address = option.value
+                    val displayText = buildAddressDisplayText(address)
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = "${address.familyName} ${address.givenName}".trim()
+                                    .ifEmpty { address.organization },
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        supportingContent = {
+                            Text(
+                                text = displayText,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        },
+                        modifier = Modifier.clickable { onSelect(option) },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    )
+                    if (option !== options.last()) {
+                        HorizontalDivider()
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("キャンセル")
+            }
+        },
+    )
+}
+
+@Composable
+private fun AddressSaveDialog(
+    address: Autocomplete.Address,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val displayText = buildAddressDisplayText(address)
+    val name = "${address.familyName} ${address.givenName}".trim()
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("住所を保存しますか？") },
+        text = {
+            Column {
+                if (name.isNotEmpty()) {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+                Text(
+                    text = displayText,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onSave) {
+                Text("保存")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("保存しない")
+            }
+        },
+    )
+}
+
+private fun buildAddressDisplayText(address: Autocomplete.Address): String {
+    return buildList {
+        if (address.postalCode.isNotEmpty()) add("〒${address.postalCode}")
+        if (address.addressLevel1.isNotEmpty()) add(address.addressLevel1)
+        if (address.addressLevel2.isNotEmpty()) add(address.addressLevel2)
+        if (address.addressLevel3.isNotEmpty()) add(address.addressLevel3)
+        if (address.streetAddress.isNotEmpty()) add(address.streetAddress)
+        if (address.tel.isNotEmpty()) add(address.tel)
+        if (address.email.isNotEmpty()) add(address.email)
+    }.joinToString(" ")
 }
 
 private fun flattenChoices(

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabDialogLayer.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -998,6 +999,7 @@ private fun AddressSelectDialog(
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
+        modifier = Modifier.testTag(BrowserTabDialogLayerTestTags.AddressSelectDialog.testTag),
         onDismissRequest = onDismiss,
         title = { Text("住所を選択") },
         text = {
@@ -1049,6 +1051,7 @@ private fun AddressSaveDialog(
     val displayText = buildAddressDisplayText(address)
     val name = "${address.familyName} ${address.givenName}".trim()
     AlertDialog(
+        modifier = Modifier.testTag(BrowserTabDialogLayerTestTags.AddressSaveDialog.testTag),
         onDismissRequest = onDismiss,
         title = { Text("住所を保存しますか？") },
         text = {
@@ -1067,7 +1070,10 @@ private fun AddressSaveDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = onSave) {
+            TextButton(
+                onClick = onSave,
+                modifier = Modifier.testTag(BrowserTabDialogLayerTestTags.AddressSaveConfirmButton.testTag),
+            ) {
                 Text("保存")
             }
         },
@@ -1077,6 +1083,15 @@ private fun AddressSaveDialog(
             }
         },
     )
+}
+
+sealed interface BrowserTabDialogLayerTestTags {
+    val id: String
+    val testTag get() = "${BrowserTabDialogLayerTestTags::class.java.name}#$id"
+
+    object AddressSelectDialog : BrowserTabDialogLayerTestTags { override val id = "address_select_dialog" }
+    object AddressSaveDialog : BrowserTabDialogLayerTestTags { override val id = "address_save_dialog" }
+    object AddressSaveConfirmButton : BrowserTabDialogLayerTestTags { override val id = "address_save_confirm_button" }
 }
 
 private fun buildAddressDisplayText(address: Autocomplete.Address): String {

--- a/app/src/main/kotlin/net/matsudamper/browser/PromptDialogState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/PromptDialogState.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.UUID
 import org.mozilla.geckoview.AllowOrDeny
+import org.mozilla.geckoview.Autocomplete
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
 
@@ -68,6 +69,15 @@ internal class PromptDialogState(
     // --- RepostConfirm (フォーム再送信確認) ---
     var pendingRepostConfirmPrompt by mutableStateOf<GeckoSession.PromptDelegate.RepostConfirmPrompt?>(null)
     var pendingRepostConfirmResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+
+    // --- AddressSelect (住所自動入力) ---
+    var pendingAddressSelectPrompt by mutableStateOf<GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.AddressSelectOption>?>(null)
+    var pendingAddressSelectResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
+
+    // --- AddressSave (住所保存確認) ---
+    var pendingAddressSaveAddress by mutableStateOf<Autocomplete.Address?>(null)
+    var pendingAddressSavePrompt by mutableStateOf<GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.AddressSaveOption>?>(null)
+    var pendingAddressSaveResult by mutableStateOf<GeckoResult<GeckoSession.PromptDelegate.PromptResponse>?>(null)
 
     // ================================================================
     // Actions
@@ -309,6 +319,41 @@ internal class PromptDialogState(
         pendingRepostConfirmResult = null
     }
 
+    fun confirmAddressSelect(option: Autocomplete.AddressSelectOption) {
+        val prompt = pendingAddressSelectPrompt ?: return
+        pendingAddressSelectResult?.complete(prompt.confirm(option))
+        pendingAddressSelectPrompt = null
+        pendingAddressSelectResult = null
+    }
+
+    fun dismissAddressSelect() {
+        val prompt = pendingAddressSelectPrompt ?: return
+        pendingAddressSelectResult?.complete(prompt.dismiss())
+        pendingAddressSelectPrompt = null
+        pendingAddressSelectResult = null
+    }
+
+    fun confirmAddressSave() {
+        val prompt = pendingAddressSavePrompt ?: return
+        val options = prompt.options
+        if (options.isNotEmpty()) {
+            pendingAddressSaveResult?.complete(prompt.confirm(options[0]))
+        } else {
+            pendingAddressSaveResult?.complete(prompt.dismiss())
+        }
+        pendingAddressSavePrompt = null
+        pendingAddressSaveResult = null
+        pendingAddressSaveAddress = null
+    }
+
+    fun dismissAddressSave() {
+        val prompt = pendingAddressSavePrompt ?: return
+        pendingAddressSaveResult?.complete(prompt.dismiss())
+        pendingAddressSavePrompt = null
+        pendingAddressSaveResult = null
+        pendingAddressSaveAddress = null
+    }
+
     // ================================================================
     // Delegate 生成
     // ================================================================
@@ -421,6 +466,34 @@ internal class PromptDialogState(
             ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
                 // ポップアップを許可する
                 return GeckoResult.fromValue(prompt.confirm(AllowOrDeny.ALLOW))
+            }
+
+            override fun onAddressSelect(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.AddressSelectOption>,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                if (prompt.options.isEmpty()) {
+                    return GeckoResult.fromValue(prompt.dismiss())
+                }
+                pendingAddressSelectPrompt = prompt
+                pendingAddressSelectResult = result
+                return result
+            }
+
+            override fun onAddressSave(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.AutocompleteRequest<Autocomplete.AddressSaveOption>,
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse> {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                val address = prompt.options.firstOrNull()?.value
+                if (address == null) {
+                    return GeckoResult.fromValue(prompt.dismiss())
+                }
+                pendingAddressSaveAddress = address
+                pendingAddressSavePrompt = prompt
+                pendingAddressSaveResult = result
+                return result
             }
         }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -20,6 +20,7 @@ import net.matsudamper.browser.data.download.DownloadRepository
 import net.matsudamper.browser.data.history.HistoryRepository
 import net.matsudamper.browser.data.websuggestion.HttpWebSuggestionRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
+import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -45,9 +46,20 @@ val dataModule = module {
 
 val appModule = module {
     single<GeckoRuntime> {
+        val context = androidContext()
+        // GeckoView の住所フォーム自動入力を有効にするための設定ファイルを準備する。
+        // GeckoRuntimeSettings.Builder には loginAutofillEnabled() はあるが
+        // 住所用の公開 API がないため、configFilePath 経由で Gecko 内部プリファレンスを設定する。
+        val geckoConfigFile = File(context.filesDir, "geckoview-config.yaml")
+        context.assets.open("geckoview-config.yaml").use { input ->
+            geckoConfigFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
         val runtime = GeckoRuntime.create(
-            androidContext(),
+            context,
             GeckoRuntimeSettings.Builder()
+                .configFilePath(geckoConfigFile.absolutePath)
                 .forceUserScalableEnabled(true)
                 // ユーザーインストール拡張機能のバックグラウンドスクリプトを専用プロセスで実行し、
                 // webRequest.onBeforeRequest 等によるリクエストのブロッキングを有効にする。

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -21,6 +21,7 @@ import net.matsudamper.browser.data.history.HistoryRepository
 import net.matsudamper.browser.data.websuggestion.HttpWebSuggestionRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
 import android.util.Log
+import androidx.annotation.OptIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -29,6 +30,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.geckoview.ExperimentalGeckoViewApi
 import org.mozilla.geckoview.GeckoPreferenceController
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
@@ -57,37 +59,7 @@ val appModule = module {
                 .extensionsProcessEnabled(true)
                 .build()
         )
-        // GeckoView の住所フォーム自動入力を有効にする。
-        // GeckoRuntimeSettings.Builder には loginAutofillEnabled() はあるが住所用の公開 API が
-        // ないため、GeckoPreferenceController で Gecko 内部プリファレンスを設定する。
-        // supported=on はリージョン判定 (detect) を回避して住所機能を常に利用可能にする。
-        GeckoPreferenceController.setGeckoPrefs(
-            listOf(
-                GeckoPreferenceController.SetGeckoPreference.setBoolPref(
-                    "extensions.formautofill.addresses.enabled",
-                    true,
-                    GeckoPreferenceController.PREF_BRANCH_USER,
-                ),
-                GeckoPreferenceController.SetGeckoPreference.setBoolPref(
-                    "extensions.formautofill.addresses.capture.enabled",
-                    true,
-                    GeckoPreferenceController.PREF_BRANCH_USER,
-                ),
-                GeckoPreferenceController.SetGeckoPreference.setStringPref(
-                    "extensions.formautofill.addresses.supported",
-                    "on",
-                    GeckoPreferenceController.PREF_BRANCH_USER,
-                ),
-            ),
-        ).accept(
-            { results ->
-                val failed = results.orEmpty().filterValues { !it }.keys
-                if (failed.isNotEmpty()) {
-                    Log.w("AppModule", "住所自動入力プリファレンスの設定に失敗: $failed")
-                }
-            },
-            { e -> Log.w("AppModule", "住所自動入力プリファレンスの設定に失敗", e) },
-        )
+        enableAddressAutofill()
         val storageDelegate = AutocompleteStorageDelegate(
             addressRepository = get(),
             coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main),
@@ -106,4 +78,42 @@ val appModule = module {
     factory { GeckoDownloadManager(androidContext(), get()) }
     viewModel { BrowserViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
     worker { DownloadWorker(get(), get(), get()) }
+}
+
+/**
+ * GeckoView の住所フォーム自動入力を有効にする。
+ *
+ * GeckoRuntimeSettings.Builder には loginAutofillEnabled() はあるが住所用の公開 API が
+ * ないため、GeckoPreferenceController で Gecko 内部プリファレンスを設定する。
+ * supported=on はリージョン判定 (detect) を回避して住所機能を常に利用可能にする。
+ */
+@OptIn(ExperimentalGeckoViewApi::class)
+private fun enableAddressAutofill() {
+    GeckoPreferenceController.setGeckoPrefs(
+        listOf(
+            GeckoPreferenceController.SetGeckoPreference.setBoolPref(
+                "extensions.formautofill.addresses.enabled",
+                true,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            ),
+            GeckoPreferenceController.SetGeckoPreference.setBoolPref(
+                "extensions.formautofill.addresses.capture.enabled",
+                true,
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            ),
+            GeckoPreferenceController.SetGeckoPreference.setStringPref(
+                "extensions.formautofill.addresses.supported",
+                "on",
+                GeckoPreferenceController.PREF_BRANCH_USER,
+            ),
+        ),
+    ).accept(
+        { results ->
+            val failed = results.orEmpty().filterValues { !it }.keys
+            if (failed.isNotEmpty()) {
+                Log.w("AppModule", "住所自動入力プリファレンスの設定に失敗: $failed")
+            }
+        },
+        { e -> Log.w("AppModule", "住所自動入力プリファレンスの設定に失敗", e) },
+    )
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -20,7 +20,7 @@ import net.matsudamper.browser.data.download.DownloadRepository
 import net.matsudamper.browser.data.history.HistoryRepository
 import net.matsudamper.browser.data.websuggestion.HttpWebSuggestionRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
-import java.io.File
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -29,6 +29,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
+import org.mozilla.geckoview.GeckoPreferenceController
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 
@@ -46,26 +47,46 @@ val dataModule = module {
 
 val appModule = module {
     single<GeckoRuntime> {
-        val context = androidContext()
-        // GeckoView の住所フォーム自動入力を有効にするための設定ファイルを準備する。
-        // GeckoRuntimeSettings.Builder には loginAutofillEnabled() はあるが
-        // 住所用の公開 API がないため、configFilePath 経由で Gecko 内部プリファレンスを設定する。
-        val geckoConfigFile = File(context.filesDir, "geckoview-config.yaml")
-        context.assets.open("geckoview-config.yaml").use { input ->
-            geckoConfigFile.outputStream().use { output ->
-                input.copyTo(output)
-            }
-        }
         val runtime = GeckoRuntime.create(
-            context,
+            androidContext(),
             GeckoRuntimeSettings.Builder()
-                .configFilePath(geckoConfigFile.absolutePath)
                 .forceUserScalableEnabled(true)
                 // ユーザーインストール拡張機能のバックグラウンドスクリプトを専用プロセスで実行し、
                 // webRequest.onBeforeRequest 等によるリクエストのブロッキングを有効にする。
                 // この設定がないと AdGuard などのコンテンツブロッカーが機能しない。
                 .extensionsProcessEnabled(true)
                 .build()
+        )
+        // GeckoView の住所フォーム自動入力を有効にする。
+        // GeckoRuntimeSettings.Builder には loginAutofillEnabled() はあるが住所用の公開 API が
+        // ないため、GeckoPreferenceController で Gecko 内部プリファレンスを設定する。
+        // supported=on はリージョン判定 (detect) を回避して住所機能を常に利用可能にする。
+        GeckoPreferenceController.setGeckoPrefs(
+            listOf(
+                GeckoPreferenceController.SetGeckoPreference.setBoolPref(
+                    "extensions.formautofill.addresses.enabled",
+                    true,
+                    GeckoPreferenceController.PREF_BRANCH_USER,
+                ),
+                GeckoPreferenceController.SetGeckoPreference.setBoolPref(
+                    "extensions.formautofill.addresses.capture.enabled",
+                    true,
+                    GeckoPreferenceController.PREF_BRANCH_USER,
+                ),
+                GeckoPreferenceController.SetGeckoPreference.setStringPref(
+                    "extensions.formautofill.addresses.supported",
+                    "on",
+                    GeckoPreferenceController.PREF_BRANCH_USER,
+                ),
+            ),
+        ).accept(
+            { results ->
+                val failed = results.orEmpty().filterValues { !it }.keys
+                if (failed.isNotEmpty()) {
+                    Log.w("AppModule", "住所自動入力プリファレンスの設定に失敗: $failed")
+                }
+            },
+            { e -> Log.w("AppModule", "住所自動入力プリファレンスの設定に失敗", e) },
         )
         val storageDelegate = AutocompleteStorageDelegate(
             addressRepository = get(),

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -8,16 +8,21 @@ import net.matsudamper.browser.GeckoDownloadManager
 import net.matsudamper.browser.MockLocationWebExtension
 import net.matsudamper.browser.ThemeColorWebExtension
 import net.matsudamper.browser.ViewportScaleWebExtension
+import net.matsudamper.browser.AutocompleteStorageDelegate
 import net.matsudamper.browser.data.BackupRepository
 import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.data.SiteSettingsRepository
 import net.matsudamper.browser.data.TabGroupRepository
 import net.matsudamper.browser.data.TabGroupRepositoryImpl
 import net.matsudamper.browser.data.TabRepository
+import net.matsudamper.browser.data.address.AddressRepository
 import net.matsudamper.browser.data.download.DownloadRepository
 import net.matsudamper.browser.data.history.HistoryRepository
 import net.matsudamper.browser.data.websuggestion.HttpWebSuggestionRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import net.matsudamper.browser.media.MediaWebExtension
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.workmanager.dsl.worker
@@ -34,12 +39,13 @@ val dataModule = module {
     single<TabGroupRepository> { TabGroupRepositoryImpl(androidContext()) }
     single { HistoryRepository(androidContext()) }
     single { DownloadRepository(androidContext()) }
+    single { AddressRepository(androidContext()) }
     single<WebSuggestionRepository> { HttpWebSuggestionRepository() }
 }
 
 val appModule = module {
     single<GeckoRuntime> {
-        GeckoRuntime.create(
+        val runtime = GeckoRuntime.create(
             androidContext(),
             GeckoRuntimeSettings.Builder()
                 .forceUserScalableEnabled(true)
@@ -49,6 +55,12 @@ val appModule = module {
                 .extensionsProcessEnabled(true)
                 .build()
         )
+        val storageDelegate = AutocompleteStorageDelegate(
+            addressRepository = get(),
+            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main),
+        )
+        runtime.autocompleteStorageDelegate = storageDelegate
+        runtime
     }
     // 拡張機能はプロセスに1つの GeckoRuntime に対してインストールするため single で管理
     single { ThemeColorWebExtension().also { it.install(get()) } }

--- a/data/schemas/net.matsudamper.browser.data.address.AddressDatabase/1.json
+++ b/data/schemas/net.matsudamper.browser.data.address.AddressDatabase/1.json
@@ -1,0 +1,115 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "f6357a4c1d1850ec985512f4043bdb53",
+    "entities": [
+      {
+        "tableName": "address",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `givenName` TEXT NOT NULL, `additionalName` TEXT NOT NULL, `familyName` TEXT NOT NULL, `organization` TEXT NOT NULL, `streetAddress` TEXT NOT NULL, `addressLevel1` TEXT NOT NULL, `addressLevel2` TEXT NOT NULL, `addressLevel3` TEXT NOT NULL, `postalCode` TEXT NOT NULL, `country` TEXT NOT NULL, `tel` TEXT NOT NULL, `email` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "givenName",
+            "columnName": "givenName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalName",
+            "columnName": "additionalName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "familyName",
+            "columnName": "familyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streetAddress",
+            "columnName": "streetAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressLevel1",
+            "columnName": "addressLevel1",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressLevel2",
+            "columnName": "addressLevel2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressLevel3",
+            "columnName": "addressLevel3",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postalCode",
+            "columnName": "postalCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tel",
+            "columnName": "tel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f6357a4c1d1850ec985512f4043bdb53')"
+    ]
+  }
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressDao.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressDao.kt
@@ -1,0 +1,31 @@
+package net.matsudamper.browser.data.address
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AddressDao {
+    @Insert
+    suspend fun insert(entity: AddressEntity): Long
+
+    @Update
+    suspend fun update(entity: AddressEntity)
+
+    @Query("SELECT * FROM address ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<AddressEntity>>
+
+    @Query("SELECT * FROM address ORDER BY updatedAt DESC")
+    suspend fun getAll(): List<AddressEntity>
+
+    @Query("SELECT * FROM address WHERE id = :id")
+    suspend fun getById(id: Long): AddressEntity?
+
+    @Query("DELETE FROM address WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM address")
+    suspend fun deleteAll()
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressDatabase.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressDatabase.kt
@@ -1,0 +1,26 @@
+package net.matsudamper.browser.data.address
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [AddressEntity::class], version = 1, exportSchema = true)
+abstract class AddressDatabase : RoomDatabase() {
+    abstract fun addressDao(): AddressDao
+
+    companion object {
+        @Volatile
+        private var instance: AddressDatabase? = null
+
+        fun getInstance(context: Context): AddressDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AddressDatabase::class.java,
+                    "address.db",
+                ).build().also { instance = it }
+            }
+        }
+    }
+}

--- a/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressEntity.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressEntity.kt
@@ -1,0 +1,23 @@
+package net.matsudamper.browser.data.address
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "address")
+data class AddressEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val givenName: String = "",
+    val additionalName: String = "",
+    val familyName: String = "",
+    val organization: String = "",
+    val streetAddress: String = "",
+    val addressLevel1: String = "",
+    val addressLevel2: String = "",
+    val addressLevel3: String = "",
+    val postalCode: String = "",
+    val country: String = "",
+    val tel: String = "",
+    val email: String = "",
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+)

--- a/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressRepository.kt
@@ -10,7 +10,12 @@ class AddressRepository(context: Context) {
     suspend fun save(entity: AddressEntity): Long {
         val existing = dao.getById(entity.id)
         return if (existing != null) {
-            dao.update(entity.copy(updatedAt = System.currentTimeMillis()))
+            dao.update(
+                entity.copy(
+                    createdAt = existing.createdAt,
+                    updatedAt = System.currentTimeMillis(),
+                ),
+            )
             entity.id
         } else {
             dao.insert(entity)

--- a/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/address/AddressRepository.kt
@@ -1,0 +1,29 @@
+package net.matsudamper.browser.data.address
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+
+class AddressRepository(context: Context) {
+    private val db = AddressDatabase.getInstance(context)
+    private val dao = db.addressDao()
+
+    suspend fun save(entity: AddressEntity): Long {
+        val existing = dao.getById(entity.id)
+        return if (existing != null) {
+            dao.update(entity.copy(updatedAt = System.currentTimeMillis()))
+            entity.id
+        } else {
+            dao.insert(entity)
+        }
+    }
+
+    suspend fun getAll(): List<AddressEntity> = dao.getAll()
+
+    fun observeAll(): Flow<List<AddressEntity>> = dao.observeAll()
+
+    suspend fun getById(id: Long): AddressEntity? = dao.getById(id)
+
+    suspend fun deleteById(id: Long) = dao.deleteById(id)
+
+    suspend fun deleteAll() = dao.deleteAll()
+}


### PR DESCRIPTION
## 概要
GeckoView の住所フォーム自動入力機能を実装しました。ユーザーが保存した住所情報を自動入力フォームから選択・保存できるようになります。

> [!WARNING]
> **現状は半分完成・半分ブロックの状態のため Draft にしています。**
> アプリ側の実装 (保存基盤・ダイアログ・プリファレンス有効化・capture パイプライン) は動作確認済みですが、
> 「サイトで入力した住所を保存しますか？」プロンプト (`onAddressSave`) だけが **GeckoView 152 本体の未実装** により発火しません。
> 詳細は下記「既知の制限」を参照。

## 主な変更

### データベース・リポジトリ層
- `AddressEntity`、`AddressDatabase`、`AddressDao`、`AddressRepository` を新規作成
- Room を使用した住所情報の永続化機能を実装
- 住所の CRUD 操作と Flow による監視機能を提供

### GeckoView 統合
- `AutocompleteStorageDelegate` を実装し、GeckoView の `Autocomplete.StorageDelegate` に対応
- 住所の取得・保存時に `AddressRepository` と連携
- `AddressEntity` ↔ `Autocomplete.Address` の相互変換機能を実装

### UI・ダイアログ
- `AddressSelectDialog`：保存済み住所から選択するダイアログ
- `AddressSaveDialog`：新規住所の保存確認ダイアログ
- `buildAddressDisplayText()` ユーティリティで住所情報を整形表示

### プロンプト処理
- `PromptDialogState` に `onAddressSelect()` と `onAddressSave()` メソッドを追加
- 住所選択・保存プロンプトの状態管理と確認・キャンセル処理を実装

### 設定・初期化
- 住所自動入力には公開 Builder API が無いため、`GeckoPreferenceController` (実験的 API) で Gecko 内部プリファレンスを設定
  - `extensions.formautofill.addresses.enabled` / `extensions.formautofill.addresses.capture.enabled` = true
  - `extensions.formautofill.addresses.supported` = "on" (リージョン判定を回避)
- `AppModule` に `AutocompleteStorageDelegate` と `AddressRepository` を DI 登録

## 実装の詳細
- 住所情報は postal code、address level 1～3、street address、tel、email を含む
- 日本語対応：ダイアログタイトルと表示テキストは日本語
- 非同期処理：住所の取得・保存は IO スレッドで実行
- エラーハンドリング：例外発生時はログ出力し、空配列を返す

## 既知の制限 (GeckoView 側の未実装)
Instrumentation テスト (`AddressAutofillPromptTest`) での検証により、**GeckoView 152.0.20260621 では住所の保存プロンプト (`PromptDelegate.onAddressSave`) が発火しない**ことが判明した。

- 原因: GeckoView 同梱の Android 版 `FormAutofillPrompter.promptToSaveAddress` が `NS_ERROR_NOT_IMPLEMENTED` を throw する未実装スタブのため (AAR 内 omni.ja のソースと logcat の JavaScript Error で確認)
- プリファレンス適用 → フィールド検出 → フォーム送信検出 → `_onAddressSubmit` 到達までの capture パイプラインは動作確認済みで、アプリ側実装の問題ではない
- クレジットカードの保存プロンプト (`promptToSaveCreditCard`) は同バージョンでも実装済み
- 住所の選択・自動入力 (`onAddressSelect`) は GeckoView 152 でも実装済みだが、保存プロンプトが動かないため現状は住所を DB へ登録する手段が無い
- テストは `@Ignore` で残し、GeckoView 更新後に有効化する

## 今後の対応 (このままマージ可能にする道)
1. **GeckoView を新しい nightly に更新する**
   mozilla-central の main には `promptToSaveAddress` の実装が入っているため、`152.0.20260621` より新しいビルドへ更新すれば保存プロンプトが動く可能性がある。更新後に `AddressAutofillPromptTest` の `@Ignore` を外して検証する。
2. **設定画面に住所管理 UI (手動登録・編集・削除) を追加する**
   選択・自動入力の経路は現バージョンでも動くため、手動登録があれば自動入力機能自体は先に提供できる。保存プロンプトは GeckoView 更新後に自動的に有効になる。

https://claude.ai/code/session_01HW12oVd2V86z4fothQ4zBL


## Summary by CodeRabbit

* **New Features**
  * Added address autofill support, including saving and selecting addresses during form prompts.
  * Added a new address book experience with persisted address data in the browser.
* **Bug Fixes**
  * Improved handling of address-related prompt flows to ensure selection and save dialogs complete correctly.
* **Tests**
  * Added an end-to-end test covering address form submission through the save prompt flow.
