### PR TITLE
予測型バックでリンク開きタブから opener タブへ戻る機能を追加

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -329,6 +329,18 @@ private fun BrowserAppContent(
                             onSelectTab = { tabId ->
                                 selectTab(tabId, null)
                             },
+                            onBackToOpenerTab = { tabId ->
+                                // リンクから開いたタブを予測型バックで閉じ、opener タブへ戻る。
+                                // opener が存在すればそれを、なければ closeTab が選んだタブを選択する。
+                                val openerTabId = browserTabController.findTab(tabId)?.openerTabId
+                                val fallbackTabId = browserTabController.closeTab(tabId)
+                                val targetTabId = openerTabId
+                                    ?.takeIf { browserTabController.findTab(it) != null }
+                                    ?: fallbackTabId
+                                if (targetTabId != null) {
+                                    selectTab(targetTabId, null)
+                                }
+                            },
                             previewHeaderContent = { modifier, tab, tabCount ->
                                 BrowserToolbar(
                                     modifier = modifier,

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserTabScreenState.kt
@@ -1035,6 +1035,8 @@ internal class BrowserTabScreenState(
 
     override fun onCanGoBackChanged(value: Boolean) {
         canGoBack = value
+        // BrowserScreen 側で opener タブへの予測型バック可否を判定するため BrowserTab にも反映する
+        browserTab.canGoBack = value
     }
 
     override fun onCanGoForwardChanged(value: Boolean) {

--- a/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
+++ b/browser-engine-gecko/src/main/kotlin/net/matsudamper/browser/BrowserTab.kt
@@ -84,6 +84,12 @@ class BrowserTab(
             onThemeColorChanged(tabId, value)
         }
 
+    // このタブが現在ページ内で「戻る」履歴を持つか（永続化は不要）。
+    // GeckoBrowserTab がフォアグラウンドのとき onCanGoBackChanged で更新される。
+    // リンクから開いたタブが未遷移(canGoBack=false)かどうかの判定に使用し、
+    // その状態でのみ予測型バックで opener タブへ戻す。
+    var canGoBack: Boolean by mutableStateOf(false)
+
     // ページのfavicon（ホーム追加時のアイコンに使用、永続化は不要）
     var faviconBitmap: Bitmap? by mutableStateOf(null)
 

--- a/ui/browser/build.gradle.kts
+++ b/ui/browser/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
+++ b/ui/browser/src/main/kotlin/net/matsudamper/browser/ui/browser/BrowserScreen.kt
@@ -2,6 +2,7 @@ package net.matsudamper.browser.ui.browser
 
 import android.graphics.BitmapFactory
 import android.util.Log
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
@@ -33,6 +34,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import net.matsudamper.browser.BrowserTab
 import net.matsudamper.browser.BrowserTabController
@@ -45,6 +47,7 @@ fun BrowserScreen(
     uiState: BrowserScreenUiState,
     browserTabController: BrowserTabController,
     onSelectTab: (String) -> Unit,
+    onBackToOpenerTab: (tabId: String) -> Unit,
     previewHeaderContent: @Composable (modifier: Modifier, tab: BrowserTab, tabCount: Int?) -> Unit,
     browserTabContent: @Composable (
         modifier: Modifier,
@@ -110,6 +113,29 @@ fun BrowserScreen(
         val density = LocalDensity.current
         // タブ切替スワイプ閾値：割合と固定距離の短い方を使用（タブレット等の広い画面でも操作しやすくなる）
         val swipeThreshold = minOf(pageWidthPx * 0.3f, with(density) { 120.dp.toPx() })
+
+        // リンクから開いたタブ（opener あり）で、まだページ内を遷移しておらず
+        // (canGoBack=false)、前のタブが opener 本人である場合のみ予測型バックを有効化する。
+        // この状態でのバックは「タブを閉じて opener へ戻る」ため、前のタブへスライドさせる。
+        val backToOpenerEnabled = prevTab != null &&
+            selectedTab.openerTabId != null &&
+            prevTab.tabId == selectedTab.openerTabId &&
+            !selectedTab.canGoBack
+        PredictiveBackHandler(enabled = backToOpenerEnabled) { progress ->
+            try {
+                // ジェスチャーの進捗に合わせて現在タブを右へずらし、左から opener タブを覗かせる
+                progress.collect { backEvent ->
+                    swipeOffset.snapTo(pageWidthPx * backEvent.progress)
+                }
+                // コミット：opener タブを画面いっぱいまでスライドさせてから現在タブを閉じて戻る
+                swipeOffset.animateTo(pageWidthPx)
+                onBackToOpenerTab(selectedTab.tabId)
+            } catch (e: CancellationException) {
+                // キャンセル：元の位置へ戻す（handler のコルーチンは終了するため別スコープで実行）
+                coroutineScope.launch { swipeOffset.animateTo(0f) }
+                throw e
+            }
+        }
 
         // 前のタブのプレビュー画像（右スワイプ時に左から表示）
         prevTab?.let { tab ->


### PR DESCRIPTION
## 概要

Android 14 の予測型バック（Predictive Back）ジェスチャーに対応し、リンクから開いたタブ（opener あり）で、まだページ内を遷移していない状態（canGoBack=false）の場合、バックジェスチャーで opener タブへ戻る機能を実装しました。

## 主な変更

- **BrowserScreen.kt**: `PredictiveBackHandler` を追加し、以下の条件を満たす場合に有効化
  - 前のタブが現在タブの opener である
  - 現在タブが canGoBack=false（ページ内遷移なし）
  - ジェスチャー進捗に合わせて現在タブを右へスライドさせ、左から opener タブを表示
  - コミット時に opener タブへ遷移、キャンセル時に元の位置へ戻す

- **BrowserApp.kt**: `onBackToOpenerTab` コールバックを実装
  - タブを閉じて opener タブを選択、または fallback タブを選択

- **BrowserTab.kt**: `canGoBack` プロパティを追加
  - ページ内の戻る履歴の有無を管理（永続化不要）

- **BrowserTabScreenState.kt**: `onCanGoBackChanged` で `BrowserTab.canGoBack` を更新
  - BrowserScreen 側で予測型バック可否を判定するため

- **build.gradle.kts**: `androidx.activity.compose` 依存を追加

## 実装の詳細

予測型バックのジェスチャーキャンセル時は handler のコルーチンが終了するため、別スコープ（coroutineScope.launch）でアニメーションを実行し、元の位置へ戻します。

https://claude.ai/code/session_01CeBCkuEH6x624Z53ivFtTR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added predictive back navigation for tabs opened from another tab.
  * Swipe-back gestures can now reveal and return to the opener tab when no in-tab history is available.
  * If the opener tab is no longer available, the current tab closes and navigation falls back automatically.

* **Bug Fixes**
  * Improved tracking of whether a tab can navigate back, ensuring back behavior reflects the current browsing history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->