### PR TITLE
Renovate の自動マージ設定を minor/patch 更新に拡張

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,13 @@
         "org.mozilla.geckoview:**"
       ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

Renovate の自動マージ設定を拡張し、GeckoView 以外の依存関係についても minor および patch 更新を自動マージするようにしました。

## 変更内容

- **新しい自動マージルールを追加**: `matchUpdateTypes` で `minor` と `patch` 更新を対象とした自動マージ設定を追加
  - 既存の GeckoView 専用ルール（automerge: true）に加えて、他の依存関係の minor/patch 更新も自動マージされるようになります
  - major 更新は対象外のため、破壊的変更は手動レビューが必要です

## 実装詳細

- renovate.json の `extends` セクションに新しいマージ設定オブジェクトを追加
- 既存の GeckoView ルールとの競合を避けるため、別のルールオブジェクトとして定義

https://claude.ai/code/session_01XXnNfYEqKTPmK9qMFMyjn9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic merging of minor and patch dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->