### PR TITLE
Upgrade compileSdk to 37 across all modules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ val useCiDebugKeystore = ciDebugKeystoreFile != null && ciDebugKeystoreFile.exis
 
 android {
     namespace = "net.matsudamper.browser"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "net.matsudamper.browser"

--- a/browser-engine-gecko/build.gradle.kts
+++ b/browser-engine-gecko/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.engine"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.data"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/feature-browser/build.gradle.kts
+++ b/feature-browser/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.feature.browser"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/feature-tabs/build.gradle.kts
+++ b/feature-tabs/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.feature.tabs"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.resources"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/browser/build.gradle.kts
+++ b/ui/browser/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.browser"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/common/build.gradle.kts
+++ b/ui/common/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.common"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/downloads/build.gradle.kts
+++ b/ui/downloads/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.downloads"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/extensions/build.gradle.kts
+++ b/ui/extensions/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.extensions"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/history/build.gradle.kts
+++ b/ui/history/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.history"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/settings/build.gradle.kts
+++ b/ui/settings/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.settings"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/ui/tabs/build.gradle.kts
+++ b/ui/tabs/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "net.matsudamper.browser.ui.tabs"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30


### PR DESCRIPTION
## 概要
すべてのモジュールの `compileSdk` を 36 から 37 に更新しました。

## 変更内容
以下の 13 モジュールの `build.gradle.kts` で `compileSdk` を 37 に統一:
- app
- browser-engine-gecko
- data
- feature-browser
- feature-tabs
- resources
- ui/browser
- ui/common
- ui/downloads
- ui/extensions
- ui/history
- ui/settings
- ui/tabs

## 実装の詳細
- Android SDK 37（Android 15）に対応するための compileSdk バージョン統一
- 各モジュールの `minSdk` は変更なし（既存の互換性を維持）
- ビルド確認済み

https://claude.ai/code/session_019kJMhNCkyJV6rnNu65N7yz