### PR TITLE
fix: モック位置情報のコールバックを非同期化する

### DIFF
--- a/app/src/main/assets/web_extensions/mock_location_bridge/content.js
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/content.js
@@ -30,6 +30,15 @@
     return geoConfig ? geoConfig.mode : 'mock';
   }
 
+  // Geolocation API の仕様ではコールバックは必ず非同期に呼ばれる。
+  // モック/拒否を同期的に呼ぶと、getCurrentPosition() の「呼び出し直後」に
+  // 状態を初期化するページ（例: 取得完了フラグを呼び出し後に立て直すサイト）で
+  // コールバックの結果が上書きされ、処理が進まなくなる。
+  // そのため実位置情報と同じく必ず次のタスクへ回して呼び出す。
+  function dispatchAsync(fn) {
+    setTimeout(fn, 0);
+  }
+
   function buildPosition(lat, lng) {
     return cloneInto(
       {
@@ -48,16 +57,41 @@
     );
   }
 
+  // モック座標を成功コールバックへ通知する
+  function notifyMockPosition(success, error) {
+    if (!geoConfig) {
+      notifyUnsupported(error);
+      return;
+    }
+    if (!success) return;
+    // 非同期化するため、通知時点ではなく呼び出し時点の座標を退避しておく
+    const lat = geoConfig.latitude;
+    const lng = geoConfig.longitude;
+    dispatchAsync(function () {
+      try {
+        success(buildPosition(lat, lng));
+      } catch (e) {
+        if (error) {
+          try { error(cloneInto({ code: 2, message: 'mock error' }, pageWin)); } catch (_) {}
+        }
+      }
+    });
+  }
+
   // PERMISSION_DENIED(code: 1) のエラーを通知する
   function notifyDenied(error) {
     if (!error) return;
-    try { error(cloneInto({ code: 1, message: 'User denied Geolocation' }, pageWin)); } catch (_) {}
+    dispatchAsync(function () {
+      try { error(cloneInto({ code: 1, message: 'User denied Geolocation' }, pageWin)); } catch (_) {}
+    });
   }
 
   // 元の geolocation が存在しない環境でのエラーを通知する
   function notifyUnsupported(error) {
     if (!error) return;
-    try { error(cloneInto({ code: 2, message: 'Geolocation not supported' }, pageWin)); } catch (_) {}
+    dispatchAsync(function () {
+      try { error(cloneInto({ code: 2, message: 'Geolocation not supported' }, pageWin)); } catch (_) {}
+    });
   }
 
   // ページが位置情報を要求したことをネイティブへ通知する（ページごとに一度だけ）
@@ -70,13 +104,7 @@
   function handleGetCurrentPosition(success, error, options) {
     const mode = currentMode();
     if (mode === 'mock') {
-      try {
-        success(buildPosition(geoConfig.latitude, geoConfig.longitude));
-      } catch (e) {
-        if (error) {
-          try { error(cloneInto({ code: 2, message: 'mock error' }, pageWin)); } catch (_) {}
-        }
-      }
+      notifyMockPosition(success, error);
     } else if (mode === 'deny') {
       notifyDenied(error);
     } else if (origGeo) {
@@ -112,7 +140,7 @@
     const mode = currentMode();
     if (mode === 'mock') {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
-      try { success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+      notifyMockPosition(success, error);
     } else if (mode === 'deny') {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
       notifyDenied(error);
@@ -166,7 +194,7 @@
       if (!entry.pending) continue;
       entry.pending = false;
       if (mode === 'mock') {
-        try { entry.success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+        notifyMockPosition(entry.success, entry.error);
       } else if (mode === 'deny') {
         notifyDenied(entry.error);
       } else if (origGeo) {
@@ -183,7 +211,7 @@
     ) {
       for (const [, entry] of activeWatches) {
         if (entry.pending || entry.realId !== undefined) continue;
-        try { entry.success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+        notifyMockPosition(entry.success, entry.error);
       }
     }
 
@@ -197,7 +225,7 @@
           entry.realId = undefined;
         }
         if (mode === 'mock') {
-          try { entry.success(buildPosition(geoConfig.latitude, geoConfig.longitude)); } catch (_) {}
+          notifyMockPosition(entry.success, entry.error);
         } else if (mode === 'deny') {
           notifyDenied(entry.error);
         } else if (entry.realId === undefined && origGeo) {

--- a/app/src/main/assets/web_extensions/mock_location_bridge/content.js
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/content.js
@@ -77,32 +77,46 @@
     const lng = geoConfig.longitude;
     dispatchAsync(function () {
       if (!isWatchActive(watchId)) return;
+      let position;
+      // 位置オブジェクトの生成失敗のみをここで拾う。
+      // success が投げた例外まで拾うとページ側の不具合を
+      // POSITION_UNAVAILABLE として誤って通知してしまう
       try {
-        success(buildPosition(lat, lng));
+        position = buildPosition(lat, lng);
       } catch (e) {
         if (error) {
           try { error(cloneInto({ code: 2, message: 'mock error' }, pageWin)); } catch (_) {}
         }
+        return;
       }
+      success(position);
+    });
+  }
+
+  // エラーオブジェクトを生成してエラーコールバックへ通知する
+  function notifyError(error, watchId, code, message) {
+    if (!error) return;
+    dispatchAsync(function () {
+      if (!isWatchActive(watchId)) return;
+      let positionError;
+      // 生成失敗のみをここで拾う。error が投げた例外はページ側の不具合なので伝播させる
+      try {
+        positionError = cloneInto({ code: code, message: message }, pageWin);
+      } catch (_) {
+        return;
+      }
+      error(positionError);
     });
   }
 
   // PERMISSION_DENIED(code: 1) のエラーを通知する
   function notifyDenied(error, watchId) {
-    if (!error) return;
-    dispatchAsync(function () {
-      if (!isWatchActive(watchId)) return;
-      try { error(cloneInto({ code: 1, message: 'User denied Geolocation' }, pageWin)); } catch (_) {}
-    });
+    notifyError(error, watchId, 1, 'User denied Geolocation');
   }
 
   // 元の geolocation が存在しない環境でのエラーを通知する
   function notifyUnsupported(error, watchId) {
-    if (!error) return;
-    dispatchAsync(function () {
-      if (!isWatchActive(watchId)) return;
-      try { error(cloneInto({ code: 2, message: 'Geolocation not supported' }, pageWin)); } catch (_) {}
-    });
+    notifyError(error, watchId, 2, 'Geolocation not supported');
   }
 
   // ページが位置情報を要求したことをネイティブへ通知する（ページごとに一度だけ）

--- a/app/src/main/assets/web_extensions/mock_location_bridge/content.js
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/content.js
@@ -39,7 +39,7 @@
     setTimeout(fn, 0);
   }
 
-  function buildPosition(lat, lng) {
+  function buildPosition(lat, lng, timestamp) {
     return cloneInto(
       {
         coords: {
@@ -51,7 +51,7 @@
           heading: null,
           speed: null,
         },
-        timestamp: Date.now(),
+        timestamp: timestamp,
       },
       pageWin
     );
@@ -72,9 +72,11 @@
       return;
     }
     if (!success) return;
-    // 非同期化するため、通知時点ではなく呼び出し時点の座標を退避しておく
+    // 非同期化するため、通知時点ではなく要求時点の座標・時刻を退避しておく。
+    // timestamp は「位置を取得した時刻」を表すため要求時点の値を使う
     const lat = geoConfig.latitude;
     const lng = geoConfig.longitude;
+    const timestamp = Date.now();
     dispatchAsync(function () {
       if (!isWatchActive(watchId)) return;
       let position;
@@ -82,7 +84,7 @@
       // success が投げた例外まで拾うとページ側の不具合を
       // POSITION_UNAVAILABLE として誤って通知してしまう
       try {
-        position = buildPosition(lat, lng);
+        position = buildPosition(lat, lng, timestamp);
       } catch (e) {
         if (error) {
           try { error(cloneInto({ code: 2, message: 'mock error' }, pageWin)); } catch (_) {}

--- a/app/src/main/assets/web_extensions/mock_location_bridge/content.js
+++ b/app/src/main/assets/web_extensions/mock_location_bridge/content.js
@@ -57,10 +57,18 @@
     );
   }
 
+  // 通知を予約したウォッチがまだ有効かを判定する。
+  // 通知は非同期のため、予約から実行までの間に clearWatch() される場合がある。
+  // 実 geolocation は解除後に通知しないので、解除済みなら破棄する。
+  // watchId が undefined の場合は getCurrentPosition 由来なので常に有効。
+  function isWatchActive(watchId) {
+    return watchId === undefined || activeWatches.has(watchId);
+  }
+
   // モック座標を成功コールバックへ通知する
-  function notifyMockPosition(success, error) {
+  function notifyMockPosition(success, error, watchId) {
     if (!geoConfig) {
-      notifyUnsupported(error);
+      notifyUnsupported(error, watchId);
       return;
     }
     if (!success) return;
@@ -68,6 +76,7 @@
     const lat = geoConfig.latitude;
     const lng = geoConfig.longitude;
     dispatchAsync(function () {
+      if (!isWatchActive(watchId)) return;
       try {
         success(buildPosition(lat, lng));
       } catch (e) {
@@ -79,17 +88,19 @@
   }
 
   // PERMISSION_DENIED(code: 1) のエラーを通知する
-  function notifyDenied(error) {
+  function notifyDenied(error, watchId) {
     if (!error) return;
     dispatchAsync(function () {
+      if (!isWatchActive(watchId)) return;
       try { error(cloneInto({ code: 1, message: 'User denied Geolocation' }, pageWin)); } catch (_) {}
     });
   }
 
   // 元の geolocation が存在しない環境でのエラーを通知する
-  function notifyUnsupported(error) {
+  function notifyUnsupported(error, watchId) {
     if (!error) return;
     dispatchAsync(function () {
+      if (!isWatchActive(watchId)) return;
       try { error(cloneInto({ code: 2, message: 'Geolocation not supported' }, pageWin)); } catch (_) {}
     });
   }
@@ -140,16 +151,16 @@
     const mode = currentMode();
     if (mode === 'mock') {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
-      notifyMockPosition(success, error);
+      notifyMockPosition(success, error, id);
     } else if (mode === 'deny') {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
-      notifyDenied(error);
+      notifyDenied(error, id);
     } else if (origGeo) {
       const realId = origGeo.watchPosition(success, error, options);
       activeWatches.set(id, { success: success, error: error, options: options, realId: realId, pending: false });
     } else {
       activeWatches.set(id, { success: success, error: error, options: options, realId: undefined, pending: false });
-      notifyUnsupported(error);
+      notifyUnsupported(error, id);
     }
     return id;
   }, pageWin);
@@ -190,17 +201,17 @@
     }
 
     // 設定待ちの watchPosition を処理（pending=true のエントリ）
-    for (const [, entry] of activeWatches) {
+    for (const [watchId, entry] of activeWatches) {
       if (!entry.pending) continue;
       entry.pending = false;
       if (mode === 'mock') {
-        notifyMockPosition(entry.success, entry.error);
+        notifyMockPosition(entry.success, entry.error, watchId);
       } else if (mode === 'deny') {
-        notifyDenied(entry.error);
+        notifyDenied(entry.error, watchId);
       } else if (origGeo) {
         entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
       } else {
-        notifyUnsupported(entry.error);
+        notifyUnsupported(entry.error, watchId);
       }
     }
 
@@ -209,15 +220,15 @@
       msg.action === 'update' && prevConfig !== null && prevMode === mode && mode === 'mock' &&
       (prevConfig.latitude !== msg.latitude || prevConfig.longitude !== msg.longitude)
     ) {
-      for (const [, entry] of activeWatches) {
+      for (const [watchId, entry] of activeWatches) {
         if (entry.pending || entry.realId !== undefined) continue;
-        notifyMockPosition(entry.success, entry.error);
+        notifyMockPosition(entry.success, entry.error, watchId);
       }
     }
 
     // update 時: モード切り替えによるアクティブウォッチの移行
     if (msg.action === 'update' && prevMode !== null && prevMode !== mode) {
-      for (const [, entry] of activeWatches) {
+      for (const [watchId, entry] of activeWatches) {
         if (entry.pending) continue;
         // real から離れる場合は origGeo ウォッチをキャンセルする
         if (mode !== 'real' && entry.realId !== undefined && origGeo) {
@@ -225,14 +236,14 @@
           entry.realId = undefined;
         }
         if (mode === 'mock') {
-          notifyMockPosition(entry.success, entry.error);
+          notifyMockPosition(entry.success, entry.error, watchId);
         } else if (mode === 'deny') {
-          notifyDenied(entry.error);
+          notifyDenied(entry.error, watchId);
         } else if (entry.realId === undefined && origGeo) {
           // モック/拒否ウォッチを実 origGeo ウォッチへ切り替え
           entry.realId = origGeo.watchPosition(entry.success, entry.error, entry.options);
         } else if (entry.realId === undefined) {
-          notifyUnsupported(entry.error);
+          notifyUnsupported(entry.error, watchId);
         }
       }
     }


### PR DESCRIPTION
## 概要

モック位置情報だと動作せず、実際の位置情報だと動作するサイトがある問題を修正する。

例: [animate-onlineshop の商品ページ](``https://www.animate-onlineshop.jp/sphone/products/detail.php?product_id=3557693)で「店舗在庫を確認」を押しても新しいタブが開かない。``

## 原因

モック/拒否モードでは `getCurrentPosition()` / `watchPosition()` のコールバックを同期的に呼んでいた。Geolocation API の仕様ではコールバックは必ず非同期に呼ばれるため、「呼び出し直後に状態を初期化するページ」で結果が上書きされ、処理が進まなくなっていた。

サイト側 (`kaitos.js`) の実装:

```js
function getLocation() {
    navigator.geolocation.getCurrentPosition(
        function (position) { latitude = ...; watchGPS = false; },
        function (error)    { watchGPS = false; },
        { enableHighAccuracy: false, timeout: 8000, maximumAge: 2000 });
}

$('#kaitos_open').click(function () {
    getLocation();
    watchGPS = true;        // ← getLocation() の「後」に true へ再代入
    count = 0;
    var id = setInterval(function () {
        if (watchGPS == false) {
            clearInterval(id);
            $('form[name="zaiko_form"]').submit();   // target="_blank" → 新しいタブ
        } else if (count > 3000) { clearInterval(id); }  // 5分で諦める
        else { count++; }
    }, 100);
});
```

- 実際の位置情報: Gecko 本体が非同期に呼ぶ → `watchGPS = true` の後で `false` になる → submit されて新しいタブが開く
- モック: 同期的に呼ぶため `watchGPS = false` が直後の `watchGPS = true;` で上書きされる → `setInterval` が検知できず 5 分後に黙って終了 → タブが開かない

同じ理由で「拒否」モードでも動作しなかった。

## 変更内容

いずれも `app/src/main/assets/web_extensions/mock_location_bridge/content.js` の変更。

1. **コールバックの非同期化** (4a0811d)
   モック / 拒否 / 未サポートのコールバックをすべて `setTimeout(fn, 0)` 経由にし、実位置情報と同じ呼び出し順序に揃える。モック座標の通知を `notifyMockPosition()` に集約し、`getCurrentPosition`・`watchPosition`・設定更新時の再通知すべてで共通化する。非同期化に伴い、通知時点ではなく要求時点の座標を退避してから渡す。
2. **clearWatch 済みウォッチへ通知しない** (ab18f25)
   非同期化により、通知の予約から実行までの間に `clearWatch()` される可能性が生まれた。予約時にウォッチ ID を渡し、実行時に `activeWatches` に残っているかを確認してから呼び出す。
3. **ページ側コールバックの例外を位置情報エラーとして通知しない** (df69ebb)
   `success` が投げた例外を拾って `POSITION_UNAVAILABLE` (code: 2) を通知していた。位置オブジェクトの生成のみを `try` の対象にする。エラー通知側も同様にし、共通処理を `notifyError` に切り出す。
4. **timestamp を要求時点の時刻にする** (23b3f1e)
   `GeolocationPosition.timestamp` は「位置を取得した時刻」を表すため、座標と同様に要求時点で退避して渡す。

## 動作確認

Node 上で `content.js` を読み込み、`kaitos.js` と同じ呼び出しパターンを再現:

```
修正前: タイムアウト。新しいタブが開かない
修正後: フォーム submit 実行 (新しいタブが開く) latitude=35.6
```

各挙動の確認:

```
OK   timestamp は要求時点の時刻 : 差 0ms
OK   clearWatch 済みウォッチへは通知しない : 0 回
OK   継続中ウォッチへは通知する : 1 回
OK   success の例外で error を呼ばない : error 呼び出し []
OK   deny は PERMISSION_DENIED を非同期通知 : code=1
```

- `./gradlew :app:assembleDebug` 成功
- `./gradlew detekt` 成功
- `./gradlew test`: `:data` の Robolectric テスト 4 件が `Package targetSdkVersion=37 > maxSdkVersion=36` で失敗するが、本変更前 (stash 状態) でも同様に失敗する既存の問題であり本変更とは無関係。他モジュールは通過
- UI 変更なしのため Paparazzi 撮影は不要

なお、このリポジトリには JS のテスト基盤が無いため、上記は手元の Node スクリプトでの確認に留めている。JS のテスト基盤導入が必要であれば別途対応する。