### PR TITLE
IME非表示のpause時にsurface維持でオーバーレイ白画面化を防止

### DIFF
--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -54,6 +54,44 @@ class GeckoSurfaceResumeTest {
         Log.d(TAG, "復帰後レンダリング確認完了")
     }
 
+    /**
+     * Gemini 等のアシスタントオーバーレイのように、Activity を STOP させず pause だけして
+     * 戻す focus-only 離脱を再現する。STARTED への遷移は ON_PAUSE のみを発火し ON_STOP は
+     * 発火しない。
+     *
+     * IME 非表示の pause では surface を維持する (PAUSED_KEEP_SURFACE) ため、pause 中も
+     * GeckoView のピクセルを取得でき続ける。過去に ON_PAUSE で常に releaseSession +
+     * INVISIBLE していた頃は、この経路で surface が破棄され GeckoView が白画面化していた
+     * (capturePixels も失敗していた)。本テストはそのデグレを検出する。
+     */
+    @Test
+    fun geckoPixelsRemainVisibleWhilePausedWithoutStop() {
+        val pageUri = prepareSurfaceResumePageUri()
+
+        Log.d(TAG, "ページロード開始: $pageUri")
+        composeRule.openUrlFromUrlBar(pageUri)
+        composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
+        composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
+        waitForGeckoContainer()
+        waitForNonBlackGeckoPixels()
+
+        // STARTED = ON_PAUSE のみ (ON_STOP は発火しない) = アシスタントオーバーレイ相当。
+        Log.d(TAG, "pause (STARTED) へ遷移")
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+
+        // pause 中でも surface は維持されているので capturePixels が成功し続ける。
+        Log.d(TAG, "pause 中のピクセル確認開始")
+        waitForNonBlackGeckoPixels()
+        Log.d(TAG, "pause 中のピクセル確認完了")
+
+        // 復帰後も引き続き表示される。
+        Log.d(TAG, "RESUMED へ復帰")
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        waitForGeckoContainer()
+        waitForNonBlackGeckoPixels()
+        Log.d(TAG, "復帰後レンダリング確認完了")
+    }
+
     private fun waitForGeckoContainer() {
         composeRule.waitUntil(timeoutMillis = 20_000) {
             composeRule.onAllNodesWithTag(GeckoBrowserTabTestTags.GeckoContainer.testTag)

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -15,7 +15,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.geckoview.GeckoView
-import java.io.File
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -29,30 +33,32 @@ class GeckoSurfaceResumeTest {
 
     @Test
     fun geckoPixelsRemainVisibleAfterActivityReturnsFromBackground() {
-        val pageUri = prepareSurfaceResumePageUri()
+        LocalFixtureServer().use { server ->
+            val pageUrl = server.pageUrl
 
-        Log.d(TAG, "ページロード開始: $pageUri")
-        composeRule.openUrlFromUrlBar(pageUri)
-        composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
-        composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
-        waitForGeckoContainer()
-        Log.d(TAG, "初期レンダリング確認開始")
-        waitForFixtureBackgroundGeckoPixels()
-        Log.d(TAG, "初期レンダリング確認完了")
+            Log.d(TAG, "ページロード開始: $pageUrl")
+            composeRule.openUrlFromUrlBar(pageUrl)
+            composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
+            composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
+            waitForGeckoContainer()
+            Log.d(TAG, "初期レンダリング確認開始")
+            waitForFixtureBackgroundGeckoPixels()
+            Log.d(TAG, "初期レンダリング確認完了")
 
-        Log.d(TAG, "バックグラウンド移行")
-        composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
-        Log.d(TAG, "フォアグラウンド復帰")
-        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+            Log.d(TAG, "バックグラウンド移行")
+            composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+            Log.d(TAG, "フォアグラウンド復帰")
+            composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
 
-        // 復帰直後に URL バーがフォーカスを得ると urlInput が空にクリアされる。
-        // GeckoContainer の復帰を待ってから検証する。waitForUrlBarContains は
-        // フォーカス状態に依存せず現在ページ URL を読む。
-        waitForGeckoContainer()
-        composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
-        Log.d(TAG, "復帰後レンダリング確認開始")
-        waitForFixtureBackgroundGeckoPixels()
-        Log.d(TAG, "復帰後レンダリング確認完了")
+            // 復帰直後に URL バーがフォーカスを得ると urlInput が空にクリアされる。
+            // GeckoContainer の復帰を待ってから検証する。waitForUrlBarContains は
+            // フォーカス状態に依存せず現在ページ URL を読む。
+            waitForGeckoContainer()
+            composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
+            Log.d(TAG, "復帰後レンダリング確認開始")
+            waitForFixtureBackgroundGeckoPixels()
+            Log.d(TAG, "復帰後レンダリング確認完了")
+        }
     }
 
     /**
@@ -67,31 +73,33 @@ class GeckoSurfaceResumeTest {
      */
     @Test
     fun geckoPixelsRemainVisibleWhilePausedWithoutStop() {
-        val pageUri = prepareSurfaceResumePageUri()
+        LocalFixtureServer().use { server ->
+            val pageUrl = server.pageUrl
 
-        Log.d(TAG, "ページロード開始: $pageUri")
-        composeRule.openUrlFromUrlBar(pageUri)
-        composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
-        composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
-        waitForGeckoContainer()
-        waitForFixtureBackgroundGeckoPixels()
+            Log.d(TAG, "ページロード開始: $pageUrl")
+            composeRule.openUrlFromUrlBar(pageUrl)
+            composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
+            composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
+            waitForGeckoContainer()
+            waitForFixtureBackgroundGeckoPixels()
 
-        // STARTED = ON_PAUSE のみ (ON_STOP は発火しない) = アシスタントオーバーレイ相当。
-        Log.d(TAG, "pause (STARTED) へ遷移")
-        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+            // STARTED = ON_PAUSE のみ (ON_STOP は発火しない) = アシスタントオーバーレイ相当。
+            Log.d(TAG, "pause (STARTED) へ遷移")
+            composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
 
-        // pause 中でも surface は維持されているので capturePixels が成功し続け、
-        // フィクスチャの背景色が表示され続ける (真っ白な surface では失敗する)。
-        Log.d(TAG, "pause 中のピクセル確認開始")
-        waitForFixtureBackgroundGeckoPixels()
-        Log.d(TAG, "pause 中のピクセル確認完了")
+            // pause 中でも surface は維持されているので capturePixels が成功し続け、
+            // フィクスチャの背景色が表示され続ける (真っ白な surface では失敗する)。
+            Log.d(TAG, "pause 中のピクセル確認開始")
+            waitForFixtureBackgroundGeckoPixels()
+            Log.d(TAG, "pause 中のピクセル確認完了")
 
-        // 復帰後も引き続き表示される。
-        Log.d(TAG, "RESUMED へ復帰")
-        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
-        waitForGeckoContainer()
-        waitForFixtureBackgroundGeckoPixels()
-        Log.d(TAG, "復帰後レンダリング確認完了")
+            // 復帰後も引き続き表示される。
+            Log.d(TAG, "RESUMED へ復帰")
+            composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+            waitForGeckoContainer()
+            waitForFixtureBackgroundGeckoPixels()
+            Log.d(TAG, "復帰後レンダリング確認完了")
+        }
     }
 
     private fun waitForGeckoContainer() {
@@ -210,12 +218,71 @@ class GeckoSurfaceResumeTest {
         return null
     }
 
-    private fun prepareSurfaceResumePageUri(): String {
-        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val destinationDir = File(targetContext.cacheDir, SURFACE_RESUME_DIR_NAME).apply { mkdirs() }
-        val destination = File(destinationDir, SURFACE_RESUME_FILE_NAME)
-        destination.writeText(
-            """
+    /**
+     * フィクスチャページを配信するローカル HTTP サーバー。
+     *
+     * 以前は cacheDir に書いた HTML を file: URI で開いていたが、URL バーの
+     * buildUrlFromInput は http(s):// 以外を検索/https 付与として扱うため
+     * `https://file:/...` になり OnLoadError の白いエラーページが表示されていた
+     * (旧「非黒」検証はそれでもパスしていた)。実際にフィクスチャを描画させるため、
+     * AboutBlankNewTabLocationTest と同じローカル HTTP 配信方式を使う。
+     */
+    private class LocalFixtureServer : AutoCloseable {
+        private val serverSocket = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        private val serverThread = Thread {
+            while (!serverSocket.isClosed) {
+                val socket = runCatching { serverSocket.accept() }.getOrNull() ?: break
+                runCatching {
+                    handleRequest(socket)
+                }.onFailure {
+                    if (!serverSocket.isClosed) {
+                        Log.w(TAG, "local-http error=${it.message}")
+                    }
+                }
+            }
+        }.apply {
+            isDaemon = true
+            start()
+        }
+
+        val pageUrl: String = "http://127.0.0.1:${serverSocket.localPort}/$SURFACE_RESUME_FILE_NAME"
+
+        private fun handleRequest(socket: Socket) {
+            socket.use { client ->
+                val reader = BufferedReader(InputStreamReader(client.getInputStream(), Charsets.US_ASCII))
+                reader.readLine() ?: return
+                while (true) {
+                    val header = reader.readLine() ?: break
+                    if (header.isEmpty()) break
+                }
+                // favicon 等の付随リクエストにも同じ HTML を返して構わない
+                val bodyBytes = FIXTURE_HTML.toByteArray(Charsets.UTF_8)
+                val output = client.getOutputStream()
+                val headers = buildString {
+                    append("HTTP/1.1 200 OK\r\n")
+                    append("Content-Type: text/html; charset=utf-8\r\n")
+                    append("Content-Length: ${bodyBytes.size}\r\n")
+                    append("Connection: close\r\n")
+                    append("\r\n")
+                }
+                output.write(headers.toByteArray(Charsets.US_ASCII))
+                output.write(bodyBytes)
+                output.flush()
+            }
+        }
+
+        override fun close() {
+            runCatching { serverSocket.close() }
+            runCatching { serverThread.join(2_000) }
+        }
+    }
+
+    private companion object {
+        private const val TAG = "GeckoSurfaceResumeTest"
+        private const val SURFACE_RESUME_FILE_NAME = "index.html"
+        private const val SAMPLE_GRID_SIZE = 20
+
+        private val FIXTURE_HTML = """
             <!doctype html>
             <html lang="ja">
               <head>
@@ -242,18 +309,9 @@ class GeckoSurfaceResumeTest {
                 <main>Gecko Surface Resume Test</main>
               </body>
             </html>
-            """.trimIndent(),
-        )
-        return destination.toURI().toString()
-    }
+        """.trimIndent()
 
-    private companion object {
-        private const val TAG = "GeckoSurfaceResumeTest"
-        private const val SURFACE_RESUME_DIR_NAME = "surface-resume"
-        private const val SURFACE_RESUME_FILE_NAME = "index.html"
-        private const val SAMPLE_GRID_SIZE = 20
-
-        // フィクスチャページの背景色 (prepareSurfaceResumePageUri の CSS と一致させること)
+        // フィクスチャページの背景色 (FIXTURE_HTML の CSS と一致させること)
         private const val FIXTURE_BACKGROUND_RED = 61
         private const val FIXTURE_BACKGROUND_GREEN = 220
         private const val FIXTURE_BACKGROUND_BLUE = 132

--- a/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
+++ b/app/src/androidTest/kotlin/net/matsudamper/browser/GeckoSurfaceResumeTest.kt
@@ -19,6 +19,7 @@ import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.abs
 import kotlin.math.max
 
 @RunWith(AndroidJUnit4::class)
@@ -36,7 +37,7 @@ class GeckoSurfaceResumeTest {
         composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
         waitForGeckoContainer()
         Log.d(TAG, "初期レンダリング確認開始")
-        waitForNonBlackGeckoPixels()
+        waitForFixtureBackgroundGeckoPixels()
         Log.d(TAG, "初期レンダリング確認完了")
 
         Log.d(TAG, "バックグラウンド移行")
@@ -50,7 +51,7 @@ class GeckoSurfaceResumeTest {
         waitForGeckoContainer()
         composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
         Log.d(TAG, "復帰後レンダリング確認開始")
-        waitForNonBlackGeckoPixels()
+        waitForFixtureBackgroundGeckoPixels()
         Log.d(TAG, "復帰後レンダリング確認完了")
     }
 
@@ -73,22 +74,23 @@ class GeckoSurfaceResumeTest {
         composeRule.waitForUrlBarContains(SURFACE_RESUME_FILE_NAME, timeoutMillis = 60_000)
         composeRule.waitForUrlBarNotFocused(timeoutMillis = 30_000)
         waitForGeckoContainer()
-        waitForNonBlackGeckoPixels()
+        waitForFixtureBackgroundGeckoPixels()
 
         // STARTED = ON_PAUSE のみ (ON_STOP は発火しない) = アシスタントオーバーレイ相当。
         Log.d(TAG, "pause (STARTED) へ遷移")
         composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
 
-        // pause 中でも surface は維持されているので capturePixels が成功し続ける。
+        // pause 中でも surface は維持されているので capturePixels が成功し続け、
+        // フィクスチャの背景色が表示され続ける (真っ白な surface では失敗する)。
         Log.d(TAG, "pause 中のピクセル確認開始")
-        waitForNonBlackGeckoPixels()
+        waitForFixtureBackgroundGeckoPixels()
         Log.d(TAG, "pause 中のピクセル確認完了")
 
         // 復帰後も引き続き表示される。
         Log.d(TAG, "RESUMED へ復帰")
         composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         waitForGeckoContainer()
-        waitForNonBlackGeckoPixels()
+        waitForFixtureBackgroundGeckoPixels()
         Log.d(TAG, "復帰後レンダリング確認完了")
     }
 
@@ -100,7 +102,12 @@ class GeckoSurfaceResumeTest {
         }
     }
 
-    private fun waitForNonBlackGeckoPixels(timeoutMillis: Long = 30_000): Bitmap {
+    /**
+     * フィクスチャページの背景色が一定比率以上表示されるまで待つ。
+     * 「黒くない」だけの判定では真っ白な GeckoView (白画面デグレ) もパスしてしまうため、
+     * フィクスチャ固有の背景色の比率を検証する。
+     */
+    private fun waitForFixtureBackgroundGeckoPixels(timeoutMillis: Long = 30_000): Bitmap {
         val deadline = System.currentTimeMillis() + timeoutMillis
         val startTime = System.currentTimeMillis()
         var latestBitmap: Bitmap? = null
@@ -110,11 +117,11 @@ class GeckoSurfaceResumeTest {
             attempt++
             try {
                 latestBitmap = captureGeckoPixels()
-                val ratio = latestBitmap.blackRatio()
-                Log.d(TAG, "試行${attempt}: 黒比率=${String.format("%.1f", ratio * 100)}%" +
+                val ratio = latestBitmap.fixtureBackgroundRatio()
+                Log.d(TAG, "試行${attempt}: 背景色比率=${String.format("%.1f", ratio * 100)}%" +
                     " (${latestBitmap.width}x${latestBitmap.height})")
-                if (ratio < BLACK_RATIO_THRESHOLD) {
-                    Log.d(TAG, "非黒ピクセル確認完了 (試行${attempt}, 経過${System.currentTimeMillis() - startTime}ms)")
+                if (ratio >= FIXTURE_BACKGROUND_RATIO_THRESHOLD) {
+                    Log.d(TAG, "背景色ピクセル確認完了 (試行${attempt}, 経過${System.currentTimeMillis() - startTime}ms)")
                     return latestBitmap
                 }
             } catch (e: AssertionError) {
@@ -127,7 +134,7 @@ class GeckoSurfaceResumeTest {
         }
         val elapsed = System.currentTimeMillis() - startTime
         error(
-            "GeckoView pixels stayed mostly black or capture failed after ${attempt} attempts (${elapsed}ms). " +
+            "GeckoView pixels never showed the fixture background color after ${attempt} attempts (${elapsed}ms). " +
                 "lastBitmap=${latestBitmap?.width}x${latestBitmap?.height}, " +
                 "lastError=$lastError",
         )
@@ -160,11 +167,18 @@ class GeckoSurfaceResumeTest {
         }
     }
 
-    private fun Bitmap.blackRatio(): Double {
+    /**
+     * サンプリングした不透明ピクセルのうち、フィクスチャの背景色
+     * (FIXTURE_BACKGROUND_*) に近い色が占める比率を返す。
+     * 黒画面 (blackout) も白画面 (release 済み surface) もこの比率が 0 になるため、
+     * どちらのデグレも検出できる。色管理による僅かな色ズレを許容するため
+     * チャンネルごとに FIXTURE_CHANNEL_TOLERANCE の誤差を認める。
+     */
+    private fun Bitmap.fixtureBackgroundRatio(): Double {
         val stepX = max(1, width / SAMPLE_GRID_SIZE)
         val stepY = max(1, height / SAMPLE_GRID_SIZE)
         var sampled = 0
-        var black = 0
+        var matched = 0
         var y = 0
         while (y < height) {
             var x = 0
@@ -173,18 +187,18 @@ class GeckoSurfaceResumeTest {
                 if (Color.alpha(pixel) > 0) {
                     sampled++
                     if (
-                        Color.red(pixel) < BLACK_CHANNEL_THRESHOLD &&
-                        Color.green(pixel) < BLACK_CHANNEL_THRESHOLD &&
-                        Color.blue(pixel) < BLACK_CHANNEL_THRESHOLD
+                        abs(Color.red(pixel) - FIXTURE_BACKGROUND_RED) <= FIXTURE_CHANNEL_TOLERANCE &&
+                        abs(Color.green(pixel) - FIXTURE_BACKGROUND_GREEN) <= FIXTURE_CHANNEL_TOLERANCE &&
+                        abs(Color.blue(pixel) - FIXTURE_BACKGROUND_BLUE) <= FIXTURE_CHANNEL_TOLERANCE
                     ) {
-                        black++
+                        matched++
                     }
                 }
                 x += stepX
             }
             y += stepY
         }
-        return if (sampled > 0) black.toDouble() / sampled else 0.0
+        return if (sampled > 0) matched.toDouble() / sampled else 0.0
     }
 
     private fun View.findGeckoView(): GeckoView? {
@@ -211,7 +225,10 @@ class GeckoSurfaceResumeTest {
                   html, body {
                     margin: 0;
                     min-height: 100%;
-                    background: #f8fafc;
+                    /* テストが検証する背景色。FIXTURE_BACKGROUND_* と一致させること。
+                       白でも黒でもない特徴的な色にして、release 済みの真っ白な surface や
+                       blackout をどちらもデグレとして検出できるようにする。 */
+                    background: rgb(61, 220, 132);
                     color: #0f172a;
                     font: 24px sans-serif;
                   }
@@ -235,7 +252,17 @@ class GeckoSurfaceResumeTest {
         private const val SURFACE_RESUME_DIR_NAME = "surface-resume"
         private const val SURFACE_RESUME_FILE_NAME = "index.html"
         private const val SAMPLE_GRID_SIZE = 20
-        private const val BLACK_CHANNEL_THRESHOLD = 16
-        private const val BLACK_RATIO_THRESHOLD = 0.95
+
+        // フィクスチャページの背景色 (prepareSurfaceResumePageUri の CSS と一致させること)
+        private const val FIXTURE_BACKGROUND_RED = 61
+        private const val FIXTURE_BACKGROUND_GREEN = 220
+        private const val FIXTURE_BACKGROUND_BLUE = 132
+
+        // 色管理・レンダリングによる僅かな色ズレの許容幅 (チャンネルごと)
+        private const val FIXTURE_CHANNEL_TOLERANCE = 48
+
+        // ページは背景色が大部分を占める (テキスト1行のみ) ため、
+        // 半分以上が背景色ならフィクスチャが表示されていると判定する
+        private const val FIXTURE_BACKGROUND_RATIO_THRESHOLD = 0.5
     }
 }

--- a/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/GeckoBrowserTab.kt
@@ -209,6 +209,9 @@ internal fun GeckoBrowserTab(
     // ON_START / ON_RESUME が重複発火しても state=ACTIVE なら即 no-op にする。
     var surfaceResumeState by remember(session) { mutableStateOf(SurfaceResumeState.ACTIVE) }
     val resumeCoverColor = MaterialTheme.colorScheme.surface.toArgb()
+    // LifecycleEventObserver は DisposableEffect のキーが変わらない限り再生成されないため、
+    // ラムダ内で ON_PAUSE 時点の最新 IME 表示状態を読めるよう rememberUpdatedState で包む。
+    val currentIsImeVisible by rememberUpdatedState(isImeVisible)
 
     // ファイルピッカー（単一ファイル選択）Google Photos を含むピッカーを表示するため ACTION_GET_CONTENT を使用
     val singleFileLauncher = rememberLauncherForActivityResult(
@@ -399,6 +402,27 @@ internal fun GeckoBrowserTab(
         )
     }
 
+    // pause からの復帰処理。
+    // - RELEASED: surface 破棄済みのため再作成を伴う重い復元。
+    // - PAUSED_KEEP_SURFACE: オーバーレイ等の focus-only 離脱から active を保持したまま
+    //   戻ってきたケース。surface も session も生きているので state を ACTIVE に戻すだけ。
+    //   setActive は呼ばない (可視のまま deactivate していないので再 activate も不要。
+    //   呼ぶとコンポジタが一瞬クリアされ単一色フラッシュが出る)。
+    fun resumeFromPauseIfNeeded(gecko: GeckoView) {
+        when (surfaceResumeState) {
+            SurfaceResumeState.RELEASED -> restoreSurfaceIfNeeded(gecko)
+            SurfaceResumeState.PAUSED_KEEP_SURFACE -> {
+                Log.d(
+                    TAG_SURFACE_RESUME,
+                    "resumeFromPauseIfNeeded: PAUSED_KEEP_SURFACE → ACTIVE (active 保持済み)" +
+                        " session=${session.logKey()}",
+                )
+                surfaceResumeState = SurfaceResumeState.ACTIVE
+            }
+            SurfaceResumeState.ACTIVE, SurfaceResumeState.WAITING_STABLE -> Unit
+        }
+    }
+
     DisposableEffect(lifecycleOwner, session, resumeCoverColor) {
         val observer = LifecycleEventObserver { _, event ->
             val gv = geckoView
@@ -418,17 +442,28 @@ internal fun GeckoBrowserTab(
                     // GeckoView から detach しておけば、surface 再作成時の自動レンダリングを
                     // 抑止できる。
                     //
+                    // ただしこのハング経路は .imePadding() による IME 由来の stale サイズが
+                    // 前提のため、IME 非表示の pause (Gemini 等のアシスタントオーバーレイに
+                    // よる focus-only 離脱を含む) では踏まない。この場合に release + INVISIBLE
+                    // すると、Activity が可視のまま (ON_STOP が来ないまま) GeckoView だけが
+                    // 真っ白になるため、surface と active を維持する (PAUSED_KEEP_SURFACE)。
+                    // 完全に不可視になる ON_STOP 側で従来どおり release する。
+                    //
                     // capture preview は release 前に start する。capturePixels() は非同期
                     // GeckoResult を返すため release 直後に走るキャプチャ完了率は低下するが、
                     // ハング回避を優先する。
-                    //
-                    // WAITING_STABLE 中（前回 resume の安定待ちが完了する前に再度 pause した
-                    // 場合）も releaseSession を行いたいので ACTIVE と同じ扱いにする。
-                    if (surfaceResumeState != SurfaceResumeState.RELEASED &&
-                        !mediaWebExtension.shouldKeepSessionAttached(session)
-                    ) {
-                        val target = geckoView
-                        if (target == null) {
+                    val target = geckoView
+                    when {
+                        mediaWebExtension.shouldKeepSessionAttached(session) ||
+                            surfaceResumeState == SurfaceResumeState.RELEASED ||
+                            surfaceResumeState == SurfaceResumeState.PAUSED_KEEP_SURFACE -> {
+                            Log.d(
+                                TAG_SURFACE_RESUME,
+                                "ON_PAUSE skipped: state=$surfaceResumeState" +
+                                    " mediaKeep=${mediaWebExtension.shouldKeepSessionAttached(session)}",
+                            )
+                        }
+                        target == null -> {
                             // geckoView が更新されないまま ON_PAUSE が来ると release できず、
                             // 復帰時に session 付きで surface が再作成され BLAST reject が起きる。
                             // ここで検知できれば再現条件を絞り込めるため明示的に警告を残す。
@@ -437,7 +472,25 @@ internal fun GeckoBrowserTab(
                                 "ON_PAUSE: geckoView=null のため releaseSession 不可。" +
                                     " 復帰時にハングする可能性あり session=${session.logKey()}",
                             )
-                        } else {
+                        }
+                        surfaceResumeState == SurfaceResumeState.ACTIVE && !currentIsImeVisible -> {
+                            // IME 非表示: stale サイズ resize のハング経路を踏まないため
+                            // surface を維持し、オーバーレイ表示中の白画面化を防ぐ。
+                            // view はまだ可視のため setActive(false) もしない (Mozilla の契約上
+                            // deactivate は不可視時のみ。可視中に deactivate→再 activate すると
+                            // コンポジタが一瞬クリアされ単一色フラッシュが出る)。
+                            Log.d(
+                                TAG_SURFACE_RESUME,
+                                "ON_PAUSE: IME 非表示のため surface 維持 (active 保持)" +
+                                    " gv.size=${target.width}x${target.height}",
+                            )
+                            // surface と compositor が生きているうちに capture する。
+                            state.captureTabPreview(target)
+                            surfaceResumeState = SurfaceResumeState.PAUSED_KEEP_SURFACE
+                        }
+                        else -> {
+                            // IME 表示中の ACTIVE、または WAITING_STABLE 中（前回 resume の
+                            // 安定待ちが完了する前に再度 pause した場合）は従来どおり release。
                             Log.d(
                                 TAG_SURFACE_RESUME,
                                 "ON_PAUSE: releaseSession + INVISIBLE 実行 gv.size=${target.width}x${target.height}",
@@ -454,17 +507,11 @@ internal fun GeckoBrowserTab(
                             target.visibility = View.INVISIBLE
                             surfaceResumeState = SurfaceResumeState.RELEASED
                         }
-                    } else {
-                        Log.d(
-                            TAG_SURFACE_RESUME,
-                            "ON_PAUSE skipped: state=$surfaceResumeState" +
-                                " mediaKeep=${mediaWebExtension.shouldKeepSessionAttached(session)}",
-                        )
                     }
                 }
                 Lifecycle.Event.ON_STOP -> {
                     session.flushSessionState()
-                    // non-media の場合は ON_PAUSE で release 済み。
+                    // IME 表示中の pause は ON_PAUSE で release 済み (RELEASED)。
                     // media の場合は session 維持のため capture のみ実行（従来どおり）。
                     // TODO: media 再生継続中の session は release しないため、surface 再作成時の
                     //       SyncResumeResizeCompositor ハング経路を踏むリスクが残る。実機で
@@ -472,16 +519,38 @@ internal fun GeckoBrowserTab(
                     //       （releaseSession しても MediaSession 経由で音は継続する可能性が高い）
                     //       を検討する。
                     geckoView?.also { target ->
-                        if (mediaWebExtension.shouldKeepSessionAttached(session)) {
-                            state.captureTabPreview(target)
+                        when {
+                            mediaWebExtension.shouldKeepSessionAttached(session) -> {
+                                state.captureTabPreview(target)
+                            }
+                            surfaceResumeState == SurfaceResumeState.PAUSED_KEEP_SURFACE -> {
+                                // IME 非表示の pause で surface を維持していたが、ON_STOP に
+                                // 到達した = 完全に不可視化した (ホームボタン等)。ここで release
+                                // せず session を attach したまま停止すると、復帰時に surface が
+                                // session 付きで再作成され自動 resume-resize のハング経路を踏む
+                                // (revert された #398 の STOPPED_KEEP_SURFACE はこれが原因と推測)。
+                                // 従来どおり release して、復帰は実績のある RELEASED →
+                                // fresh attach 経路に合流させる。
+                                Log.d(
+                                    TAG_SURFACE_RESUME,
+                                    "ON_STOP: PAUSED_KEEP_SURFACE → releaseSession + INVISIBLE 実行" +
+                                        " gv.size=${target.width}x${target.height}",
+                                )
+                                // 不可視になったので Mozilla の契約どおり deactivate してよい。
+                                session.setActive(false)
+                                target.releaseSession()
+                                target.visibility = View.INVISIBLE
+                                surfaceResumeState = SurfaceResumeState.RELEASED
+                            }
+                            else -> Unit
                         }
                     }
                 }
                 Lifecycle.Event.ON_START -> {
-                    geckoView?.also(::restoreSurfaceIfNeeded)
+                    geckoView?.also(::resumeFromPauseIfNeeded)
                 }
                 Lifecycle.Event.ON_RESUME -> {
-                    geckoView?.also(::restoreSurfaceIfNeeded)
+                    geckoView?.also(::resumeFromPauseIfNeeded)
                 }
                 else -> Unit
             }
@@ -1064,15 +1133,23 @@ private fun TabHistoryBottomSheet(
  * Surface/Session 復元の進行状態。
  *
  * - ACTIVE: 前面表示中。復元処理は全て no-op。
- * - RELEASED: ON_PAUSE で releaseSession() 済。ON_START で復元処理が必要。
+ * - RELEASED: ON_PAUSE (IME 表示中) または ON_STOP で releaseSession() 済。
+ *   ON_START で復元処理が必要。
  * - WAITING_STABLE: 復元の preDraw ループ中で gv.height が安定するのを待っている。
  *   IME アニメーション中の resize で GPU プロセスが kill される現象を避けるため、
  *   サイズが連続フレーム同じになるまで setSession を遅延する。
+ * - PAUSED_KEEP_SURFACE: IME 非表示の ON_PAUSE (Gemini 等のアシスタントオーバーレイに
+ *   よる focus-only 離脱を含む)。GeckoView は縮んでおらず復帰時の stale サイズ resize
+ *   ハング経路を踏まないため surface は破棄せず維持する。オーバーレイ中はまだ画面に
+ *   見えているため session も active のまま保持し、白画面化とフラッシュを防ぐ。
+ *   ON_RESUME で ACTIVE に戻るだけの軽い復帰。ON_STOP に到達した (完全に不可視化した)
+ *   場合はそこで release して RELEASED に遷移する。
  */
 private enum class SurfaceResumeState {
     ACTIVE,
     RELEASED,
     WAITING_STABLE,
+    PAUSED_KEEP_SURFACE,
 }
 
 sealed interface GeckoBrowserTabTestTags {


### PR DESCRIPTION
## 概要

GeckoView の pause/resume 時の surface 管理を改善し、Gemini 等のアシスタントオーバーレイによる focus-only 離脱時に GeckoView が白画面化する問題を解決しました。

## 主な変更

- **新しい resume 状態 `PAUSED_KEEP_SURFACE` を追加**
  - IME 非表示の ON_PAUSE 時に surface と session を維持する状態
  - オーバーレイ表示中の白画面化とフラッシュを防止

- **ON_PAUSE の処理を条件分岐で整理**
  - IME 表示中: 従来どおり `releaseSession()` + INVISIBLE (RELEASED)
  - IME 非表示: surface 維持で active を保持 (PAUSED_KEEP_SURFACE)
  - media 再生中: session 維持 (スキップ)

- **ON_STOP で PAUSED_KEEP_SURFACE を release**
  - 完全に不可視化した場合のみ release して RELEASED に遷移
  - 復帰時に実績のある fresh attach 経路に合流
  - revert された #398 (STOPPED_KEEP_SURFACE で session を attach したまま停止し、復帰時の surface 再作成でハング経路を再導入していたと推測) との決定的な違い

- **ON_START/ON_RESUME を統一**
  - `resumeFromPauseIfNeeded()` 関数で RELEASED と PAUSED_KEEP_SURFACE を処理
  - PAUSED_KEEP_SURFACE は state を ACTIVE に戻すだけの軽い復帰

- **`rememberUpdatedState` で IME 表示状態を追跡**
  - LifecycleEventObserver が ON_PAUSE 時点の最新 IME 状態を読めるように対応

## 実装の詳細

- stale サイズ resize のハング経路は IME アニメーション中の resize が前提のため、IME 非表示の pause では踏まない
- surface と compositor が生きているうちに preview capture を実行
- Mozilla の契約上、可視中の deactivate は禁止（コンポジタが一瞬クリアされフラッシュが出る）

## テスト

- focus-only 離脱を再現するテスト `geckoPixelsRemainVisibleWhilePausedWithoutStop()` を追加
- フィクスチャページを特徴的な緑背景 rgb(61, 220, 132) にし、pause 中もその背景色のピクセルが過半数を占め続けることを検証（レビュー指摘対応: 「非黒」判定では真っ白な surface もパスしてしまうため、白画面・黒画面のどちらのデグレも検出できる方式に変更）

https://claude.ai/code/session_01XYxAcgAJW1ynwewqb2eEvh