### PR TITLE
予測型バック時のwebAppMode処理を削除

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -12,7 +12,6 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.net.toUri
 import androidx.activity.compose.PredictiveBackHandler
-import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -691,11 +690,11 @@ internal fun GeckoBrowserTab(
         }
     }
 
-    // Back handler (when 分岐で優先度を制御: showFindInPage > isUrlInputFocused > canGoBack > webAppMode)
-    // webAppMode かつ canGoBack=false 時は Activity を終了せずタスクをバックグラウンドへ移動して
-    // セッション（ブラウザ履歴・入力状態）を保持する
-    val activity = LocalActivity.current
-    PredictiveBackHandler(enabled = state.isFullScreen || state.showFindInPage || state.isUrlInputFocused || state.canGoBack || webAppMode) { progress ->
+    // Back handler (when 分岐で優先度を制御: showFindInPage > isUrlInputFocused > canGoBack)
+    // webAppMode で上記いずれにも該当しない（これ以上戻れない）場合はバックを消費しない。
+    // ハンドラを無効化してシステムに委ねることで、メインアプリと同様に予測型バック
+    // （ホーム画面へ縮小していくアニメーション）を発生させ、そのまま Activity を終了させる。
+    PredictiveBackHandler(enabled = state.isFullScreen || state.showFindInPage || state.isUrlInputFocused || state.canGoBack) { progress ->
         state.isBackGestureInProgress = true
         try {
             progress.collect {}
@@ -704,7 +703,6 @@ internal fun GeckoBrowserTab(
                 state.showFindInPage -> state.closeFindInPage()
                 state.isUrlInputFocused -> closeUrlInput(true)
                 state.canGoBack -> state.onGoBack()
-                webAppMode -> activity?.moveTaskToBack(true)
             }
         } finally {
             state.isBackGestureInProgress = false


### PR DESCRIPTION
## 概要
予測型バックハンドラ（PredictiveBackHandler）から webAppMode 時の `moveTaskToBack()` 処理を削除し、バック操作をシステムに委ねるように変更しました。

## 変更内容

- **LocalActivity の削除**: 不要になったため import を削除
- **PredictiveBackHandler の enabled 条件を変更**: `webAppMode` を条件から除外
  - 変更前: `state.isFullScreen || state.showFindInPage || state.isUrlInputFocused || state.canGoBack || webAppMode`
  - 変更後: `state.isFullScreen || state.showFindInPage || state.isUrlInputFocused || state.canGoBack`
- **バック処理の分岐から webAppMode ケースを削除**: `activity?.moveTaskToBack(true)` の呼び出しを削除

## 実装の詳細

webAppMode で上記いずれの条件にも該当しない場合（これ以上戻れない状態）、ハンドラを無効化してシステムに委ねることで、メインアプリと同様に予測型バック（ホーム画面へ縮小していくアニメーション）を発生させ、そのまま Activity を終了させるようになります。

コメントも更新し、バック処理の優先度制御の仕様を明確にしました。

https://claude.ai/code/session_01Q7MPLz3kRM7uQShoXqtpjL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back gesture behavior in web app mode.
  * Back gestures now follow standard navigation behavior instead of unexpectedly moving the app to the background.
  * Back handling remains available for full-screen content, find-in-page, URL entry, and normal page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->