### PR TITLE
タブのテーマカラーをツールバーに反映

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.viewmodel.compose.viewModel as composeViewModel
@@ -316,7 +317,7 @@ private fun BrowserAppContent(
                             previewHeaderContent = { modifier, tab, tabCount ->
                                 BrowserToolbar(
                                     modifier = modifier,
-                                    toolbarColor = null,
+                                    toolbarColor = tab.themeColor?.let { Color(it) },
                                     isFocused = false,
                                     onLongClickUrl = {},
                                     tabCount = tabCount,


### PR DESCRIPTION
## 概要
ブラウザツールバーのカラーをタブのテーマカラーに動的に反映するよう変更しました。

## 変更内容
- `BrowserToolbar` の `toolbarColor` パラメータに `null` を渡していた部分を、タブのテーマカラーを使用するように修正
  - `tab.themeColor?.let { Color(it) }` でタブのテーマカラーが存在する場合のみ適用
  - テーマカラーが存在しない場合は `null` となり、デフォルトカラーが使用される
- 必要な import を追加（`androidx.compose.ui.graphics.Color`）

## 実装詳細
プレビューヘッダーのツールバーが、訪問中のウェブサイトのテーマカラーを反映することで、より視覚的に統一されたUIを実現します。

https://claude.ai/code/session_01U3MUYeUAiHi3ws4bNXWekd