### PR TITLE
外部アプリナビゲーション確認ダイアログ中の後続ナビゲーションをキューイング

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -268,6 +268,9 @@ internal class BrowserTabScreenState(
     // --- ファイルダウンロード確認ダイアログ用state ---
     var pendingDownloadResponse by mutableStateOf<WebResponse?>(null)
     var pendingExternalAppLaunch by mutableStateOf<PendingExternalAppLaunch?>(null)
+    // 外部アプリ確認ダイアログ表示中に到着した後続の外部アプリナビゲーション。
+    // ダイアログをキャンセルした場合にこちらを表示する（アプリ起動した場合は破棄する）。
+    private var queuedExternalAppLaunch: PendingExternalAppLaunch? = null
 
     // --- ダウンロード重複確認ダイアログ用state ---
     var duplicateDownloadState by mutableStateOf<DuplicateDownloadState?>(null)
@@ -792,6 +795,7 @@ internal class BrowserTabScreenState(
     fun confirmPendingExternalAppLaunch() {
         val request = pendingExternalAppLaunch ?: return
         pendingExternalAppLaunch = null
+        queuedExternalAppLaunch = null
         val result = launchExternalApp(context, request)
         if (result.isSuccess) {
             return
@@ -807,6 +811,7 @@ internal class BrowserTabScreenState(
 
     fun dismissPendingExternalAppLaunch() {
         pendingExternalAppLaunch = null
+        promoteQueuedExternalAppLaunch()
     }
 
     /**
@@ -819,6 +824,13 @@ internal class BrowserTabScreenState(
         val request = pendingExternalAppLaunch ?: return
         pendingExternalAppLaunch = null
 
+        val queued = queuedExternalAppLaunch
+        queuedExternalAppLaunch = null
+        if (queued != null) {
+            pendingExternalAppLaunch = queued
+            return
+        }
+
         val url = if (request.sourceUri.startsWith("http://") || request.sourceUri.startsWith("https://")) {
             request.sourceUri
         } else {
@@ -828,6 +840,12 @@ internal class BrowserTabScreenState(
             skipExternalAppCheckForNextLoad = true
             openFallbackUrl(url)
         }
+    }
+
+    private fun promoteQueuedExternalAppLaunch() {
+        val queued = queuedExternalAppLaunch ?: return
+        queuedExternalAppLaunch = null
+        pendingExternalAppLaunch = queued
     }
 
     fun restoreCurrentPageUrlToInput() {
@@ -1192,6 +1210,16 @@ internal class BrowserTabScreenState(
         if (skipExternalAppCheckForNextLoad) {
             skipExternalAppCheckForNextLoad = false
             return null
+        }
+        // 外部アプリ確認ダイアログを表示中に後続のナビゲーションが来た場合、
+        // ダイアログを上書きせずキューに入れる。ダイアログをキャンセルした場合に
+        // キューの内容（Play Store 等）を表示し、アプリ起動した場合は破棄する。
+        if (pendingExternalAppLaunch != null) {
+            val externalAction = resolveExternalAppNavigationAction(context, request.uri)
+            if (externalAction is ExternalAppNavigationAction.Launch) {
+                queuedExternalAppLaunch = externalAction.request
+            }
+            return GeckoResult.fromValue(AllowOrDeny.DENY)
         }
         val externalAction = resolveExternalAppNavigationAction(context, request.uri)
         // single-page モードで TARGET_WINDOW_NEW は外部アプリ判定を先に通してから現在タブへ畳み込む

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -795,17 +795,20 @@ internal class BrowserTabScreenState(
     fun confirmPendingExternalAppLaunch() {
         val request = pendingExternalAppLaunch ?: return
         pendingExternalAppLaunch = null
-        queuedExternalAppLaunch = null
         val result = launchExternalApp(context, request)
         if (result.isSuccess) {
+            queuedExternalAppLaunch = null
             return
         }
 
         val fallbackUrl = request.fallbackUrl
         if (fallbackUrl != null) {
+            queuedExternalAppLaunch = null
             openFallbackUrl(fallbackUrl)
             return
         }
+        promoteQueuedExternalAppLaunch()
+        if (pendingExternalAppLaunch != null) return
         Toast.makeText(context, "対応するアプリを開けませんでした", Toast.LENGTH_SHORT).show()
     }
 


### PR DESCRIPTION
## 概要
外部アプリ確認ダイアログ表示中に後続の外部アプリナビゲーションが発生した場合、ダイアログを上書きせずキューに入れるようにしました。ユーザーがダイアログをキャンセルした場合はキューの内容を表示し、アプリ起動した場合はキューを破棄します。

## 主な変更

- **キューイング機構の追加**
  - `queuedExternalAppLaunch` プロパティを追加して、ダイアログ表示中に到着した後続ナビゲーションを保持
  - コメントで動作仕様を明記

- **ダイアログ確認時の処理**
  - `confirmPendingExternalAppLaunch()` でキューをクリア

- **ダイアログキャンセル時の処理**
  - `dismissPendingExternalAppLaunch()` で `promoteQueuedExternalAppLaunch()` を呼び出し、キューの内容をペンディング状態に昇格

- **キュー昇格ロジック**
  - `promoteQueuedExternalAppLaunch()` メソッドを新規追加
  - `onLoadRequest()` 内でも同様のロジックを実装し、ダイアログ表示中のナビゲーション要求をキューに入れる

- **ナビゲーション要求時の処理**
  - `onLoadRequest()` でペンディングダイアログが存在する場合、新しい外部アプリナビゲーション要求をキューに入れて `DENY` を返す
  - これにより、ダイアログが複数表示されることを防止

## 実装の詳細
ダイアログ表示中に複数のナビゲーション要求が来た場合、最後の要求のみがキューに保持されます。ユーザーの操作（確認またはキャンセル）に応じて、キューの内容が適切に処理されます。

https://claude.ai/code/session_01WiDtdTLjNwE9zFVnnCugVX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of consecutive external-app launch requests while the confirmation dialog is open.
  * Incoming launch requests are now queued, so the current prompt isn’t overwritten and no navigations are missed.
  * Confirming or dismissing the dialog now correctly advances to the next queued request, including avoiding immediate in-browser navigation when a queued launch exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->