### PR TITLE
メインスレッド監視機能と拡張プロセス設定の追加

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -457,6 +457,15 @@ private fun BrowserAppContent(
                                     override fun onNavigateToBackupProgress(isImport: Boolean) {
                                         backStack.add(AppDestination.BackupProgress(isImport))
                                     }
+
+                                    override fun onRestartProcess() {
+                                        android.os.Handler(android.os.Looper.getMainLooper())
+                                            .postDelayed({
+                                                android.os.Process.killProcess(
+                                                    android.os.Process.myPid(),
+                                                )
+                                            }, 300)
+                                    }
                                 })
                             }
                         }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -3,6 +3,9 @@ package net.matsudamper.browser
 import android.Manifest
 import android.content.Intent
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.os.Process
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
@@ -459,10 +462,10 @@ private fun BrowserAppContent(
                                     }
 
                                     override fun onRestartProcess() {
-                                        android.os.Handler(android.os.Looper.getMainLooper())
+                                        Handler(Looper.getMainLooper())
                                             .postDelayed({
-                                                android.os.Process.killProcess(
-                                                    android.os.Process.myPid(),
+                                                Process.killProcess(
+                                                    Process.myPid(),
                                                 )
                                             }, 300)
                                     }

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApplication.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApplication.kt
@@ -23,6 +23,7 @@ class BrowserApplication : Application() {
             workManagerFactory()
             modules(dataModule, appModule)
         }
+        MainThreadWatchdog().start()
     }
 
     private fun cleanFilePromptsCache() {

--- a/app/src/main/kotlin/net/matsudamper/browser/MainThreadWatchdog.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/MainThreadWatchdog.kt
@@ -1,0 +1,59 @@
+package net.matsudamper.browser
+
+import android.os.Debug
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.os.Process
+import android.util.Log
+
+/**
+ * メインスレッドの応答性を監視し、デッドロック検知時にプロセスをキルして復旧する。
+ *
+ * GeckoView の子プロセス（拡張プロセス等）が OS にキルされた場合、
+ * Gecko エンジン内部でメインスレッドがデッドロックし、スプラッシュ画面のまま
+ * 完全にフリーズすることがある。
+ * 定期的にメインスレッドへハートビートを投稿し、一定時間応答がなければ
+ * プロセスをキルして Android に再起動させる。
+ */
+internal class MainThreadWatchdog {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    @Volatile
+    private var heartbeatAcknowledged = true
+
+    fun start() {
+        val thread = HandlerThread("MainThreadWatchdog").apply {
+            isDaemon = true
+            start()
+        }
+        val watchdogHandler = Handler(thread.looper)
+        watchdogHandler.postDelayed(
+            { runCheck(watchdogHandler) },
+            STARTUP_GRACE_MS,
+        )
+    }
+
+    private fun runCheck(watchdogHandler: Handler) {
+        heartbeatAcknowledged = false
+        mainHandler.post { heartbeatAcknowledged = true }
+        watchdogHandler.postDelayed({
+            if (!heartbeatAcknowledged && !Debug.isDebuggerConnected()) {
+                Log.e(
+                    TAG,
+                    "メインスレッドが ${TIMEOUT_MS}ms 応答なし。プロセスを再起動します",
+                )
+                Process.killProcess(Process.myPid())
+                return@postDelayed
+            }
+            runCheck(watchdogHandler)
+        }, TIMEOUT_MS)
+    }
+
+    private companion object {
+        private const val TAG = "MainThreadWatchdog"
+        private const val TIMEOUT_MS = 8_000L
+        // 起動直後は GeckoRuntime.create() 等でメインスレッドが占有されるため猶予を設ける
+        private const val STARTUP_GRACE_MS = 15_000L
+    }
+}

--- a/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/di/AppModule.kt
@@ -18,9 +18,12 @@ import net.matsudamper.browser.data.TabGroupRepositoryImpl
 import net.matsudamper.browser.data.TabRepository
 import net.matsudamper.browser.data.download.DownloadRepository
 import net.matsudamper.browser.data.history.HistoryRepository
+import net.matsudamper.browser.data.resolvedExtensionsProcessEnabled
 import net.matsudamper.browser.data.websuggestion.HttpWebSuggestionRepository
 import net.matsudamper.browser.data.websuggestion.WebSuggestionRepository
 import net.matsudamper.browser.media.MediaWebExtension
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.workmanager.dsl.worker
 import org.koin.core.module.dsl.viewModel
@@ -41,14 +44,15 @@ val dataModule = module {
 
 val appModule = module {
     single<GeckoRuntime> {
+        val settings = get<SettingsRepository>()
+        val extensionsProcessEnabled = runBlocking {
+            settings.settings.first().resolvedExtensionsProcessEnabled()
+        }
         GeckoRuntime.create(
             androidContext(),
             GeckoRuntimeSettings.Builder()
                 .forceUserScalableEnabled(true)
-                // ユーザーインストール拡張機能のバックグラウンドスクリプトを専用プロセスで実行し、
-                // webRequest.onBeforeRequest 等によるリクエストのブロッキングを有効にする。
-                // この設定がないと AdGuard などのコンテンツブロッカーが機能しない。
-                .extensionsProcessEnabled(true)
+                .extensionsProcessEnabled(extensionsProcessEnabled)
                 .build()
         )
     }

--- a/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/screen/settings/SettingsScreenViewModel.kt
@@ -18,6 +18,7 @@ import net.matsudamper.browser.data.SettingsRepository
 import net.matsudamper.browser.data.ThemeMode
 import net.matsudamper.browser.data.TranslationProvider
 import net.matsudamper.browser.data.resolvedEnableWebSuggestions
+import net.matsudamper.browser.data.resolvedExtensionsProcessEnabled
 import net.matsudamper.browser.ui.settings.SettingsScreenUiState
 
 internal class SettingsScreenViewModel(
@@ -35,6 +36,10 @@ internal class SettingsScreenViewModel(
     // 確認ダイアログの表示状態
     private val backupConfirmDialogFlow =
         MutableStateFlow<SettingsScreenUiState.BackupConfirmType?>(null)
+
+    // 拡張プロセス設定変更時の再起動確認ダイアログ
+    private val extensionsProcessRestartDialogFlow = MutableStateFlow(false)
+    private var pendingExtensionsProcessEnabled: Boolean? = null
 
     private val callbacks = object : SettingsScreenUiState.Callbacks {
         override fun setHomepageType(type: HomepageType) {
@@ -67,6 +72,26 @@ internal class SettingsScreenViewModel(
 
         override fun setEnableWebSuggestions(enabled: Boolean) {
             viewModelScope.launch { settingsRepository.setEnableWebSuggestions(enabled) }
+        }
+
+        override fun setExtensionsProcessEnabled(enabled: Boolean) {
+            pendingExtensionsProcessEnabled = enabled
+            extensionsProcessRestartDialogFlow.value = true
+        }
+
+        override fun confirmExtensionsProcessRestart() {
+            val enabled = pendingExtensionsProcessEnabled ?: return
+            extensionsProcessRestartDialogFlow.value = false
+            pendingExtensionsProcessEnabled = null
+            viewModelScope.launch {
+                settingsRepository.setExtensionsProcessEnabled(enabled)
+                eventHandler.trySend { it.onRestartProcess() }
+            }
+        }
+
+        override fun dismissExtensionsProcessRestartDialog() {
+            extensionsProcessRestartDialogFlow.value = false
+            pendingExtensionsProcessEnabled = null
         }
 
         override fun setMockLocationInput(input: String) {
@@ -108,8 +133,10 @@ internal class SettingsScreenViewModel(
                 combine(
                     settingsRepository.settings,
                     backupConfirmDialogFlow,
-                ) { settings, confirmDialog -> settings to confirmDialog }
-                    .collectLatest { (settings, confirmDialog) ->
+                    extensionsProcessRestartDialogFlow,
+                ) { settings, confirmDialog, restartDialog ->
+                    Triple(settings, confirmDialog, restartDialog)
+                }.collectLatest { (settings, confirmDialog, restartDialog) ->
                     // 初回だけ入力欄をリポジトリの値で初期化する
                     if (!mockLocationInputInitialized) {
                         mockLocationInputFlow.value = formatMockLocationInput(
@@ -123,6 +150,7 @@ internal class SettingsScreenViewModel(
                             callbacks = callbacks,
                             mockLocationInput = mockLocationInputFlow.value,
                             backupConfirmDialog = confirmDialog,
+                            extensionsProcessRestartDialog = restartDialog,
                         )
                     }
                     // 拡張機能への反映は BrowserViewModel が設定の Flow を監視して行う
@@ -146,6 +174,8 @@ internal class SettingsScreenViewModel(
         fun onOpenMockLocationOnMap()
         /** バックアップ進行画面に遷移する */
         fun onNavigateToBackupProgress(isImport: Boolean)
+        /** 拡張プロセス設定変更のためプロセスを再起動する */
+        fun onRestartProcess()
     }
 }
 
@@ -196,6 +226,7 @@ private fun BrowserSettings.toUiState(
     callbacks: SettingsScreenUiState.Callbacks,
     mockLocationInput: String,
     backupConfirmDialog: SettingsScreenUiState.BackupConfirmType?,
+    extensionsProcessRestartDialog: Boolean,
 ): SettingsScreenUiState {
     return SettingsScreenUiState(
         callbacks = callbacks,
@@ -207,8 +238,10 @@ private fun BrowserSettings.toUiState(
         translationProvider = translationProvider,
         enableThirdPartyCa = enableThirdPartyCa,
         enableWebSuggestions = resolvedEnableWebSuggestions(),
+        extensionsProcessEnabled = resolvedExtensionsProcessEnabled(),
         mockLocationInput = mockLocationInput,
         mockLocationInputError = validateMockLocationInput(mockLocationInput),
         backupConfirmDialog = backupConfirmDialog,
+        extensionsProcessRestartDialog = extensionsProcessRestartDialog,
     )
 }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
@@ -34,6 +34,13 @@ class SettingsRepository(context: Context) {
                         clearEnableWebSuggestions()
                     }
                 }
+                .apply {
+                    if (settings.hasExtensionsProcessEnabled()) {
+                        setExtensionsProcessEnabled(settings.extensionsProcessEnabled)
+                    } else {
+                        clearExtensionsProcessEnabled()
+                    }
+                }
                 .build()
         }
     }

--- a/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
+++ b/data/src/main/kotlin/net/matsudamper/browser/data/SettingsRepository.kt
@@ -102,6 +102,14 @@ class SettingsRepository(context: Context) {
         }
     }
 
+    suspend fun setExtensionsProcessEnabled(enabled: Boolean) {
+        dataStore.updateData { current ->
+            current.toBuilder()
+                .setExtensionsProcessEnabled(enabled)
+                .build()
+        }
+    }
+
     suspend fun setMockLocationCoordinates(latitude: Double, longitude: Double) {
         dataStore.updateData { current ->
             current.toBuilder()
@@ -138,6 +146,14 @@ fun BrowserSettings.resolvedSearchTemplate(): String = when (searchProvider) {
     SearchProvider.DUCKDUCKGO -> "https://duckduckgo.com/?q=%s"
     SearchProvider.CUSTOM -> customSearchUrl.ifBlank { "https://www.google.com/search?q=%s" }
     else -> "https://www.google.com/search?q=%s"
+}
+
+fun BrowserSettings.resolvedExtensionsProcessEnabled(): Boolean {
+    return if (hasExtensionsProcessEnabled()) {
+        extensionsProcessEnabled
+    } else {
+        true
+    }
 }
 
 fun BrowserSettings.resolvedEnableWebSuggestions(): Boolean {

--- a/proto/src/main/proto/browser_settings.proto
+++ b/proto/src/main/proto/browser_settings.proto
@@ -41,4 +41,5 @@ message BrowserSettings {
   bool mock_location_enabled = 12 [deprecated = true];
   double mock_location_latitude = 13;
   double mock_location_longitude = 14;
+  optional bool extensions_process_enabled = 15;
 }

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -341,6 +341,38 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(betweenPadding))
 
+            SettingSection(title = "拡張プロセス") {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .toggleable(
+                            value = uiState.extensionsProcessEnabled,
+                            role = Role.Switch,
+                            onValueChange = uiState.callbacks::setExtensionsProcessEnabled,
+                        )
+                        .padding(vertical = 4.dp),
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "拡張機能を別プロセスで実行",
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text(
+                            text = "AdGuard等のコンテンツブロッカーに必要です。無効にするとフリーズが改善する場合があります。変更にはアプリの再起動が必要です",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Switch(
+                        checked = uiState.extensionsProcessEnabled,
+                        onCheckedChange = null,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(betweenPadding))
+
             SettingSection(title = "拡張機能") {
                 TextButton(
                     onClick = onOpenExtensions,
@@ -365,6 +397,26 @@ fun SettingsScreen(
             Spacer(Modifier.height(8.dp))
             Spacer(Modifier.padding(bottom = paddingValues.calculateBottomPadding()))
         }
+    }
+
+    if (uiState.extensionsProcessRestartDialog) {
+        AlertDialog(
+            onDismissRequest = uiState.callbacks::dismissExtensionsProcessRestartDialog,
+            title = { Text("アプリを再起動しますか？") },
+            text = {
+                Text("拡張プロセスの設定を変更するにはアプリの再起動が必要です。")
+            },
+            confirmButton = {
+                Button(onClick = uiState.callbacks::confirmExtensionsProcessRestart) {
+                    Text("再起動")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = uiState.callbacks::dismissExtensionsProcessRestartDialog) {
+                    Text("キャンセル")
+                }
+            },
+        )
     }
 
     // バックアップ操作の確認ダイアログ（設定画面の上に重ねて表示する）
@@ -433,6 +485,9 @@ private fun SettingsScreenPreview() {
                     override fun setTranslationProvider(provider: TranslationProvider) = Unit
                     override fun setEnableThirdPartyCa(enabled: Boolean) = Unit
                     override fun setEnableWebSuggestions(enabled: Boolean) = Unit
+                    override fun setExtensionsProcessEnabled(enabled: Boolean) = Unit
+                    override fun confirmExtensionsProcessRestart() = Unit
+                    override fun dismissExtensionsProcessRestartDialog() = Unit
                     override fun setMockLocationInput(input: String) = Unit
                     override fun openMockLocationOnMap() = Unit
                     override fun requestBackupExport() = Unit
@@ -448,9 +503,11 @@ private fun SettingsScreenPreview() {
                 translationProvider = TranslationProvider.TRANSLATION_PROVIDER_GECKO,
                 enableThirdPartyCa = false,
                 enableWebSuggestions = false,
+                extensionsProcessEnabled = true,
                 mockLocationInput = "35.685175,139.752797",
                 mockLocationInputError = null,
                 backupConfirmDialog = null,
+                extensionsProcessRestartDialog = false,
             ),
             onOpenExtensions = {},
             onOpenHistory = {},

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreenUiState.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreenUiState.kt
@@ -17,9 +17,11 @@ data class SettingsScreenUiState(
     val translationProvider: TranslationProvider,
     val enableThirdPartyCa: Boolean,
     val enableWebSuggestions: Boolean,
+    val extensionsProcessEnabled: Boolean,
     val mockLocationInput: String,
     val mockLocationInputError: String?,
     val backupConfirmDialog: BackupConfirmType?,
+    val extensionsProcessRestartDialog: Boolean,
 ) {
     enum class BackupConfirmType { Export, Import }
 
@@ -32,6 +34,9 @@ data class SettingsScreenUiState(
         fun setTranslationProvider(provider: TranslationProvider)
         fun setEnableThirdPartyCa(enabled: Boolean)
         fun setEnableWebSuggestions(enabled: Boolean)
+        fun setExtensionsProcessEnabled(enabled: Boolean)
+        fun confirmExtensionsProcessRestart()
+        fun dismissExtensionsProcessRestartDialog()
         fun setMockLocationInput(input: String)
         fun openMockLocationOnMap()
         /** バックアップのエクスポートを要求する（確認ダイアログを表示） */


### PR DESCRIPTION
## 概要

GeckoView の拡張プロセスが OS にキルされた際のメインスレッドデッドロック対策として、監視・自動復旧機能と拡張プロセスのオン・オフ設定を追加しました。

#516 から関連コードのみを main ベースで切り出した PR です（動作確認用）。GeckoRuntime 初期化の遅延（UI先行表示）は #519 でマージ済みのため含まれません。

## 主な変更

### MainThreadWatchdog の追加
- メインスレッドの応答性を定期的に監視する新しいクラスを実装
- 8秒以上応答がない場合、プロセスをキルして Android に再起動させる
- 起動直後の GeckoRuntime.create() による占有を考慮し、15秒の猶予期間を設定
- デバッガ接続時はプロセスキルを実行しない
- `BrowserApplication.onCreate()` で自動起動

### 拡張プロセス設定の追加
- 設定画面に「拡張機能を別プロセスで実行」トグルを追加
- 設定変更時に再起動確認ダイアログを表示し、確定後にプロセスを再起動
- Proto バッファに `extensions_process_enabled` フィールドを追加
- `GeckoRuntimeSettings.Builder.extensionsProcessEnabled()` を設定値に基づいて動的に設定
- バックアップの復元時にも設定値が正しく伝搬されるよう `updateSettings()` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Spj9vEFoUmzcJHXrCKBhy

---
_Generated by [Claude Code](https://claude.ai/code/session_012Spj9vEFoUmzcJHXrCKBhy)_