### PR TITLE
Predictive Back Gesture対応とジェスチャー中のコンテキストメニュー抑制

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -174,6 +174,9 @@ internal class BrowserTabScreenState(
     /** 無効な正規表現が入力された場合のエラーメッセージ */
     var findQueryError by mutableStateOf<String?>(null)
 
+    // --- Back gesture state ---
+    var isBackGestureInProgress by mutableStateOf(false)
+
     // --- Context menu state ---
     var contextMenuState by mutableStateOf<ContextMenuState?>(null)
         private set
@@ -1087,6 +1090,7 @@ internal class BrowserTabScreenState(
     }
 
     override fun onContextMenu(element: GeckoSession.ContentDelegate.ContextElement) {
+        if (isBackGestureInProgress) return
         val linkUri = element.linkUri
         val srcUri = element.srcUri
         val isImage = element.type == GeckoSession.ContentDelegate.ContextElement.TYPE_IMAGE

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -11,7 +11,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import androidx.core.net.toUri
-import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -671,13 +671,19 @@ internal fun GeckoBrowserTab(
     // webAppMode かつ canGoBack=false 時は Activity を終了せずタスクをバックグラウンドへ移動して
     // セッション（ブラウザ履歴・入力状態）を保持する
     val activity = LocalActivity.current
-    BackHandler(enabled = state.isFullScreen || state.showFindInPage || state.isUrlInputFocused || state.canGoBack || webAppMode) {
-        when {
-            state.isFullScreen -> state.exitFullScreen()
-            state.showFindInPage -> state.closeFindInPage()
-            state.isUrlInputFocused -> closeUrlInput(true)
-            state.canGoBack -> state.onGoBack()
-            webAppMode -> activity?.moveTaskToBack(true)
+    PredictiveBackHandler(enabled = state.isFullScreen || state.showFindInPage || state.isUrlInputFocused || state.canGoBack || webAppMode) { progress ->
+        state.isBackGestureInProgress = true
+        try {
+            progress.collect {}
+            when {
+                state.isFullScreen -> state.exitFullScreen()
+                state.showFindInPage -> state.closeFindInPage()
+                state.isUrlInputFocused -> closeUrlInput(true)
+                state.canGoBack -> state.onGoBack()
+                webAppMode -> activity?.moveTaskToBack(true)
+            }
+        } finally {
+            state.isBackGestureInProgress = false
         }
     }
 


### PR DESCRIPTION
## 概要

Android 13以降の予測的バックジェスチャー（Predictive Back Gesture）に対応しました。ジェスチャー実行中はコンテキストメニューの表示を抑制し、ユーザー体験を向上させます。

## 主な変更

- **BackHandler → PredictiveBackHandler への移行**
  - `androidx.activity.compose.BackHandler` から `PredictiveBackHandler` に変更
  - ジェスチャーの進捗状態（progress）を監視するコールバック構造に対応

- **バックジェスチャー状態の追跡**
  - `BrowserTabScreenState` に `isBackGestureInProgress` フラグを追加
  - ジェスチャー実行中は `true`、完了時に `false` に設定

- **コンテキストメニュー表示の制御**
  - `onContextMenu()` でジェスチャー実行中の場合は早期リターン
  - ジェスチャー中の誤操作によるメニュー表示を防止

## 実装詳細

- `progress.collect {}` でジェスチャーの完了を待機
- try-finally ブロックで確実に状態をリセット
- 既存のバックハンドラロジック（フルスクリーン終了、検索パネル閉鎖など）は変更なし

https://claude.ai/code/session_014YXNVpaUR1i1RXWmLUmvYM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android back gesture behavior so context menus no longer appear while a back swipe is in progress.
  * Made back navigation feel smoother and more reliable during predictive back actions in fullscreen, search, address bar, and web app mode states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->