### PR TITLE
fix: 拡張機能ポップアップの下側が見切れる問題を修正

### DIFF
--- a/app/src/main/kotlin/net/matsudamper/browser/ExtensionActionPopupDialog.kt
+++ b/app/src/main/kotlin/net/matsudamper/browser/ExtensionActionPopupDialog.kt
@@ -1,13 +1,17 @@
 package net.matsudamper.browser
 
+import android.content.res.Configuration
 import android.view.ViewGroup
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -20,11 +24,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.mozilla.geckoview.GeckoView
+import net.matsudamper.browser.data.ThemeMode
+import net.matsudamper.browser.ui.common.BrowserTheme
 import net.matsudamper.browser.resources.R as ResourcesR
 
 /**
@@ -39,61 +46,116 @@ internal fun ExtensionActionPopupDialog(
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        // targetSdk 35 以降は decorFitsSystemWindows が無視されるため、
+        // ダイアログ側でシステムバー・IME のインセットを自前で避ける。
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
     ) {
-        Surface(
-            modifier = modifier
-                .fillMaxWidth(0.92f)
-                .fillMaxHeight(0.7f)
-                .testTag(ExtensionActionPopupDialogTestTags.Dialog.testTag),
-            shape = MaterialTheme.shapes.large,
-            tonalElevation = 6.dp,
+        ExtensionActionPopupContent(
+            title = popup.title,
+            onCloseRequest = onDismissRequest,
+            modifier = modifier.windowInsetsPadding(WindowInsets.safeDrawing),
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
-                Row(
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = { context ->
+                    GeckoView(context).also { geckoView ->
+                        geckoView.layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        )
+                        geckoView.setSession(popup.session)
+                        // 非アクティブのままだと Compositor が描画を開始せず白画面になる
+                        popup.session.setActive(true)
+                    }
+                },
+                onRelease = { geckoView ->
+                    // ダイアログを閉じる際にセッションが先に close されている場合があるため保護する
+                    runCatching { popup.session.setActive(false) }
+                    runCatching { geckoView.releaseSession() }
+                },
+            )
+        }
+    }
+}
+
+/**
+ * ポップアップダイアログの枠。ポップアップ本体 ([content]) は GeckoView のため、
+ * Preview から差し替えられるようにスロットで受け取る。
+ */
+@Composable
+private fun ExtensionActionPopupContent(
+    title: String,
+    onCloseRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        // 拡張機能のポップアップは HTML 側が高さを決めており、AdGuard のように
+        // ビューポートより高い内容を持つものはスクロールできず下側が見切れてしまう。
+        // ダイアログの高さを固定せず、表示できる領域いっぱいまで広げて見切れを防ぐ。
+        modifier = modifier
+            .padding(horizontal = 8.dp, vertical = 16.dp)
+            .fillMaxSize()
+            .testTag(ExtensionActionPopupDialogTestTags.Dialog.testTag),
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = 6.dp,
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                IconButton(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                        .testTag(ExtensionActionPopupDialogTestTags.CloseButton.testTag),
+                    onClick = onCloseRequest,
+                ) {
+                    Icon(
+                        painter = painterResource(ResourcesR.drawable.close_24dp),
+                        contentDescription = "閉じる",
+                    )
+                }
+            }
+            HorizontalDivider()
+            Box(modifier = Modifier.weight(1f)) {
+                content()
+            }
+        }
+    }
+}
+
+@Preview(name = "ExtensionActionPopupLight")
+@Preview(name = "ExtensionActionPopupDark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PreviewExtensionActionPopup() {
+    BrowserTheme(themeMode = ThemeMode.THEME_SYSTEM) {
+        Surface {
+            ExtensionActionPopupContent(
+                title = "AdGuard",
+                onCloseRequest = {},
+            ) {
+                // GeckoView は Preview で描画できないため、ポップアップの表示領域を色で示す
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        modifier = Modifier.weight(1f),
-                        text = popup.title,
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    IconButton(
-                        modifier = Modifier
-                            .testTag(ExtensionActionPopupDialogTestTags.CloseButton.testTag),
-                        onClick = onDismissRequest,
-                    ) {
-                        Icon(
-                            painter = painterResource(ResourcesR.drawable.close_24dp),
-                            contentDescription = "閉じる",
-                        )
-                    }
-                }
-                HorizontalDivider()
-                Box(modifier = Modifier.weight(1f)) {
-                    AndroidView(
-                        modifier = Modifier.fillMaxSize(),
-                        factory = { context ->
-                            GeckoView(context).also { geckoView ->
-                                geckoView.layoutParams = ViewGroup.LayoutParams(
-                                    ViewGroup.LayoutParams.MATCH_PARENT,
-                                    ViewGroup.LayoutParams.MATCH_PARENT,
-                                )
-                                geckoView.setSession(popup.session)
-                                // 非アクティブのままだと Compositor が描画を開始せず白画面になる
-                                popup.session.setActive(true)
-                            }
-                        },
-                        onRelease = { geckoView ->
-                            // ダイアログを閉じる際にセッションが先に close されている場合があるため保護する
-                            runCatching { popup.session.setActive(false) }
-                            runCatching { geckoView.releaseSession() }
-                        },
+                        text = "拡張機能のポップアップ",
+                        style = MaterialTheme.typography.bodyMedium,
                     )
                 }
             }


### PR DESCRIPTION
## 概要

タブの拡張機能ポップアップ（browser_action の default_popup）で、AdGuard など内容の高いポップアップの下側が見切れる問題を修正する。

## 原因

`ExtensionActionPopupDialog` がダイアログの高さを `fillMaxHeight(0.7f)`（画面の 70%）に固定していた。拡張機能のポップアップは HTML 側が高さを決めており、ビューポートより高い内容を持つものはページ側でスクロールできないため、はみ出した下側がそのまま見切れていた。

## 変更内容

- 高さの固定をやめ、表示可能な領域いっぱい（左右 8dp / 上下 16dp のマージンのみ）まで広げる。Nexus5 相当でポップアップの表示領域が約 615px → 880px に拡大
- `decorFitsSystemWindows = false` を指定し、`windowInsetsPadding(WindowInsets.safeDrawing)` でシステムバー・IME のインセットをダイアログ側で避ける。targetSdk 36 では `decorFitsSystemWindows` が無視されるため、そのまま全画面へ広げるとナビゲーションバーの下に潜り込んで再び下端が隠れてしまうため
- Preview から GeckoView を差し替えられるよう、ダイアログの枠を `ExtensionActionPopupContent`（本体をスロットで受け取る）へ切り出し、`@Preview` を追加

## スクリーンショット (Paparazzi)

修正前後の Paparazzi スナップショットはチャットに添付済み（GeckoView は Preview で描画できないため、ポップアップの表示領域はプレースホルダで表示）。ポップアップ表示領域の高さが 615px → 880px に拡大している。

## 確認

- `./gradlew :app:assembleDebug` 成功
- `./gradlew detekt` 成功（0 findings）
- `./gradlew :app:testDebugUnitTest` 成功

`./gradlew test`（全モジュール）では `:data` の Robolectric テスト 4 件が `Package targetSdkVersion=37 > maxSdkVersion=36` で失敗するが、これは本変更とは無関係の既存の環境要因（Robolectric が SDK 37 未対応）。

## 残課題

HTML 側の内容がこの高さでもさらに長い場合は、原理的に見切れが残り得る。その場合はポップアップのボトムシート化などの対応が必要。