### PR TITLE
mainブランチへのpushでGitHub Releasesに自動アップロード

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -65,6 +65,17 @@ jobs:
           name: ${{ env.APK_NAME }}
           path: ${{ env.APK_PATH }}
 
+      - name: Run Android Lint
+        run: ./gradlew :app:lintDebug
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: app-lint-report
+          path: app/build/reports/lint-results-debug.html
+
+      # Lint 通過後にのみ公開し、失敗した APK が Releases に残らないようにする
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -75,16 +86,6 @@ jobs:
             --notes "main ブランチへの push により自動生成されたリリースです。
 
           Commit: ${COMMIT_URL}"
-
-      - name: Run Android Lint
-        run: ./gradlew :app:lintDebug
-
-      - name: Upload lint report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: app-lint-report
-          path: app/build/reports/lint-results-debug.html
 
   android-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - name: Checkout
@@ -34,16 +37,44 @@ jobs:
         run: |
           echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 --decode > "${RUNNER_TEMP}/debug.keystore"
 
-      - name: Build release APK
+      # 署名・バージョンともに PR ビルドと同じ debug ビルドを Releases にアップロードする
+      - name: Build debug APK
         env:
           DEBUG_KEYSTORE_PATH: ${{ runner.temp }}/debug.keystore
-        run: ./gradlew :app:assembleRelease
+        run: ./gradlew :app:assembleDebug
 
-      - name: Upload release APK
+      - name: Determine release version
+        run: |
+          VERSION="$(TZ=Asia/Tokyo date +%Y-%m-%d_%H-%M)"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Rename APK with release version
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          SAFE_REPO="${REPOSITORY##*/}"
+          APK_NAME="app-${SAFE_REPO}-${VERSION}.apk"
+          mv app/build/outputs/apk/debug/app-debug.apk \
+             "app/build/outputs/apk/debug/${APK_NAME}"
+          echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"
+          echo "APK_PATH=app/build/outputs/apk/debug/${APK_NAME}" >> "$GITHUB_ENV"
+
+      - name: Upload release APK to GitHub Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: app-release-apk
-          path: app/build/outputs/apk/release/app-release.apk
+          name: ${{ env.APK_NAME }}
+          path: ${{ env.APK_PATH }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        run: |
+          gh release create "${VERSION}" "${APK_PATH}" \
+            --title "${VERSION}" \
+            --notes "main ブランチへの push により自動生成されたリリースです。
+
+          Commit: ${COMMIT_URL}"
 
       - name: Run Android Lint
         run: ./gradlew :app:lintDebug

--- a/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/BrowserApp.kt
@@ -248,6 +248,16 @@ internal fun BrowserAppShell(
                             uiState = uiState,
                             onOpenExtensions = { outerBackStack.add(AppDestination.Extensions) },
                             onOpenHistory = { outerBackStack.add(AppDestination.History) },
+                            onOpenReleases = {
+                                context.startActivity(
+                                    Intent(
+                                        Intent.ACTION_VIEW,
+                                        Uri.parse(GITHUB_RELEASES_URL),
+                                        context,
+                                        CustomTabActivity::class.java,
+                                    ),
+                                )
+                            },
                             onBack = { outerBackStack.removeLastOrNull() },
                         )
                     }
@@ -884,6 +894,8 @@ private fun MainBrowserContent(
 // ──────────────────────────────────────────────────────────────
 // ユーティリティ
 // ──────────────────────────────────────────────────────────────
+
+private const val GITHUB_RELEASES_URL = "https://github.com/matsudamper/browsem/releases"
 
 private fun buildBackupFileName(): String {
     val formatter = java.text.SimpleDateFormat("yyyyMMdd-HHmmss", java.util.Locale.US)

--- a/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/net/matsudamper/browser/ui/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ fun SettingsScreen(
     uiState: SettingsScreenUiState,
     onOpenExtensions: () -> Unit,
     onOpenHistory: () -> Unit,
+    onOpenReleases: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -394,6 +395,17 @@ fun SettingsScreen(
             }
 
             Spacer(Modifier.height(betweenPadding))
+
+            SettingSection(title = "リリース") {
+                TextButton(
+                    onClick = onOpenReleases,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("GitHub Releases を開く")
+                }
+            }
+
+            Spacer(Modifier.height(betweenPadding))
             Spacer(Modifier.height(8.dp))
             Spacer(Modifier.padding(bottom = paddingValues.calculateBottomPadding()))
         }
@@ -511,6 +523,7 @@ private fun SettingsScreenPreview() {
             ),
             onOpenExtensions = {},
             onOpenHistory = {},
+            onOpenReleases = {},
             onBack = {},
         )
     }


### PR DESCRIPTION
## Summary
- `main` ブランチへの push 時に、PR ビルドと同じ署名・バージョンの debug APK をビルドし、`YYYY-MM-DD_HH-MM` 形式のバージョン名で GitHub Releases へ自動アップロードするようにしました
- 設定画面の一番下に「リリース」セクションを追加し、「GitHub Releases を開く」リンクから Releases ページを開けるようにしました

## Test plan
- [x] `./gradlew :app:assembleDebug` でビルド確認
- [x] `./gradlew detekt` で lint 確認（0 findings）
- [x] `./gradlew :app:testDebugUnitTest :ui:settings:testDebugUnitTest` でユニットテスト確認
- [x] Paparazzi スナップショットで設定画面の見た目を確認（チャットに画像を送付済み）

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjAqxErxJxMAKnGCMDmzuQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Releases section in Settings with a button to view available releases.
  * Release links now open in an in-app browser tab.
  * Builds now produce timestamped debug APKs and publish them as downloadable releases with commit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->